### PR TITLE
Allow to set rational numbers as orders price and volume #537

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.1"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -103,7 +103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -300,7 +300,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -365,7 +365,7 @@ dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mocktopus 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitives 0.1.0 (git+https://github.com/artemii235/parity-bitcoin.git)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.3.0 (git+https://github.com/artemii235/parity-common)",
@@ -421,6 +421,9 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.2.2",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitives 0.1.0 (git+https://github.com/artemii235/parity-bitcoin.git)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1394,7 +1397,8 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "mocktopus 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.2.2",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "peers 0.1.0",
  "primitives 0.1.0 (git+https://github.com/artemii235/parity-bitcoin.git)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1459,7 +1463,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1467,7 +1472,18 @@ name = "num-integer"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.2"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1475,13 +1491,16 @@ name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num_cpus"
@@ -1703,7 +1722,7 @@ name = "rand_chacha"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1759,7 +1778,7 @@ name = "rand_pcg"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2843,7 +2862,7 @@ dependencies = [
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atomic 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c210c1f4db048cda477b652d170572d84c9640695835f17663595d3bd543fc28"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
+"checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.32 (git+https://github.com/artemii235/backtrace-rs.git)" = "<none>"
 "checksum backtrace-sys 0.1.30 (git+https://github.com/artemii235/backtrace-rs.git)" = "<none>"
 "checksum base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
@@ -2980,7 +2999,7 @@ dependencies = [
 "checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "51ecbcb821e1bd256d456fe858aaa7f380b63863eab2eb86eee1bd9f33dd6682"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.2.2",
+ "num-rational 0.2.2 (git+https://github.com/artemii235/num-rational.git)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitives 0.1.0 (git+https://github.com/artemii235/parity-bitcoin.git)",
@@ -1397,7 +1397,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "mocktopus 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.2.2",
+ "num-rational 0.2.2 (git+https://github.com/artemii235/num-rational.git)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "peers 0.1.0",
  "primitives 0.1.0 (git+https://github.com/artemii235/parity-bitcoin.git)",
@@ -1478,6 +1478,7 @@ dependencies = [
 [[package]]
 name = "num-rational"
 version = "0.2.2"
+source = "git+https://github.com/artemii235/num-rational.git#7e4aa03de722b6e965075cba3088a341a99901b0"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2998,6 +2999,7 @@ dependencies = [
 "checksum nom 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9c349f68f25f596b9f44cf0e7c69752a5c633b0550c3ff849518bfba0233774a"
 "checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-rational 0.2.2 (git+https://github.com/artemii235/num-rational.git)" = "<none>"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ hyper = { version = "0.12", optional = true }
 keys = { git = "https://github.com/artemii235/parity-bitcoin.git" }
 lazy_static = "1.3"
 libc = "0.2"
+num-rational = { version = "0.2", features = ["serde", "bigint", "bigint-std"] }
 num-traits = "0.2"
 rpc = { git = "https://github.com/artemii235/parity-bitcoin.git" }
 peers = { path = "mm2src/peers" }
@@ -116,3 +117,4 @@ members = [
 [patch.crates-io]
 backtrace = { git = "https://github.com/artemii235/backtrace-rs.git" }
 backtrace-sys = { git = "https://github.com/artemii235/backtrace-rs.git" }
+num-rational = { path =  "/home/artem/dev/num-rational" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,4 +117,4 @@ members = [
 [patch.crates-io]
 backtrace = { git = "https://github.com/artemii235/backtrace-rs.git" }
 backtrace-sys = { git = "https://github.com/artemii235/backtrace-rs.git" }
-num-rational = { path =  "/home/artem/dev/num-rational" }
+num-rational = { git =  "https://github.com/artemii235/num-rational.git" }

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -20,10 +20,11 @@
 //
 use bigdecimal::BigDecimal;
 use bitcrypto::sha256;
-use common::{HyRes, MmNumber, rpc_response, slurp_url};
+use common::{HyRes, rpc_response, slurp_url};
 use common::custom_futures::TimedAsyncMutex;
 use common::executor::Timer;
 use common::mm_ctx::{MmArc, MmWeak};
+use common::mm_number::MmNumber;
 use secp256k1::PublicKey;
 use ethabi::{Contract, Token};
 use ethcore_transaction::{ Action, Transaction as UnSignedEthTx, UnverifiedTransaction};

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -32,8 +32,9 @@
 #[macro_use] extern crate unwrap;
 
 use bigdecimal::BigDecimal;
-use common::{HyRes, MmNumber, rpc_response, rpc_err_response};
+use common::{HyRes, rpc_response, rpc_err_response};
 use common::mm_ctx::{from_ctx, MmArc};
+use common::mm_number::MmNumber;
 use futures01::{Future};
 use gstuff::{slurp};
 use http::Response;

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -32,7 +32,7 @@
 #[macro_use] extern crate unwrap;
 
 use bigdecimal::BigDecimal;
-use common::{rpc_response, rpc_err_response, HyRes};
+use common::{HyRes, MmNumber, rpc_response, rpc_err_response};
 use common::mm_ctx::{from_ctx, MmArc};
 use futures01::{Future};
 use gstuff::{slurp};
@@ -323,7 +323,7 @@ pub trait MmCoin: SwapOps + MarketCoinOps + Debug + 'static {
 
     fn is_asset_chain(&self) -> bool;
 
-    fn check_i_have_enough_to_trade(&self, amount: &BigDecimal, balance: &BigDecimal, trade_info: TradeInfo) -> Box<dyn Future<Item=(), Error=String> + Send>;
+    fn check_i_have_enough_to_trade(&self, amount: &MmNumber, balance: &MmNumber, trade_info: TradeInfo) -> Box<dyn Future<Item=(), Error=String> + Send>;
 
     fn can_i_spend_other_payment(&self) -> Box<dyn Future<Item=(), Error=String> + Send>;
 

--- a/mm2src/coins/test_coin.rs
+++ b/mm2src/coins/test_coin.rs
@@ -1,5 +1,5 @@
 use bigdecimal::BigDecimal;
-use common::HyRes;
+use common::{HyRes, MmNumber};
 use common::mm_ctx::MmArc;
 use crate::{TradeInfo, FoundSwapTxSpend, WithdrawRequest};
 use futures01::Future;
@@ -194,7 +194,7 @@ impl MmCoin for TestCoin {
         unimplemented!()
     }
 
-    fn check_i_have_enough_to_trade(&self, amount: &BigDecimal, balance: &BigDecimal, trade_info: TradeInfo) -> Box<dyn Future<Item=(), Error=String> + Send> {
+    fn check_i_have_enough_to_trade(&self, amount: &MmNumber, balance: &MmNumber, trade_info: TradeInfo) -> Box<dyn Future<Item=(), Error=String> + Send> {
         unimplemented!()
     }
 

--- a/mm2src/coins/test_coin.rs
+++ b/mm2src/coins/test_coin.rs
@@ -1,6 +1,7 @@
 use bigdecimal::BigDecimal;
-use common::{HyRes, MmNumber};
+use common::{HyRes};
 use common::mm_ctx::MmArc;
+use common::mm_number::MmNumber;
 use crate::{TradeInfo, FoundSwapTxSpend, WithdrawRequest};
 use futures01::Future;
 use mocktopus::macros::*;

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -28,7 +28,7 @@ use bigdecimal::BigDecimal;
 pub use bitcrypto::{dhash160, ChecksumType, sha256};
 use chain::{TransactionOutput, TransactionInput, OutPoint};
 use chain::constants::{SEQUENCE_FINAL};
-use common::{first_char_to_upper, HyRes, rpc_response};
+use common::{first_char_to_upper, HyRes, MmNumber, rpc_response};
 use common::custom_futures::join_all_sequential;
 use common::jsonrpc_client::{JsonRpcError, JsonRpcErrorType};
 use common::mm_ctx::MmArc;
@@ -1365,7 +1365,7 @@ pub struct UtxoFeeDetails {
 impl MmCoin for UtxoCoin {
     fn is_asset_chain(&self) -> bool { self.asset_chain }
 
-    fn check_i_have_enough_to_trade(&self, amount: &BigDecimal, balance: &BigDecimal, trade_info: TradeInfo) -> Box<dyn Future<Item=(), Error=String> + Send> {
+    fn check_i_have_enough_to_trade(&self, amount: &MmNumber, balance: &MmNumber, trade_info: TradeInfo) -> Box<dyn Future<Item=(), Error=String> + Send> {
         let fee_fut = self.get_tx_fee().map_err(|e| ERRL!("{}", e));
         let arc = self.clone();
         let amount = amount.clone();
@@ -1376,16 +1376,16 @@ impl MmCoin for UtxoCoin {
                     ActualTxFee::Fixed(f) => f,
                     ActualTxFee::Dynamic(f) => f,
                 };
-                let fee_decimal = BigDecimal::from(fee) / BigDecimal::from(10u64.pow(arc.decimals as u32));
+                let fee_decimal = MmNumber::from(fee) / MmNumber::from(10u64.pow(arc.decimals as u32));
                 if &amount < &fee_decimal {
-                    return ERR!("Amount {} is too low, it'll result to dust error, at least {} is required", amount, fee_decimal);
+                    return ERR!("Amount {:?} is too low, it'll result to dust error, at least {:?} is required", amount, fee_decimal);
                 }
                 let required = match trade_info {
                     TradeInfo::Maker => amount + fee_decimal,
-                    TradeInfo::Taker(dex_fee) => &amount + dex_fee + BigDecimal::from(2) * fee_decimal,
+                    TradeInfo::Taker(dex_fee) => &amount + &MmNumber::from(dex_fee.clone()) + MmNumber::from(2) * fee_decimal,
                 };
                 if balance < required {
-                    return ERR!("{} balance {} is too low, required {:.8}", arc.ticker(), balance, required);
+                    return ERR!("{} balance {:?} is too low, required {:?}", arc.ticker(), balance, required);
                 }
                 Ok(())
             })

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -28,10 +28,11 @@ use bigdecimal::BigDecimal;
 pub use bitcrypto::{dhash160, ChecksumType, sha256};
 use chain::{TransactionOutput, TransactionInput, OutPoint};
 use chain::constants::{SEQUENCE_FINAL};
-use common::{first_char_to_upper, HyRes, MmNumber, rpc_response};
+use common::{first_char_to_upper, HyRes, rpc_response};
 use common::custom_futures::join_all_sequential;
 use common::jsonrpc_client::{JsonRpcError, JsonRpcErrorType};
 use common::mm_ctx::MmArc;
+use common::mm_number::MmNumber;
 #[cfg(feature = "native")]
 use dirs::home_dir;
 use futures01::{Future};

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -78,4 +78,4 @@ unwrap = "1.2.1"
 winapi = "0.3"
 
 [patch.crates-io]
-num-rational = { path =  "/home/artem/dev/num-rational" }
+num-rational = { git =  "https://github.com/artemii235/num-rational.git" }

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -76,6 +76,3 @@ regex = "1"
 tar = "0.4"
 unwrap = "1.2.1"
 winapi = "0.3"
-
-[patch.crates-io]
-num-rational = { git =  "https://github.com/artemii235/num-rational.git" }

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -32,11 +32,14 @@ gstuff = { version = "0.6", features = ["nightly"] }
 hex = "0.3.2"
 http = "0.1"
 http-body = "0.1"
+hyper = { version = "0.12", optional = true }
+hyper-rustls = { version = "0.16", optional = true }
 keys = { git = "https://github.com/artemii235/parity-bitcoin.git" }
 lazy_static = "1.2"
 libc = { version = "0.2", optional = true }
-hyper = { version = "0.12", optional = true }
-hyper-rustls = { version = "0.16", optional = true }
+num-bigint = { version = "0.2", features = ["serde", "std"] }
+num-rational = { version = "0.2", features = ["serde", "bigint", "bigint-std"] }
+num-traits = "0.2"
 primitives = { git = "https://github.com/artemii235/parity-bitcoin.git" }
 rand = { version = "0.7", features = ["std", "small_rng"] }
 regex = "1"
@@ -73,3 +76,6 @@ regex = "1"
 tar = "0.4"
 unwrap = "1.2.1"
 winapi = "0.3"
+
+[patch.crates-io]
+num-rational = { path =  "/home/artem/dev/num-rational" }

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -78,6 +78,7 @@ pub mod lift_body {
 }
 
 use bigdecimal::BigDecimal;
+use core::ops::{Add, Div, Mul};
 use crossbeam::{channel};
 use futures01::{future, task::Task, Future};
 #[cfg(not(feature = "native"))]
@@ -91,6 +92,9 @@ use http::{Request, Response, StatusCode, HeaderMap};
 use http::header::{HeaderValue, CONTENT_TYPE};
 #[cfg(feature = "native")]
 use libc::{malloc, free};
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use num_traits::Pow;
 use rand::{SeedableRng, rngs::SmallRng};
 use serde::{ser, de};
 #[cfg(not(feature = "native"))]
@@ -1295,4 +1299,125 @@ fn test_first_char_to_upper() {
     assert_eq!("K", first_char_to_upper("k"));
     assert_eq!("Komodo", first_char_to_upper("komodo"));
     assert_eq!(".komodo", first_char_to_upper(".komodo"));
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum MmNumber {
+    BigDecimal(BigDecimal),
+    BigRational(BigRational),
+}
+
+impl From<BigDecimal> for MmNumber {
+    fn from(n: BigDecimal) -> MmNumber {
+        MmNumber::BigDecimal(n)
+    }
+}
+
+impl From<BigRational> for MmNumber {
+    fn from(r: BigRational) -> MmNumber {
+        MmNumber::BigRational(r)
+    }
+}
+
+impl From<MmNumber> for BigDecimal {
+    fn from(n: MmNumber) -> BigDecimal {
+        match n {
+            MmNumber::BigDecimal(d) => d,
+            MmNumber::BigRational(r) => from_ratio_to_dec(r),
+        }
+    }
+}
+
+impl From<MmNumber> for BigRational {
+    fn from(n: MmNumber) -> BigRational {
+        match n {
+            MmNumber::BigDecimal(d) => from_dec_to_ratio(d),
+            MmNumber::BigRational(r) => r,
+        }
+    }
+}
+
+impl From<u64> for MmNumber {
+    fn from(n: u64) -> MmNumber {
+        BigRational::from_integer(n.into()).into()
+    }
+}
+
+fn from_ratio_to_dec(r: BigRational) -> BigDecimal {
+    BigDecimal::from(r.numer().clone()) / BigDecimal::from(r.denom().clone())
+}
+
+fn from_dec_to_ratio(r: BigDecimal) -> BigRational {
+    let (num, scale) = r.as_bigint_and_exponent();
+    let ten = BigInt::from(10);
+    if scale >= 0 {
+        BigRational::new_raw(num, ten.pow(scale as u64))
+    } else {
+        BigRational::new_raw(num * ten.pow((-scale) as u64), 1.into())
+    }
+}
+
+impl Mul for MmNumber {
+    type Output = MmNumber;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let lhs: BigRational = self.into();
+        let rhs: BigRational = rhs.into();
+        MmNumber::from(lhs * rhs)
+    }
+}
+
+impl Mul for &MmNumber {
+    type Output = MmNumber;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let lhs: BigRational = self.clone().into();
+        let rhs: BigRational = rhs.clone().into();
+        MmNumber::from(lhs * rhs)
+    }
+}
+
+impl Add for MmNumber {
+    type Output = MmNumber;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let lhs: BigRational = self.into();
+        let rhs: BigRational = rhs.into();
+        (lhs + rhs).into()
+    }
+}
+
+impl Add for &MmNumber {
+    type Output = MmNumber;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let lhs: BigRational = self.clone().into();
+        let rhs: BigRational = rhs.clone().into();
+        (lhs + rhs).into()
+    }
+}
+
+impl PartialOrd for MmNumber {
+    fn partial_cmp(&self, other: &MmNumber) -> Option<std::cmp::Ordering> {
+        let lhs: BigRational = self.clone().into();
+        let rhs: BigRational = other.clone().into();
+        Some(lhs.cmp(&rhs))
+    }
+}
+
+impl Default for MmNumber {
+    fn default() -> MmNumber {
+        BigRational::from_integer(0.into()).into()
+    }
+}
+
+impl Div for MmNumber {
+    type Output = MmNumber;
+
+    fn div(self, rhs: MmNumber) -> MmNumber {
+        let lhs: BigRational = self.into();
+        let rhs: BigRational = rhs.into();
+        (lhs / rhs).into()
+    }
 }

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -1362,11 +1362,11 @@ impl From<u64> for MmNumber {
     }
 }
 
-fn from_ratio_to_dec(r: &BigRational) -> BigDecimal {
+pub fn from_ratio_to_dec(r: &BigRational) -> BigDecimal {
     BigDecimal::from(r.numer().clone()) / BigDecimal::from(r.denom().clone())
 }
 
-fn from_dec_to_ratio(d: BigDecimal) -> BigRational {
+pub fn from_dec_to_ratio(d: BigDecimal) -> BigRational {
     let (num, scale) = d.as_bigint_and_exponent();
     let ten = BigInt::from(10);
     if scale >= 0 {

--- a/mm2src/common/mm_number.rs
+++ b/mm2src/common/mm_number.rs
@@ -1,0 +1,189 @@
+use bigdecimal::BigDecimal;
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use num_traits::Pow;
+use core::ops::{Add, Div, Mul, Sub};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum MmNumber {
+    BigDecimal(BigDecimal),
+    BigRational(BigRational),
+}
+
+impl From<BigDecimal> for MmNumber {
+    fn from(n: BigDecimal) -> MmNumber {
+        MmNumber::BigDecimal(n)
+    }
+}
+
+impl From<BigRational> for MmNumber {
+    fn from(r: BigRational) -> MmNumber {
+        MmNumber::BigRational(r)
+    }
+}
+
+impl From<MmNumber> for BigDecimal {
+    fn from(n: MmNumber) -> BigDecimal {
+        match n {
+            MmNumber::BigDecimal(d) => d,
+            MmNumber::BigRational(r) => from_ratio_to_dec(&r),
+        }
+    }
+}
+
+impl From<MmNumber> for BigRational {
+    fn from(n: MmNumber) -> BigRational {
+        match n {
+            MmNumber::BigDecimal(d) => from_dec_to_ratio(d),
+            MmNumber::BigRational(r) => r,
+        }
+    }
+}
+
+impl From<u64> for MmNumber {
+    fn from(n: u64) -> MmNumber {
+        BigRational::from_integer(n.into()).into()
+    }
+}
+
+pub fn from_ratio_to_dec(r: &BigRational) -> BigDecimal {
+    BigDecimal::from(r.numer().clone()) / BigDecimal::from(r.denom().clone())
+}
+
+pub fn from_dec_to_ratio(d: BigDecimal) -> BigRational {
+    let (num, scale) = d.as_bigint_and_exponent();
+    let ten = BigInt::from(10);
+    if scale >= 0 {
+        BigRational::new_raw(num, ten.pow(scale as u64))
+    } else {
+        BigRational::new_raw(num * ten.pow((-scale) as u64), 1.into())
+    }
+}
+
+impl Mul for MmNumber {
+    type Output = MmNumber;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let lhs: BigRational = self.into();
+        let rhs: BigRational = rhs.into();
+        MmNumber::from(lhs * rhs)
+    }
+}
+
+impl Mul for &MmNumber {
+    type Output = MmNumber;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let lhs: BigRational = self.clone().into();
+        let rhs: BigRational = rhs.clone().into();
+        MmNumber::from(lhs * rhs)
+    }
+}
+
+impl Add for MmNumber {
+    type Output = MmNumber;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let lhs: BigRational = self.into();
+        let rhs: BigRational = rhs.into();
+        (lhs + rhs).into()
+    }
+}
+
+impl Sub for MmNumber {
+    type Output = MmNumber;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        let lhs: BigRational = self.into();
+        let rhs: BigRational = rhs.into();
+        (lhs - rhs).into()
+    }
+}
+
+impl Add for &MmNumber {
+    type Output = MmNumber;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let lhs: BigRational = self.clone().into();
+        let rhs: BigRational = rhs.clone().into();
+        (lhs + rhs).into()
+    }
+}
+
+impl PartialOrd<BigDecimal> for MmNumber {
+    fn partial_cmp(&self, other: &BigDecimal) -> Option<std::cmp::Ordering> {
+        match self {
+            MmNumber::BigDecimal(d) => Some(d.cmp(other)),
+            MmNumber::BigRational(r) => Some(from_ratio_to_dec(&r).cmp(other)),
+        }
+    }
+}
+
+impl PartialOrd<MmNumber> for MmNumber {
+    fn partial_cmp(&self, other: &MmNumber) -> Option<std::cmp::Ordering> {
+        match self {
+            MmNumber::BigDecimal(lhs) => match other {
+                MmNumber::BigDecimal(rhs) => Some(lhs.cmp(rhs)),
+                MmNumber::BigRational(rhs) => Some(lhs.cmp(&from_ratio_to_dec(rhs))),
+            }
+            MmNumber::BigRational(lhs) => match other {
+                MmNumber::BigDecimal(rhs) => Some(from_ratio_to_dec(lhs).cmp(rhs)),
+                MmNumber::BigRational(rhs) => Some(lhs.cmp(rhs)),
+            },
+        }
+    }
+}
+
+impl PartialEq<BigDecimal> for MmNumber {
+    fn eq(&self, rhs: &BigDecimal) -> bool {
+        match self {
+            MmNumber::BigDecimal(d) => d == rhs,
+            MmNumber::BigRational(r) => {
+                let dec = from_ratio_to_dec(&r);
+                &dec == rhs
+            },
+        }
+    }
+}
+
+impl Default for MmNumber {
+    fn default() -> MmNumber {
+        BigRational::from_integer(0.into()).into()
+    }
+}
+
+impl Div for MmNumber {
+    type Output = MmNumber;
+
+    fn div(self, rhs: MmNumber) -> MmNumber {
+        let lhs: BigRational = self.into();
+        let rhs: BigRational = rhs.into();
+        (lhs / rhs).into()
+    }
+}
+
+impl Div for &MmNumber {
+    type Output = MmNumber;
+
+    fn div(self, rhs: &MmNumber) -> MmNumber {
+        let lhs: BigRational = self.clone().into();
+        let rhs: BigRational = rhs.clone().into();
+        (lhs / rhs).into()
+    }
+}
+
+impl PartialEq for MmNumber {
+    fn eq(&self, rhs: &MmNumber) -> bool {
+        match self {
+            MmNumber::BigDecimal(lhs) => match rhs {
+                MmNumber::BigDecimal(rhs) => lhs == rhs,
+                MmNumber::BigRational(rhs) => lhs == &from_ratio_to_dec(rhs),
+            },
+            MmNumber::BigRational(lhs) => match rhs {
+                MmNumber::BigDecimal(rhs) => &from_ratio_to_dec(lhs) == rhs,
+                MmNumber::BigRational(rhs) => lhs == rhs,
+            }
+        }
+    }
+}

--- a/mm2src/lp_ordermatch.rs
+++ b/mm2src/lp_ordermatch.rs
@@ -190,8 +190,8 @@ impl Into<MakerOrder> for TakerOrder {
             TakerAction::Sell => MakerOrder {
                 price: &self.request.rel_amount / &self.request.base_amount,
                 price_rat: (self.request.get_rel_amount() / self.request.get_base_amount()).into(),
-                max_base_vol: self.request.base_amount,
                 max_base_vol_rat: self.request.get_base_amount().into(),
+                max_base_vol: self.request.base_amount,
                 min_base_vol_rat: BigRational::from_integer(0.into()),
                 min_base_vol: 0.into(),
                 created_at: now_ms(),
@@ -205,8 +205,8 @@ impl Into<MakerOrder> for TakerOrder {
             TakerAction::Buy => MakerOrder {
                 price: &self.request.base_amount / &self.request.rel_amount,
                 price_rat: (self.request.get_base_amount() / self.request.get_rel_amount()).into(),
-                max_base_vol: self.request.rel_amount,
                 max_base_vol_rat: self.request.get_rel_amount().into(),
+                max_base_vol: self.request.rel_amount,
                 min_base_vol: 0.into(),
                 min_base_vol_rat: BigRational::from_integer(0.into()),
                 created_at: now_ms(),

--- a/mm2src/lp_swap/maker_swap.rs
+++ b/mm2src/lp_swap/maker_swap.rs
@@ -187,7 +187,7 @@ impl MakerSwap {
             ));
         }
 
-        if let Err(e) = self.maker_coin.check_i_have_enough_to_trade(&self.maker_amount, &my_balance, TradeInfo::Maker).wait() {
+        if let Err(e) = self.maker_coin.check_i_have_enough_to_trade(&self.maker_amount.clone().into(), &my_balance.clone().into(), TradeInfo::Maker).wait() {
             return Ok((
                 Some(MakerSwapCommand::Finish),
                 vec![MakerSwapEvent::StartFailed(ERRL!("!check_i_have_enough_to_trade {}", e).into())],

--- a/mm2src/lp_swap/taker_swap.rs
+++ b/mm2src/lp_swap/taker_swap.rs
@@ -401,7 +401,7 @@ impl TakerSwap {
         }
 
         let dex_fee_amount = dex_fee_amount(self.maker_coin.ticker(), self.taker_coin.ticker(), &self.taker_amount);
-        if let Err(e) = self.taker_coin.check_i_have_enough_to_trade(&self.taker_amount, &my_balance, TradeInfo::Taker(dex_fee_amount)).wait() {
+        if let Err(e) = self.taker_coin.check_i_have_enough_to_trade(&self.taker_amount.clone().into(), &my_balance.clone().into(), TradeInfo::Taker(dex_fee_amount)).wait() {
             return Ok((
                 Some(TakerSwapCommand::Finish),
                 vec![TakerSwapEvent::StartFailed(ERRL!("!check_i_have_enough_to_trade {}", e).into())],

--- a/mm2src/mm2_tests.rs
+++ b/mm2src/mm2_tests.rs
@@ -1839,14 +1839,14 @@ fn orderbook_should_display_rational_amounts() {
     let (_dump_log, _dump_dashboard) = mm_dump (&mm.log_path);
     log!({"Log path: {}", mm.log_path.display()});
     unwrap! (block_on (mm.wait_for_log (22., |log| log.contains (">>>>>>>>> DEX stats "))));
-    enable_electrum(&mm, "RICK", vec!["electrum3.cipig.net:10017", "electrum2.cipig.net:10017", "electrum1.cipig.net:10017"]);
-    enable_electrum(&mm, "MORTY", vec!["electrum3.cipig.net:10018", "electrum2.cipig.net:10018", "electrum1.cipig.net:10018"]);
+    block_on(enable_electrum(&mm, "RICK", vec!["electrum3.cipig.net:10017", "electrum2.cipig.net:10017", "electrum1.cipig.net:10017"]));
+    block_on(enable_electrum(&mm, "MORTY", vec!["electrum3.cipig.net:10018", "electrum2.cipig.net:10018", "electrum1.cipig.net:10018"]));
 
     let price = BigRational::new(9.into(), 10.into());
     let volume = BigRational::new(9.into(), 10.into());
 
     // create order with rational amount and price
-    let rc = unwrap! (mm.rpc (json! ({
+    let rc = unwrap! (block_on (mm.rpc (json! ({
         "userpass": mm.userpass,
         "method": "setprice",
         "base": "RICK",
@@ -1854,17 +1854,17 @@ fn orderbook_should_display_rational_amounts() {
         "price": price,
         "volume": volume,
         "cancel_previous": false,
-    })));
+    }))));
     assert! (rc.0.is_success(), "!setprice: {}", rc.1);
 
     thread::sleep(Duration::from_secs(12));
     log!("Get RICK/MORTY orderbook");
-    let rc = unwrap!(mm.rpc (json! ({
+    let rc = unwrap! (block_on (mm.rpc (json! ({
             "userpass": mm.userpass,
             "method": "orderbook",
             "base": "RICK",
             "rel": "MORTY",
-        })));
+        }))));
     assert!(rc.0.is_success(), "!orderbook: {}", rc.1);
 
     let orderbook: Json = unwrap!(json::from_str(&rc.1));

--- a/mm2src/mm2_tests.rs
+++ b/mm2src/mm2_tests.rs
@@ -13,6 +13,7 @@ use futures::executor::block_on;
 use hyper::StatusCode;
 #[cfg(feature = "native")]
 use hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN;
+use num_rational::BigRational;
 use peers;
 use serde_json::{self as json, Value as Json};
 use std::collections::HashMap;
@@ -1809,4 +1810,67 @@ fn test_all_orders_per_pair_per_node_must_be_displayed_in_orderbook() {
     log!("orderbook " [orderbook]);
     let asks = orderbook["asks"].as_array().unwrap();
     assert_eq!(asks.len(), 2, "RICK/MORTY orderbook must have exactly 2 asks");
+}
+
+#[test]
+fn orderbook_should_display_rational_amounts() {
+    let coins = json!([
+        {"coin":"RICK","asset":"RICK"},
+        {"coin":"MORTY","asset":"MORTY"},
+    ]);
+
+    let mut mm = unwrap! (MarketMakerIt::start (
+        json! ({
+            "gui": "nogui",
+            "netid": 9998,
+            "myipaddr": env::var ("BOB_TRADE_IP") .ok(),
+            "rpcip": env::var ("BOB_TRADE_IP") .ok(),
+            "canbind": env::var ("BOB_TRADE_PORT") .ok().map (|s| unwrap! (s.parse::<i64>())),
+            "passphrase": "bob passphrase",
+            "coins": coins,
+            "rpc_password": "pass",
+            "i_am_seed": true,
+        }),
+        "pass".into(),
+        match var ("LOCAL_THREAD_MM") {Ok (ref e) if e == "bob" => Some (local_start()), _ => None}
+    ));
+    let (_dump_log, _dump_dashboard) = mm_dump (&mm.log_path);
+    log!({"Log path: {}", mm.log_path.display()});
+    unwrap! (block_on (mm.wait_for_log (22., |log| log.contains (">>>>>>>>> DEX stats "))));
+    enable_electrum(&mm, "RICK", vec!["electrum3.cipig.net:10017", "electrum2.cipig.net:10017", "electrum1.cipig.net:10017"]);
+    enable_electrum(&mm, "MORTY", vec!["electrum3.cipig.net:10018", "electrum2.cipig.net:10018", "electrum1.cipig.net:10018"]);
+
+    let price = BigRational::new(9.into(), 10.into());
+    let volume = BigRational::new(9.into(), 10.into());
+
+    // create order with rational amount and price
+    let rc = unwrap! (mm.rpc (json! ({
+        "userpass": mm.userpass,
+        "method": "setprice",
+        "base": "RICK",
+        "rel": "MORTY",
+        "price": price,
+        "volume": volume,
+        "cancel_previous": false,
+    })));
+    assert! (rc.0.is_success(), "!setprice: {}", rc.1);
+
+    thread::sleep(Duration::from_secs(12));
+    log!("Get RICK/MORTY orderbook");
+    let rc = unwrap!(mm.rpc (json! ({
+            "userpass": mm.userpass,
+            "method": "orderbook",
+            "base": "RICK",
+            "rel": "MORTY",
+        })));
+    assert!(rc.0.is_success(), "!orderbook: {}", rc.1);
+
+    let orderbook: Json = unwrap!(json::from_str(&rc.1));
+    log!("orderbook " [orderbook]);
+    let asks = orderbook["asks"].as_array().unwrap();
+    assert_eq!(asks.len(), 1, "RICK/MORTY orderbook must have exactly 1 ask");
+    let price_in_orderbook: BigRational = unwrap!(json::from_value(asks[0]["price_rat"].clone()));
+    let volume_in_orderbook: BigRational = unwrap!(json::from_value(asks[0]["max_volume_rat"].clone()));
+    assert_eq!(price, price_in_orderbook);
+    assert_eq!(volume, volume_in_orderbook);
 }

--- a/mm2src/ordermatch_tests.rs
+++ b/mm2src/ordermatch_tests.rs
@@ -9,8 +9,11 @@ fn test_match_maker_order_and_taker_request() {
         rel: "REL".into(),
         created_at: now_ms(),
         max_base_vol: 10.into(),
+        max_base_vol_rat: BigRational::from_integer(10.into()),
         min_base_vol: 0.into(),
+        min_base_vol_rat: BigRational::from_integer(0.into()),
         price: 1.into(),
+        price_rat: BigRational::from_integer(1.into()),
         matches: HashMap::new(),
         started_swaps: Vec::new(),
         uuid: Uuid::new_v4(),
@@ -24,7 +27,9 @@ fn test_match_maker_order_and_taker_request() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 10.into(),
+        base_amount_rat: Some(BigRational::from_integer(10.into())),
         rel_amount: 20.into(),
+        rel_amount_rat: Some(BigRational::from_integer(20.into())),
         action: TakerAction::Buy,
     };
 
@@ -37,8 +42,11 @@ fn test_match_maker_order_and_taker_request() {
         rel: "REL".into(),
         created_at: now_ms(),
         max_base_vol: 10.into(),
+        max_base_vol_rat: BigRational::from_integer(10.into()),
         min_base_vol: 0.into(),
+        min_base_vol_rat: BigRational::from_integer(0.into()),
         price: "0.5".parse().unwrap(),
+        price_rat: BigRational::new(1.into(), 2.into()),
         matches: HashMap::new(),
         started_swaps: Vec::new(),
         uuid: Uuid::new_v4(),
@@ -52,7 +60,9 @@ fn test_match_maker_order_and_taker_request() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 10.into(),
+        base_amount_rat: Some(BigRational::from_integer(10.into())),
         rel_amount: 20.into(),
+        rel_amount_rat: Some(BigRational::from_integer(20.into())),
         action: TakerAction::Buy,
     };
 
@@ -65,8 +75,11 @@ fn test_match_maker_order_and_taker_request() {
         rel: "REL".into(),
         created_at: now_ms(),
         max_base_vol: 10.into(),
+        max_base_vol_rat: BigRational::from_integer(10.into()),
         min_base_vol: 0.into(),
+        min_base_vol_rat: BigRational::from_integer(0.into()),
         price: "0.5".parse().unwrap(),
+        price_rat: BigRational::new(1.into(), 2.into()),
         matches: HashMap::new(),
         started_swaps: Vec::new(),
         uuid: Uuid::new_v4(),
@@ -80,7 +93,9 @@ fn test_match_maker_order_and_taker_request() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 10.into(),
+        base_amount_rat: Some(BigRational::from_integer(10.into())),
         rel_amount: 2.into(),
+        rel_amount_rat: Some(BigRational::from_integer(2.into())),
         action: TakerAction::Buy,
     };
 
@@ -93,8 +108,11 @@ fn test_match_maker_order_and_taker_request() {
         rel: "REL".into(),
         created_at: now_ms(),
         max_base_vol: 10.into(),
+        max_base_vol_rat: BigRational::from_integer(10.into()),
         min_base_vol: 0.into(),
+        min_base_vol_rat: BigRational::from_integer(0.into()),
         price: "0.5".parse().unwrap(),
+        price_rat: BigRational::new(1.into(), 2.into()),
         matches: HashMap::new(),
         started_swaps: Vec::new(),
         uuid: Uuid::new_v4(),
@@ -108,7 +126,9 @@ fn test_match_maker_order_and_taker_request() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 5.into(),
+        base_amount_rat: Some(BigRational::from_integer(5.into())),
         rel_amount: 10.into(),
+        rel_amount_rat: Some(BigRational::from_integer(10.into())),
         action: TakerAction::Sell,
     };
 
@@ -121,8 +141,11 @@ fn test_match_maker_order_and_taker_request() {
         rel: "REL".into(),
         created_at: now_ms(),
         max_base_vol: 20.into(),
+        max_base_vol_rat: BigRational::from_integer(20.into()),
         min_base_vol: 0.into(),
+        min_base_vol_rat: BigRational::from_integer(0.into()),
         price: "0.5".parse().unwrap(),
+        price_rat: BigRational::new(1.into(), 2.into()),
         matches: HashMap::new(),
         started_swaps: Vec::new(),
         uuid: Uuid::new_v4(),
@@ -136,7 +159,9 @@ fn test_match_maker_order_and_taker_request() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 10.into(),
+        base_amount_rat: Some(BigRational::from_integer(10.into())),
         rel_amount: 10.into(),
+        rel_amount_rat: Some(BigRational::from_integer(10.into())),
         action: TakerAction::Sell,
     };
 
@@ -149,8 +174,11 @@ fn test_match_maker_order_and_taker_request() {
         rel: "REL".into(),
         created_at: now_ms(),
         max_base_vol: 1.into(),
+        max_base_vol_rat: BigRational::from_integer(1.into()),
         min_base_vol: 0.into(),
+        min_base_vol_rat: BigRational::from_integer(0.into()),
         price: "1".parse().unwrap(),
+        price_rat: BigRational::from_integer(1.into()),
         matches: HashMap::new(),
         started_swaps: Vec::new(),
         uuid: Uuid::new_v4(),
@@ -164,7 +192,9 @@ fn test_match_maker_order_and_taker_request() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
         rel_amount: "0.9".parse().unwrap(),
+        rel_amount_rat: Some(BigRational::new(9.into(), 10.into())),
         action: TakerAction::Sell,
     };
 
@@ -180,8 +210,11 @@ fn test_maker_order_available_amount() {
         rel: "REL".into(),
         created_at: now_ms(),
         max_base_vol: 10.into(),
+        max_base_vol_rat: BigRational::from_integer(10.into()),
         min_base_vol: 0.into(),
+        min_base_vol_rat: BigRational::from_integer(0.into()),
         price: 1.into(),
+        price_rat: BigRational::from_integer(1.into()),
         matches: HashMap::new(),
         started_swaps: Vec::new(),
         uuid: Uuid::new_v4(),
@@ -192,7 +225,9 @@ fn test_maker_order_available_amount() {
             base: "BASE".into(),
             rel: "REL".into(),
             base_amount: 5.into(),
+            base_amount_rat: None,
             rel_amount: 5.into(),
+            rel_amount_rat: None,
             sender_pubkey: H256Json::default(),
             dest_pub_key: H256Json::default(),
             method: "request".into(),
@@ -203,7 +238,9 @@ fn test_maker_order_available_amount() {
             base: "BASE".into(),
             rel: "REL".into(),
             base_amount: 5.into(),
+            base_amount_rat: Some(BigRational::from_integer(5.into())),
             rel_amount: 5.into(),
+            rel_amount_rat: Some(BigRational::from_integer(5.into())),
             sender_pubkey: H256Json::default(),
             dest_pub_key: H256Json::default(),
             maker_order_uuid: Uuid::new_v4(),
@@ -219,7 +256,9 @@ fn test_maker_order_available_amount() {
             base: "BASE".into(),
             rel: "REL".into(),
             base_amount: 1.into(),
+            base_amount_rat: Some(BigRational::from_integer(1.into())),
             rel_amount: 1.into(),
+            rel_amount_rat: Some(BigRational::from_integer(1.into())),
             sender_pubkey: H256Json::default(),
             dest_pub_key: H256Json::default(),
             method: "request".into(),
@@ -230,7 +269,9 @@ fn test_maker_order_available_amount() {
             base: "BASE".into(),
             rel: "REL".into(),
             base_amount: 1.into(),
+            base_amount_rat: Some(BigRational::from_integer(1.into())),
             rel_amount: 1.into(),
+            rel_amount_rat: Some(BigRational::from_integer(1.into())),
             sender_pubkey: H256Json::default(),
             dest_pub_key: H256Json::default(),
             maker_order_uuid: Uuid::new_v4(),
@@ -241,9 +282,9 @@ fn test_maker_order_available_amount() {
         last_updated: now_ms(),
     });
 
-    let expected: BigDecimal = 4.into();
+    let expected = BigRational::from_integer(4.into());
     let actual = maker.available_amount();
-    assert_eq!(expected, actual);
+    assert_eq!(MmNumber::from(expected), actual);
 }
 
 #[test]
@@ -258,7 +299,9 @@ fn test_taker_match_reserved() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 10.into(),
+        base_amount_rat: Some(BigRational::from_integer(10.into())),
         rel_amount: 10.into(),
+        rel_amount_rat: Some(BigRational::from_integer(10.into())),
         action: TakerAction::Buy,
     };
 
@@ -273,7 +316,9 @@ fn test_taker_match_reserved() {
         base: "BASE".into(),
         rel: "REL".into(),
         base_amount: 10.into(),
+        base_amount_rat: Some(BigRational::from_integer(10.into())),
         rel_amount: 10.into(),
+        rel_amount_rat: Some(BigRational::from_integer(10.into())),
         sender_pubkey: H256Json::default(),
         dest_pub_key: H256Json::default(),
         maker_order_uuid: Uuid::new_v4(),
@@ -291,7 +336,9 @@ fn test_taker_match_reserved() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 10.into(),
+        base_amount_rat: Some(BigRational::from_integer(10.into())),
         rel_amount: 10.into(),
+        rel_amount_rat: Some(BigRational::from_integer(10.into())),
         action: TakerAction::Sell,
     };
 
@@ -306,7 +353,9 @@ fn test_taker_match_reserved() {
         base: "REL".into(),
         rel: "BASE".into(),
         base_amount: 10.into(),
+        base_amount_rat: Some(BigRational::from_integer(10.into())),
         rel_amount: 10.into(),
+        rel_amount_rat: Some(BigRational::from_integer(10.into())),
         sender_pubkey: H256Json::default(),
         dest_pub_key: H256Json::default(),
         maker_order_uuid: Uuid::new_v4(),
@@ -323,7 +372,9 @@ fn test_taker_match_reserved() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
         rel_amount: "0.9".parse().unwrap(),
+        rel_amount_rat: Some(BigRational::new(9.into(), 10.into())),
         action: TakerAction::Sell,
     };
 
@@ -338,7 +389,9 @@ fn test_taker_match_reserved() {
         base: "REL".into(),
         rel: "BASE".into(),
         base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
         rel_amount: 1.into(),
+        rel_amount_rat: Some(BigRational::from_integer(1.into())),
         sender_pubkey: H256Json::default(),
         dest_pub_key: H256Json::default(),
         maker_order_uuid: Uuid::new_v4(),
@@ -355,7 +408,9 @@ fn test_taker_match_reserved() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
         rel_amount: "0.9".parse().unwrap(),
+        rel_amount_rat: Some(BigRational::new(9.into(), 10.into())),
         action: TakerAction::Sell,
     };
 
@@ -370,7 +425,9 @@ fn test_taker_match_reserved() {
         base: "REL".into(),
         rel: "BASE".into(),
         base_amount: "0.8".parse().unwrap(),
+        base_amount_rat: Some(BigRational::new(8.into(), 10.into())),
         rel_amount: 1.into(),
+        rel_amount_rat: Some(BigRational::from_integer(1.into())),
         sender_pubkey: H256Json::default(),
         dest_pub_key: H256Json::default(),
         maker_order_uuid: Uuid::new_v4(),
@@ -387,7 +444,9 @@ fn test_taker_match_reserved() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
         rel_amount: 2.into(),
+        rel_amount_rat: Some(BigRational::from_integer(2.into())),
         action: TakerAction::Buy,
     };
 
@@ -402,7 +461,9 @@ fn test_taker_match_reserved() {
         base: "BASE".into(),
         rel: "REL".into(),
         base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
         rel_amount: 1.into(),
+        rel_amount_rat: Some(BigRational::from_integer(1.into())),
         sender_pubkey: H256Json::default(),
         dest_pub_key: H256Json::default(),
         maker_order_uuid: Uuid::new_v4(),
@@ -419,7 +480,9 @@ fn test_taker_match_reserved() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 1.into(),
+        base_amount_rat: None,
         rel_amount: 2.into(),
+        rel_amount_rat: None,
         action: TakerAction::Buy,
     };
 
@@ -434,7 +497,81 @@ fn test_taker_match_reserved() {
         base: "BASE".into(),
         rel: "REL".into(),
         base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
+        rel_amount: 1.into(),
+        rel_amount_rat: Some(BigRational::from_integer(1.into())),
+        sender_pubkey: H256Json::default(),
+        dest_pub_key: H256Json::default(),
+        maker_order_uuid: Uuid::new_v4(),
+        taker_order_uuid: uuid,
+    };
+
+    assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
+
+    let request = TakerRequest {
+        base: "BASE".into(),
+        rel: "REL".into(),
+        uuid,
+        method: "request".into(),
+        dest_pub_key: H256Json::default(),
+        sender_pubkey: H256Json::default(),
+        base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
+        rel_amount: 2.into(),
+        rel_amount_rat: Some(BigRational::from_integer(2.into())),
+        action: TakerAction::Buy,
+    };
+
+    let order = TakerOrder {
+        request,
+        matches: HashMap::new(),
+        created_at: now_ms()
+    };
+
+    let reserved = MakerReserved {
+        method: "reserved".into(),
+        base: "BASE".into(),
+        rel: "REL".into(),
+        base_amount: 1.into(),
+        base_amount_rat: None,
+        rel_amount: 1.into(),
+        rel_amount_rat: None,
+        sender_pubkey: H256Json::default(),
+        dest_pub_key: H256Json::default(),
+        maker_order_uuid: Uuid::new_v4(),
+        taker_order_uuid: uuid,
+    };
+
+    assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
+
+    let request = TakerRequest {
+        base: "BASE".into(),
+        rel: "REL".into(),
+        uuid,
+        method: "request".into(),
+        dest_pub_key: H256Json::default(),
+        sender_pubkey: H256Json::default(),
+        base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
+        rel_amount: 2.into(),
+        rel_amount_rat: Some(BigRational::from_integer(2.into())),
+        action: TakerAction::Buy,
+    };
+
+    let order = TakerOrder {
+        request,
+        matches: HashMap::new(),
+        created_at: now_ms()
+    };
+
+    let reserved = MakerReserved {
+        method: "reserved".into(),
+        base: "BASE".into(),
+        rel: "REL".into(),
+        base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
         rel_amount: 3.into(),
+        rel_amount_rat: Some(BigRational::from_integer(3.into())),
         sender_pubkey: H256Json::default(),
         dest_pub_key: H256Json::default(),
         maker_order_uuid: Uuid::new_v4(),
@@ -442,6 +579,40 @@ fn test_taker_match_reserved() {
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
+
+    let order = TakerOrder {
+        created_at: 1568358064115,
+        request: TakerRequest {
+            base: "RICK".into(),
+            rel: "MORTY".into(),
+            base_amount: "0.3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333".parse().unwrap(),
+            base_amount_rat: Some(BigRational::new(1.into(), 3.into())),
+            rel_amount: 1.into(),
+            rel_amount_rat: Some(BigRational::from_integer(1.into())),
+            action: TakerAction::Buy,
+            uuid,
+            method: "request".into(),
+            sender_pubkey: H256Json::default(),
+            dest_pub_key: H256Json::default(),
+        },
+        matches: HashMap::new(),
+    };
+
+    let reserved = MakerReserved {
+        base: "RICK".into(),
+        rel: "MORTY".into(),
+        base_amount: "0.3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333".parse().unwrap(),
+        base_amount_rat: None,
+        rel_amount: "0.777777776666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666588888889".parse().unwrap(),
+        rel_amount_rat: None,
+        taker_order_uuid: uuid,
+        maker_order_uuid: uuid,
+        method: "reserved".into(),
+        sender_pubkey: H256Json::default(),
+        dest_pub_key: H256Json::default(),
+    };
+
+    assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
 }
 
 #[test]
@@ -454,7 +625,9 @@ fn test_taker_order_cancellable() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
         rel_amount: 2.into(),
+        rel_amount_rat: Some(BigRational::from_integer(2.into())),
         action: TakerAction::Buy,
     };
 
@@ -474,7 +647,9 @@ fn test_taker_order_cancellable() {
         dest_pub_key: H256Json::default(),
         sender_pubkey: H256Json::default(),
         base_amount: 1.into(),
+        base_amount_rat: Some(BigRational::from_integer(1.into())),
         rel_amount: 2.into(),
+        rel_amount_rat: Some(BigRational::from_integer(2.into())),
         action: TakerAction::Buy,
     };
 
@@ -493,7 +668,9 @@ fn test_taker_order_cancellable() {
                 base: "BASE".into(),
                 rel: "REL".into(),
                 base_amount: 1.into(),
+                base_amount_rat: Some(BigRational::from_integer(1.into())),
                 rel_amount: 3.into(),
+                rel_amount_rat: Some(BigRational::from_integer(3.into())),
                 sender_pubkey: H256Json::default(),
                 dest_pub_key: H256Json::default(),
                 maker_order_uuid: Uuid::new_v4(),
@@ -525,8 +702,11 @@ fn prepare_for_cancel_by(ctx: &MmArc) {
         created_at: now_ms(),
         matches: HashMap::new(),
         max_base_vol: 0.into(),
+        max_base_vol_rat: BigRational::from_integer(0.into()),
         min_base_vol: 0.into(),
+        min_base_vol_rat: BigRational::from_integer(0.into()),
         price: 0.into(),
+        price_rat: BigRational::from_integer(0.into()),
         started_swaps: vec![],
     });
     maker_orders.insert(Uuid::from_bytes([1; 16]), MakerOrder {
@@ -536,8 +716,11 @@ fn prepare_for_cancel_by(ctx: &MmArc) {
         created_at: now_ms(),
         matches: HashMap::new(),
         max_base_vol: 0.into(),
+        max_base_vol_rat: BigRational::from_integer(0.into()),
         min_base_vol: 0.into(),
+        min_base_vol_rat: BigRational::from_integer(0.into()),
         price: 0.into(),
+        price_rat: BigRational::from_integer(0.into()),
         started_swaps: vec![],
     });
     maker_orders.insert(Uuid::from_bytes([2; 16]), MakerOrder {
@@ -547,8 +730,11 @@ fn prepare_for_cancel_by(ctx: &MmArc) {
         created_at: now_ms(),
         matches: HashMap::new(),
         max_base_vol: 0.into(),
+        max_base_vol_rat: BigRational::from_integer(0.into()),
         min_base_vol: 0.into(),
+        min_base_vol_rat: BigRational::from_integer(0.into()),
         price: 0.into(),
+        price_rat: BigRational::from_integer(0.into()),
         started_swaps: vec![],
     });
     taker_orders.insert(Uuid::from_bytes([3; 16]), TakerOrder {
@@ -560,7 +746,9 @@ fn prepare_for_cancel_by(ctx: &MmArc) {
             uuid: Uuid::from_bytes([3; 16]),
             action: TakerAction::Buy,
             base_amount: 0.into(),
+            base_amount_rat: Some(BigRational::from_integer(0.into())),
             rel_amount: 0.into(),
+            rel_amount_rat: Some(BigRational::from_integer(0.into())),
             dest_pub_key: H256Json::default(),
             method: "request".into(),
             sender_pubkey: H256Json::default(),


### PR DESCRIPTION
The implementation is backwards compatible with other nodes that use BigDecimal type only.
Rational amounts are displayed as separate fields in orderbook and order_status calls.