### PR TITLE
Recommend Rust 2020-02-01 (1.41)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.2)
+cmake_minimum_required(VERSION 3.5.1)
 
 project(SuperNET)
 set(DEPS_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install)

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,27 +11,22 @@ FROM ubuntu:xenial
 RUN \
     apt-get update &&\
     apt-get install -y git build-essential libssl-dev wget &&\
+    apt-get install -y cmake &&\
     # https://github.com/rust-lang/rust-bindgen/blob/master/book/src/requirements.md#debian-based-linuxes
     apt-get install -y llvm-3.9-dev libclang-3.9-dev clang-3.9 &&\
     # openssl-sys requirements, cf. https://crates.io/crates/openssl-sys
     apt-get install -y pkg-config libssl-dev &&\
     apt-get clean
 
-#Cmake 3.12.0 supports multi-platform -j option, it allows to use all cores for concurrent build to speed up it
-RUN wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh && \
-    sh cmake-3.12.0-Linux-x86_64.sh --skip-license --exclude-subdir --prefix=/usr/local && \
-    rm -rf cmake-3.12.0-Linux-x86_64.sh
-
 RUN \
     wget -O- https://sh.rustup.rs > /tmp/rustup-init.sh &&\
     sh /tmp/rustup-init.sh -y --default-toolchain none &&\
     . /root/.cargo/env &&\
     rustup set profile minimal &&\
-    rustup install nightly-2019-10-24 &&\
-    rustup default nightly-2019-10-24 &&\
+    rustup install nightly-2020-02-01 &&\
+    rustup default nightly-2020-02-01 &&\
     # It seems that bindgen won't prettify without it:
     rustup component add rustfmt-preview &&\
-    rm -rf /root/.rustup/toolchains/nightly-2019-10-24-x86_64-unknown-linux-gnu/share/doc &&\
     rm -f /tmp/rustup-init.sh
 
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The current state can be considered as very early alpha.
 1. (Optional) OSX: run `LIBRARY_PATH=/usr/local/opt/openssl/lib`
 1. Run
     ```
-    rustup install nightly-2019-10-06
-    rustup default nightly-2019-10-06
+    rustup install nightly-2020-02-01
+    rustup default nightly-2020-02-01
     rustup component add rustfmt-preview
     ```
 1. (Optional) Win: run `marketmaker_build_depends.cmd` to build dependencies.

--- a/js/Dockerfile
+++ b/js/Dockerfile
@@ -10,26 +10,22 @@ FROM ubuntu:xenial
 RUN \
     apt-get update &&\
     apt-get install -y git build-essential libssl-dev wget &&\
+    apt-get install -y cmake &&\
     # https://github.com/rust-lang/rust-bindgen/blob/master/book/src/requirements.md#debian-based-linuxes
     apt-get install -y llvm-3.9-dev libclang-3.9-dev clang-3.9 &&\
     # openssl-sys requirements, cf. https://crates.io/crates/openssl-sys
     apt-get install -y pkg-config libssl-dev &&\
     apt-get clean
 
-RUN wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh && \
-    sh cmake-3.12.0-Linux-x86_64.sh --skip-license --exclude-subdir --prefix=/usr/local && \
-    rm -rf cmake-3.12.0-Linux-x86_64.sh
-
 RUN \
     wget -O- https://sh.rustup.rs > /tmp/rustup-init.sh &&\
     sh /tmp/rustup-init.sh -y --default-toolchain none &&\
     . /root/.cargo/env &&\
     rustup set profile minimal &&\
-    rustup install nightly-2019-10-24 &&\
-    rustup default nightly-2019-10-24 &&\
+    rustup install nightly-2020-02-01 &&\
+    rustup default nightly-2020-02-01 &&\
     # It seems that bindgen won't prettify without it:
     rustup component add rustfmt-preview &&\
-    rm -rf /root/.rustup/toolchains/nightly-2019-10-24-x86_64-unknown-linux-gnu/share/doc &&\
     rm -f /tmp/rustup-init.sh
 
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
We didn't had a stable Rust version for a while: some of the recommended versions where too outdated for the fresh asynchronous code while others had issues with RLS being unavailble for the given version, one of the platforms not being supported for the given version, etc.

Rust 1.41 [relaxed the orphan rule](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#relaxed-restrictions-when-implementing-traits), which I think is of major importance for API design, and the time of release is also a good time to pin the Rust nightly version as it minimizes the likehood of nightly issues.

(If the motion is approved then I can bump the mobile version as well).