### PR TITLE
Portability WIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "ethkey 0.3.0 (git+https://github.com/artemii235/parity-ethereum.git)",
  "fomat-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstuff 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/js/Dockerfile
+++ b/js/Dockerfile
@@ -34,7 +34,7 @@ RUN \
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # First 7 characters of the commit ID.
-ENV MM_VERSION="f236ad1"
+ENV MM_VERSION="8cf193c"
 
 RUN cd /tmp &&\
     wget https://api.github.com/repos/KomodoPlatform/atomicDEX-API/tarball/$MM_VERSION &&\

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -31,6 +31,7 @@ ethkey = { git = "https://github.com/artemii235/parity-ethereum.git" }
 #enum_dispatch = "0.1"
 fomat-macros = "0.2"
 futures = "0.1"
+futures03 = { version = ">=0.3.0-alpha.16, <0.4", package = "futures-preview", features = ["compat", "async-await", "nightly"] }
 futures-timer = "0.1"
 gstuff = "0.5"
 hashbrown = {version = "0.1.8", features = ["serde", "nightly"]}

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -20,8 +20,7 @@
 //
 use bigdecimal::BigDecimal;
 use bitcrypto::sha256;
-use common::{HyRes, MutexGuardWrapper, rpc_response};
-use common::wio::slurp_url;
+use common::{rpc_response, slurp_url, HyRes, MutexGuardWrapper};
 use common::mm_ctx::MmArc;
 use secp256k1::PublicKey;
 use ethabi::{Contract, Token};

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -20,7 +20,7 @@
 
 #![feature(integer_atomics)]
 #![feature(non_ascii_idents)]
-#![feature(async_await)]
+#![feature(async_await, async_closure)]
 
 #[macro_use] extern crate common;
 #[macro_use] extern crate fomat_macros;

--- a/mm2src/coins/utxo/rpc_clients.rs
+++ b/mm2src/coins/utxo/rpc_clients.rs
@@ -12,7 +12,7 @@ use futures::sync::mpsc;
 use futures03::compat::Future01CompatExt;
 use futures03::future::FutureExt;
 use futures_timer::{Delay, FutureExt as FutureTimerExt};
-use gstuff::now_ms;
+use gstuff::{now_float, now_ms};
 use hashbrown::HashMap;
 use hashbrown::hash_map::Entry;
 use http::{Request, StatusCode};
@@ -1137,11 +1137,11 @@ fn electrum_connect(
             spawn ((async move || {
                 loop {
                     Timer::after(ELECTRUM_TIMEOUT as f64).await;
-                    let last = last_chunkʹ.load(AtomicOrdering::Relaxed);
-                    if now_ms() - last < ELECTRUM_TIMEOUT * 1000 {continue}
+                    let last = last_chunkʹ.load(AtomicOrdering::Relaxed) as f64 * 1000.;
+                    if now_float() - last < ELECTRUM_TIMEOUT as f64 {continue}
                     // AG: NB: In certain situations a TCP/IP shutdown can block!
                     unwrap!(thread::Builder::new().name("ElectrumShutdown".into()).spawn(move || {
-                        log!([addr] " Didn't receive any data since " (last / 1000) ". Shutting down the connection.");
+                        log!([addr] " Didn't receive any data since " (last as i64) ". Shutting down the connection.");
                         if let Err(e) = stream_clone.shutdown(Shutdown::Both) {
                             log!([addr] " error shutting down the connection " [e]);
                         }

--- a/mm2src/coins/utxo/rpc_clients.rs
+++ b/mm2src/coins/utxo/rpc_clients.rs
@@ -1103,7 +1103,6 @@ fn electrum_connect(
         let connect_f = match connection.config.clone() {
             ElectrumConfig::TCP => Either::A(TcpStream::connect(&connection.addr).map(|stream| ElectrumStream::Tcp(stream))),
             ElectrumConfig::SSL {dns_name, skip_validation} => {
-                //let dns = dns.clone();
                 let mut ssl_config = ClientConfig::new();
                 ssl_config.root_store.add_server_trust_anchors(&TLS_SERVER_ROOTS);
                 if skip_validation {

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -724,7 +724,7 @@ pub mod executor {
         let delta = now_float() - started;
         println! ("time delta is {}", delta);
         assert! (delta > 0.2);
-        assert! (delta < 0.3)
+        assert! (delta < 0.4)
     }
 }
 

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -12,6 +12,7 @@
 
 #![feature(non_ascii_idents, integer_atomics, panic_info_message)]
 #![feature(async_await, async_closure)]
+#![feature(duration_float)]
 #![cfg_attr(not(feature = "native"), allow(unused_imports))]
 #![cfg_attr(not(feature = "native"), allow(dead_code))]
 
@@ -74,7 +75,7 @@ use futures::task::Task;
 #[cfg(not(feature = "native"))]
 use futures03::task::{Context, Poll as Poll03, Waker};
 use hex::FromHex;
-use http::{Response, StatusCode, HeaderMap};
+use http::{Request, Response, StatusCode, HeaderMap};
 use http::header::{HeaderValue, CONTENT_TYPE};
 #[cfg(feature = "native")]
 use libc::{c_char, c_void, malloc, free};
@@ -479,10 +480,8 @@ pub mod wio {
     use future::IntoFuture;
     use gstuff::{any_to_str, duration_to_float, now_float};
     use http::{Request, StatusCode, HeaderMap};
-    //use http_body::Body;
     use hyper::Client;
     use hyper::client::HttpConnector;
-    use hyper::header::{ HeaderValue, CONTENT_TYPE };
     use hyper::rt::Stream;
     use hyper::server::conn::Http;
     use hyper_rustls::HttpsConnector;
@@ -492,7 +491,6 @@ pub mod wio {
     use std::thread;
     use std::thread::JoinHandle;
     use std::time::Duration;
-    use std::str;
     use tokio_core::reactor::Remote;
     use tokio_core::reactor::Handle;
 
@@ -676,61 +674,116 @@ pub mod wio {
         });
         Box::new (drive_s (response_f))
     }
+}
 
-    /// Executes a GET request, returning the response status, headers and body.
-    pub fn slurp_url (url: &str) -> SlurpFut {
-        slurp_req (try_fus! (Request::builder().uri (url) .body (Vec::new())))
+#[cfg(feature = "native")]
+pub mod executor {
+    use futures03::{FutureExt, Future as Future03, Poll as Poll03, TryFutureExt};
+    use futures03::task::Context;
+    use gstuff::now_float;
+    use std::pin::Pin;
+    use std::time::Duration;
+    use std::thread;
+
+    pub fn spawn (future: impl Future03<Output = ()> + 'static + Send) {
+        let f = future.unit_error().boxed().compat();
+        crate::wio::CORE.spawn (|_| f)
     }
 
-    #[test]
-    #[ignore]
-    fn test_slurp_req() {
-        let (status, headers, body) = unwrap! (slurp_url ("https://httpbin.org/get") .wait());
-        assert! (status.is_success(), format!("{:?} {:?} {:?}", status, headers, body));
+    /// A future that completes at a given time.  
+    pub struct Timer {till_utc: f64}
+
+    impl Timer {
+        pub fn till (till_utc: f64) -> Timer {Timer {till_utc}}
+        pub fn after (seconds: f64) -> Timer {Timer {till_utc: now_float() + seconds}}
+        pub fn till_utc (&self) -> f64 {self.till_utc}
     }
 
-    /// Fetch URL by HTTPS and parse JSON response
-    pub fn fetch_json<T>(url: &str) -> Box<dyn Future<Item=T, Error=String>>
-    where T: serde::de::DeserializeOwned + Send + 'static {
-        Box::new(slurp_url(url).and_then(|result| {
-            // try to parse as json with serde_json
-            let result = try_s!(serde_json::from_slice(&result.2));
-
-            Ok(result)
-        }))
-    }
-
-    /// Send POST JSON HTTPS request and parse response
-    pub fn post_json<T>(url: &str, json: String) -> Box<dyn Future<Item=T, Error=String>>
-    where T: serde::de::DeserializeOwned + Send + 'static {
-        let request = try_fus!(Request::builder()
-            .method("POST")
-            .uri(url)
-            .header(
-                CONTENT_TYPE,
-                HeaderValue::from_static("application/json")
-            )
-            .body(json.into())
-        );
-
-        Box::new(slurp_req(request).and_then(|result| {
-            // try to parse as json with serde_json
-            let result = try_s!(serde_json::from_slice(&result.2));
-
-            Ok(result)
-        }))
-    }
-
-    /// Returns a JSON error HyRes on a failure.
-    #[macro_export]
-    macro_rules! try_h {
-        ($e: expr) => {
-            match $e {
-                Ok (ok) => ok,
-                Err (err) => {return $crate::rpc_err_response (500, &ERRL! ("{}", err))}
-            }
+    impl Future03 for Timer {
+        type Output = ();
+        fn poll (self: Pin<&mut Self>, cx: &mut Context) -> Poll03<Self::Output> {
+            let delta = self.till_utc - now_float();
+            if delta <= 0. {return Poll03::Ready(())}
+            // NB: We should get a new `Waker` on every `poll` in case the future migrates between executors.
+            let waker = cx.waker().clone();
+            unwrap! (thread::Builder::new().name ("Timer".into()) .spawn (move || {
+                thread::sleep (Duration::from_secs_f64 (delta));
+                waker.wake()
+            }), "Can't spawn a Timer thread");
+            Poll03::Pending
         }
     }
+
+    #[test] fn test_timer() {
+        use futures03::executor::block_on;
+
+        let started = now_float();
+        let ti = Timer::after (0.2);
+        assert! (now_float() - started < 0.01);
+        block_on (ti);
+        let delta = now_float() - started;
+        println! ("time delta is {}", delta);
+        assert! (delta > 0.2);
+        assert! (delta < 0.3)
+    }
+}
+
+#[cfg(not(feature = "native"))]
+pub mod executor;
+
+/// Returns a JSON error HyRes on a failure.
+#[macro_export]
+macro_rules! try_h {
+    ($e: expr) => {
+        match $e {
+            Ok (ok) => ok,
+            Err (err) => {return $crate::rpc_err_response (500, &ERRL! ("{}", err))}
+        }
+    }
+}
+
+/// Executes a GET request, returning the response status, headers and body.
+pub fn slurp_url (url: &str) -> SlurpFut {
+    wio::slurp_req (try_fus! (Request::builder().uri (url) .body (Vec::new())))
+}
+
+#[test]
+#[ignore]
+fn test_slurp_req() {
+    let (status, headers, body) = unwrap! (slurp_url ("https://httpbin.org/get") .wait());
+    assert! (status.is_success(), format!("{:?} {:?} {:?}", status, headers, body));
+}
+
+/// Fetch URL by HTTPS and parse JSON response
+pub fn fetch_json<T>(url: &str) -> Box<dyn Future<Item=T, Error=String>>
+where T: serde::de::DeserializeOwned + Send + 'static {
+    Box::new(slurp_url(url).and_then(|result| {
+        // try to parse as json with serde_json
+        let result = try_s!(serde_json::from_slice(&result.2));
+
+        Ok(result)
+    }))
+}
+
+/// Send POST JSON HTTPS request and parse response
+pub fn post_json<T>(url: &str, json: String) -> Box<dyn Future<Item=T, Error=String>>
+where T: serde::de::DeserializeOwned + Send + 'static {
+    let request = try_fus!(Request::builder()
+        .method("POST")
+        .uri(url)
+        .header(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/json")
+        )
+        .body(json.into())
+    );
+
+    Box::new(wio::slurp_req(request).and_then(|result| {
+        // try to parse as json with serde_json
+        let result = try_s!(serde_json::from_slice(&result.2));
+
+        Ok(result)
+    }))
 }
 
 /// Wraps a JSON string into the `HyRes` RPC response future.

--- a/mm2src/common/executor.rs
+++ b/mm2src/common/executor.rs
@@ -7,6 +7,8 @@
 
 // TODO: The portable executor should be available under `CORE.spawn`.
 
+// TODO: call https://docs.rs/futures-preview/0.3.0-alpha.17/futures/executor/fn.enter.html
+
 use futures03::{FutureExt};
 use futures03::task::{waker_ref, ArcWake, Context, Poll};
 use futures03::future::BoxFuture;
@@ -16,7 +18,7 @@ use std::sync::{Arc, Mutex};
 struct Task {future: Mutex<BoxFuture<'static, ()>>}
 
 impl ArcWake for Task {
-    fn wake_by_ref (arc_self: &Arc<Self>) {
+    fn wake_by_ref (_arc_self: &Arc<Self>) {
         // Currently a NOP because `run` will run all the tasks anyway.  
         // Should later reimplement it to wake a specific future.  
         // cf. https://rust-lang.github.io/async-book/02_execution/04_executor.html

--- a/mm2src/lp_native_dex.rs
+++ b/mm2src/lp_native_dex.rs
@@ -40,10 +40,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self};
 
 use coins::utxo::{key_pair_from_seed};
-use peers::http_fallback::new_http_fallback;
 
-use crate::common::{nonz, lp, MM_VERSION};
-use crate::common::wio::{slurp_url, CORE};
+use crate::common::{nonz, lp, slurp_url, MM_VERSION};
+use crate::common::wio::{CORE};
 use crate::common::log::TagParam;
 use crate::common::mm_ctx::{MmCtx, MmArc};
 use crate::mm2::lp_network::{lp_command_q_loop, seednode_loop, client_p2p_loop};
@@ -1256,6 +1255,8 @@ pub unsafe fn lp_passphrase_init (passphrase: Option<&str>, _gui: Option<&str>) 
 /// 
 /// Also the port of the HTTP fallback server is returned.
 fn test_ip (ctx: &MmArc, ip: IpAddr) -> Result<(Sender<()>, u16), String> {
+    use peers::http_fallback::new_http_fallback;
+
     // NB: The `bind` just always works on certain operating systems.
     // To actually check the address we should try communicating on it.
     // Reusing the HTTP fallback server for that.

--- a/mm2src/peers/peers.rs
+++ b/mm2src/peers/peers.rs
@@ -19,12 +19,6 @@
 #[macro_use] extern crate serde_json;
 #[macro_use] extern crate unwrap;
 
-#[cfg(feature = "native")]
-mod executor {}
-
-#[cfg(not(feature = "native"))]
-pub mod executor;
-
 #[doc(hidden)]
 pub mod peers_tests;
 

--- a/mm2src/peers/peers_tests.rs
+++ b/mm2src/peers/peers_tests.rs
@@ -135,7 +135,7 @@ pub fn peers_dht() -> impl Future03<Output=()> {peers_exchange (json! ({"dht": "
 #[cfg(not(feature = "native"))]
 #[no_mangle]
 pub extern fn test_peers_dht() {
-    crate::executor::spawn (peers_dht())
+    common::executor::spawn (peers_dht())
 }
 
 /// Using a minimal one second HTTP fallback which should happen before the DHT kicks in.


### PR DESCRIPTION
@artemii235 , I'm trying to use async/await futures for the portable version of `CORE.spawn`,
for reasons of compatibility with the future of futures and code simplification.
As a part of it I changed some of the Electrum code in `rpc_clients` to use the async/await `spawn`.
Would like you to take a look, maybe you'll spot something I've missed in the logic during refactorings.