### PR TITLE
Setup automatic Github release publishing on mm2 branch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "findshlibs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fomat-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fomat-macros 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -835,6 +836,15 @@ dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3190,6 +3200,7 @@ dependencies = [
 "checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a2df5c1a8c4be27e7707789dc42ae65976e60b394afd293d1419ab915833e646"
+"checksum findshlibs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1260d61e4fe2a6ab845ffdc426a0bd68ffb240b91cf0ec5a8d1170cec535bd8"
 "checksum fixed-hash 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7afe6ce860afb14422711595a7b26ada9ed7de2f43c0b2ab79d09ee196287273"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fomat-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b541b35d643a4dfbba66fc2a4d401314d6eb16e36155c92b439baeb232c5d0c7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,6 @@
 # We should use the "objcopy --only-keep-debug" and "add-symbol-file" meanwhile
 # and separating stack tracing into raw trace and symbolication parts.
 
-# https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#profile-overrides
-cargo-features = ["profile-overrides"]
-
 [package]
 name = "mm2"
 version = "0.1.0"

--- a/azure-pipelines-build-stage-job.yml
+++ b/azure-pipelines-build-stage-job.yml
@@ -1,4 +1,4 @@
-# Job template for MM2 build
+# Job template for MM2 Build
 
 parameters:
   name: ''  # defaults for any parameters that aren't specified

--- a/azure-pipelines-build-stage-job.yml
+++ b/azure-pipelines-build-stage-job.yml
@@ -57,6 +57,10 @@ jobs:
           zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Debug target/debug/mm2 -j
         displayName: 'Prepare debug build upload Linux/MacOS'
         condition: ne( variables['Agent.OS'], 'Windows_NT' )
+      - bash: |
+          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Debug.dSYM target/debug/mm2.dSYM -j -r
+        displayName: 'Prepare dSYM upload MacOS'
+        condition: eq( variables['Agent.OS'], 'Darwin' )
       - powershell: |
           7z a .\upload\mm2-$(COMMIT_HASH)-$(Agent.OS)-Debug.zip .\target\debug\mm2.exe .\target\debug\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
         displayName: 'Prepare debug build upload Windows'

--- a/azure-pipelines-build-stage-job.yml
+++ b/azure-pipelines-build-stage-job.yml
@@ -55,10 +55,11 @@ jobs:
           ALICE_USERPASS: $(${{ parameters.alice_userpass }})
       - bash: |
           zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Debug target/debug/mm2 -j
-        displayName: 'Prepare debug build upload Linux/MacOS'
-        condition: ne( variables['Agent.OS'], 'Windows_NT' )
+        displayName: 'Prepare debug build upload Linux'
+        condition: eq( variables['Agent.OS'], 'Linux' )
       - bash: |
-          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Debug.dSYM target/debug/mm2.dSYM -j -r
+          cd target/release
+          zip ../../upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Debug mm2.dSYM mm2 -r
         displayName: 'Prepare dSYM upload MacOS'
         condition: eq( variables['Agent.OS'], 'Darwin' )
       - powershell: |

--- a/azure-pipelines-build-stage-job.yml
+++ b/azure-pipelines-build-stage-job.yml
@@ -60,9 +60,19 @@ jobs:
       - bash: |
           cd target/release
           zip ../../upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Debug mm2.dSYM mm2 -r
-        displayName: 'Prepare dSYM upload MacOS'
+        displayName: 'Prepare debug build upload MacOS'
         condition: eq( variables['Agent.OS'], 'Darwin' )
       - powershell: |
           7z a .\upload\mm2-$(COMMIT_HASH)-$(Agent.OS)-Debug.zip .\target\debug\mm2.exe .\target\debug\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
         displayName: 'Prepare debug build upload Windows'
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
+      # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/copy-files-over-ssh?view=vsts
+      - task: CopyFilesOverSSH@0
+        inputs:
+          sshEndpoint: nightly_build_server
+          sourceFolder: 'upload' # Optional
+          contents: "**"
+          targetFolder: "uploads/$(Build.SourceBranchName)" # Optional
+          overwrite: true
+        displayName: 'Upload nightly'
+        condition: ne(variables['build.sourceBranch'], 'refs/heads/mm2')

--- a/azure-pipelines-build-stage-job.yml
+++ b/azure-pipelines-build-stage-job.yml
@@ -48,7 +48,6 @@ jobs:
           cargo test --features native --all -- --test-threads=8
         displayName: 'Test MM2'
         timeoutInMinutes: 22
-        enabled: false
         env:
           BOB_PASSPHRASE: $(${{ parameters.bob_passphrase }})
           BOB_USERPASS: $(${{ parameters.bob_userpass }})

--- a/azure-pipelines-job.yml
+++ b/azure-pipelines-job.yml
@@ -80,6 +80,8 @@ jobs:
           artifactName: "MM2-$(Agent.OS)"
           targetPath: 'upload'
         enabled: false
+      # do not upload on scheduled builds
+      # do not create release if at least 1 platform build failed
       - task: GitHubRelease@0
         inputs:
           action: edit

--- a/azure-pipelines-job.yml
+++ b/azure-pipelines-job.yml
@@ -68,31 +68,3 @@ jobs:
           7z a .\upload\mm2-latest-$(Agent.OS).zip .\target\debug\mm2.exe .\target\debug\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
         displayName: 'Prepare upload Windows'
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
-      # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/copy-files-over-ssh?view=vsts
-      - task: CopyFilesOverSSH@0
-        inputs:
-          sshEndpoint: nightly_build_server
-          sourceFolder: 'upload' # Optional
-          contents: "**"
-          targetFolder: "uploads/$(Build.SourceBranchName)" # Optional
-          overwrite: true
-        displayName: 'Upload nightly'
-        enabled: false
-      # https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml
-      - task: PublishPipelineArtifact@0
-        inputs:
-          artifactName: "MM2-$(Agent.OS)"
-          targetPath: 'upload'
-        enabled: false
-      # do not release same commit multiple times
-      # upload both debug and release builds
-      - task: GitHubRelease@0
-        enabled: false
-        inputs:
-          action: edit
-          gitHubConnection: artemii235
-          isPreRelease: true
-          assets: 'upload/*'
-          assetUploadMode: replace
-          tagSource: manual
-          tag: 2.0.$(Build.BuildId)

--- a/azure-pipelines-job.yml
+++ b/azure-pipelines-job.yml
@@ -77,3 +77,7 @@ jobs:
         inputs:
           artifactName: "MM2-$(Agent.OS)"
           targetPath: 'upload'
+      - task: GitHubRelease@0
+        inputs:
+          gitHubConnection: artemii235
+          isPreRelease: true

--- a/azure-pipelines-job.yml
+++ b/azure-pipelines-job.yml
@@ -30,10 +30,6 @@ jobs:
           export TAG="$(git rev-parse --short=9 HEAD)"
           echo "##vso[task.setvariable variable=COMMIT_HASH]${TAG}"
         displayName: Setup ENV
-      - bash: pwd
-        displayName: Pwd
-        failOnStderr: false
-        continueOnError: true
       - powershell: |
           .\marketmaker_build_depends.cmd
         displayName: Build Windows deps
@@ -41,11 +37,11 @@ jobs:
       - bash: |
           rm -rf upload
           mkdir upload
-          echo 2.0.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_$(Agent.OS) > MM_VERSION
+          echo 2.0.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_$(Agent.OS)_Debug > MM_VERSION
           cat MM_VERSION
           touch mm2src/common/build.rs
           cargo build --features native -vv
-        displayName: 'Build MM2'
+        displayName: 'Build MM2 Debug'
       # Cargo uses CPU threads count by default running only 2 concurrent tests on Linux.
       # Explicit --test-threads=8 makes the process faster
       - bash: |
@@ -59,12 +55,10 @@ jobs:
           ALICE_PASSPHRASE: $(${{ parameters.alice_passphrase }})
           ALICE_USERPASS: $(${{ parameters.alice_userpass }})
       - bash: |
-          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS) target/debug/mm2 -j
-          zip upload/mm2-latest-$(Agent.OS) target/debug/mm2 -j
-        displayName: 'Prepare upload Linux/MacOS'
+          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Debug target/debug/mm2 -j
+        displayName: 'Prepare debug build upload Linux/MacOS'
         condition: ne( variables['Agent.OS'], 'Windows_NT' )
       - powershell: |
-          7z a .\upload\mm2-$(COMMIT_HASH)-$(Agent.OS).zip .\target\debug\mm2.exe .\target\debug\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
-          7z a .\upload\mm2-latest-$(Agent.OS).zip .\target\debug\mm2.exe .\target\debug\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
-        displayName: 'Prepare upload Windows'
+          7z a .\upload\mm2-$(COMMIT_HASH)-$(Agent.OS)-Debug.zip .\target\debug\mm2.exe .\target\debug\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
+        displayName: 'Prepare debug build upload Windows'
         condition: eq( variables['Agent.OS'], 'Windows_NT' )

--- a/azure-pipelines-job.yml
+++ b/azure-pipelines-job.yml
@@ -82,3 +82,5 @@ jobs:
           gitHubConnection: artemii235
           isPreRelease: true
           assets: 'upload/*'
+          tagSource: manual
+          tag: 2.0.$(Build.BuildId)

--- a/azure-pipelines-job.yml
+++ b/azure-pipelines-job.yml
@@ -84,8 +84,8 @@ jobs:
           artifactName: "MM2-$(Agent.OS)"
           targetPath: 'upload'
         enabled: false
-      # do not upload on scheduled builds
-      # do not create release if at least 1 platform build failed
+      # do not release same commit multiple times
+      # upload both debug and release builds
       - task: GitHubRelease@0
         enabled: false
         inputs:

--- a/azure-pipelines-job.yml
+++ b/azure-pipelines-job.yml
@@ -83,6 +83,7 @@ jobs:
       # do not upload on scheduled builds
       # do not create release if at least 1 platform build failed
       - task: GitHubRelease@0
+        enabled: false
         inputs:
           action: edit
           gitHubConnection: artemii235

--- a/azure-pipelines-job.yml
+++ b/azure-pipelines-job.yml
@@ -48,6 +48,7 @@ jobs:
           cargo test --features native --all -- --test-threads=8
         displayName: 'Test MM2'
         timeoutInMinutes: 22
+        enabled: false
         env:
           BOB_PASSPHRASE: $(${{ parameters.bob_passphrase }})
           BOB_USERPASS: $(${{ parameters.bob_userpass }})
@@ -72,13 +73,16 @@ jobs:
           targetFolder: "uploads/$(Build.SourceBranchName)" # Optional
           overwrite: true
         displayName: 'Upload nightly'
+        enabled: false
       # https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml
       - task: PublishPipelineArtifact@0
         inputs:
           artifactName: "MM2-$(Agent.OS)"
           targetPath: 'upload'
+        enabled: false
       - task: GitHubRelease@0
         inputs:
+          action: edit
           gitHubConnection: artemii235
           isPreRelease: true
           assets: 'upload/*'

--- a/azure-pipelines-job.yml
+++ b/azure-pipelines-job.yml
@@ -86,5 +86,6 @@ jobs:
           gitHubConnection: artemii235
           isPreRelease: true
           assets: 'upload/*'
+          assetUploadMode: replace
           tagSource: manual
           tag: 2.0.$(Build.BuildId)

--- a/azure-pipelines-job.yml
+++ b/azure-pipelines-job.yml
@@ -30,6 +30,10 @@ jobs:
           export TAG="$(git rev-parse --short=9 HEAD)"
           echo "##vso[task.setvariable variable=COMMIT_HASH]${TAG}"
         displayName: Setup ENV
+      - bash: pwd
+        displayName: Pwd
+        failOnStderr: false
+        continueOnError: true
       - powershell: |
           .\marketmaker_build_depends.cmd
         displayName: Build Windows deps

--- a/azure-pipelines-job.yml
+++ b/azure-pipelines-job.yml
@@ -81,3 +81,4 @@ jobs:
         inputs:
           gitHubConnection: artemii235
           isPreRelease: true
+          assets: 'upload/*'

--- a/azure-pipelines-release-stage-job.yml
+++ b/azure-pipelines-release-stage-job.yml
@@ -36,12 +36,13 @@ jobs:
           objcopy --only-keep-debug target/release/mm2 target/release/mm2.debug
           strip -g target/release/mm2
           zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release target/release/mm2 -j
-          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release.debug target/release/mm2.debug -j
+          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release-debuginfo.zip target/release/mm2.debug -j
         displayName: 'Prepare release build upload Linux'
         condition: eq( variables['Agent.OS'], 'Linux' )
       - bash: |
-          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release target/release/mm2 -j
-          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release.dSYM target/release/mm2.dSYM -j -r
+          cd target/release
+          zip ../../upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release.zip mm2
+          zip ../../upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release.dSYM.zip mm2.dSYM -r
         displayName: 'Prepare release build upload MacOS'
         condition: eq( variables['Agent.OS'], 'Darwin' )
       - powershell: |

--- a/azure-pipelines-release-stage-job.yml
+++ b/azure-pipelines-release-stage-job.yml
@@ -33,9 +33,17 @@ jobs:
           cargo build --features native --release -vv
         displayName: 'Build MM2 Release'
       - bash: |
+          objcopy --only-keep-debug target/release/mm2 target/release/mm2.debug
+          strip -g target/release/mm2
           zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release target/release/mm2 -j
-        displayName: 'Prepare release build upload Linux/MacOS'
-        condition: ne( variables['Agent.OS'], 'Windows_NT' )
+          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release.debug target/release/mm2.debug -j
+        displayName: 'Prepare release build upload Linux'
+        condition: eq( variables['Agent.OS'], 'Linux' )
+      - bash: |
+          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release target/release/mm2 -j
+          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release.dSYM target/release/mm2.dSYM -j -r
+        displayName: 'Prepare release build upload MacOS'
+        condition: eq( variables['Agent.OS'], 'Darwin' )
       - powershell: |
           7z a .\upload\mm2-$(COMMIT_HASH)-$(Agent.OS)-Release.zip .\target\release\mm2.exe .\target\release\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
         displayName: 'Prepare release build upload Windows'

--- a/azure-pipelines-release-stage-job.yml
+++ b/azure-pipelines-release-stage-job.yml
@@ -48,5 +48,5 @@ jobs:
           assets: 'upload/*'
           assetUploadMode: replace
           tagSource: manual
-          tag: 2.0.$(Build.BuildId)
+          tag: beta-2.0.$(Build.BuildId)
         condition: eq( variables['COMMIT_TAG'], '' )

--- a/azure-pipelines-release-stage-job.yml
+++ b/azure-pipelines-release-stage-job.yml
@@ -31,7 +31,7 @@ jobs:
           cat MM_VERSION
           touch mm2src/common/build.rs
           cargo build --features native --release -vv
-          displayName: 'Build MM2 Release'
+        displayName: 'Build MM2 Release'
       - bash: |
           zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release target/release/mm2 -j
         displayName: 'Prepare release build upload Linux/MacOS'

--- a/azure-pipelines-release-stage-job.yml
+++ b/azure-pipelines-release-stage-job.yml
@@ -1,0 +1,52 @@
+# Job template for MM2 Release stage build
+
+parameters:
+  name: ''  # defaults for any parameters that aren't specified
+  os: ''
+  bob_passphrase: ''
+  bob_userpass: ''
+  alice_passphrase: ''
+  alice_userpass: ''
+
+jobs:
+  - job: ${{ parameters.name }}
+    timeoutInMinutes: 0 # 0 means infinite for self-hosted agent
+    pool:
+      name: Default
+      demands: agent.os -equals ${{ parameters.os }}
+    steps:
+      # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-a-job-scoped-variable-from-a-script
+      - bash: |
+          export SHORT_HASH="$(git rev-parse --short=9 HEAD)"
+          echo "##vso[task.setvariable variable=COMMIT_HASH]${SHORT_HASH}"
+          export TAG="$(git tag -l --points-at HEAD)"
+          echo "##vso[task.setvariable variable=COMMIT_TAG]${TAG}"
+        displayName: Setup ENV
+      - powershell: |
+          .\marketmaker_build_depends.cmd
+        displayName: Build Windows deps
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+      - bash: |
+          echo 2.0.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_$(Agent.OS)_Release > MM_VERSION
+          cat MM_VERSION
+          touch mm2src/common/build.rs
+          cargo build --features native --release -vv
+          displayName: 'Build MM2 Release'
+      - bash: |
+          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release target/release/mm2 -j
+        displayName: 'Prepare release build upload Linux/MacOS'
+        condition: ne( variables['Agent.OS'], 'Windows_NT' )
+      - powershell: |
+          7z a .\upload\mm2-$(COMMIT_HASH)-$(Agent.OS)-Release.zip .\target\release\mm2.exe .\target\release\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
+        displayName: 'Prepare release build upload Windows'
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+      - task: GitHubRelease@0
+        inputs:
+          action: edit
+          gitHubConnection: artemii235
+          isPreRelease: true
+          assets: 'upload/*'
+          assetUploadMode: replace
+          tagSource: manual
+          tag: 2.0.$(Build.BuildId)
+        condition: eq( variables['COMMIT_TAG'], '' )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,21 +54,32 @@ stages:
       - job: release
         pool:
           name: Default
-          demands: agent.os -equals Linux
+          demands: agent.os -equals Darwin
+        # release only mm2 branch
         steps:
-          - bash: |
-              pwd
-              ls upload/
-            displayName: Pwd
-            failOnStderr: false
-            continueOnError: true
           # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-a-job-scoped-variable-from-a-script
           - bash: |
+              export SHORT_HASH="$(git rev-parse --short=9 HEAD)"
+              echo "##vso[task.setvariable variable=COMMIT_HASH]${SHORT_HASH}"
               export TAG="$(git tag -l --points-at HEAD)"
               echo "##vso[task.setvariable variable=COMMIT_TAG]${TAG}"
-              echo $TAG
-          # do not release same commit multiple times
-          # upload both debug and release builds
+            displayName: Setup ENV
+          - powershell: |
+              .\marketmaker_build_depends.cmd
+            displayName: Build Windows deps
+            condition: eq( variables['Agent.OS'], 'Windows_NT' )
+          - bash: |
+              echo 2.0.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_$(Agent.OS)_Release > MM_VERSION
+              cat MM_VERSION
+              touch mm2src/common/build.rs
+              cargo build --features native --release -vv
+          - bash: |
+              zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release target/release/mm2 -j
+            displayName: 'Prepare debug build upload Linux/MacOS'
+            condition: ne( variables['Agent.OS'], 'Windows_NT' )
+          - powershell: |
+              7z a .\upload\mm2-$(COMMIT_HASH)-$(Agent.OS)-Release.zip .\target\release\mm2.exe .\target\debug\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
+            displayName: 'Prepare debug build upload Windows'
           - task: GitHubRelease@0
             inputs:
               action: edit

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,3 +47,16 @@ stages:
           bob_userpass: 'BOB_USERPASS_WIN'
           alice_passphrase: 'ALICE_PASSPHRASE_WIN'
           alice_userpass: 'ALICE_USERPASS_WIN'
+
+  - stage: Release
+    displayName: Release
+    jobs:
+      - job: Test Release stage
+        pool:
+          name: Default
+          demands: agent.os -equals Linux
+        steps:
+          - bash: echo 1
+            displayName: Echo
+            failOnStderr: false
+            continueOnError: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,9 @@ stages:
           name: Default
           demands: agent.os -equals Linux
         steps:
-          - bash: pwd
+          - bash: |
+              pwd
+              ls upload/
             displayName: Pwd
             failOnStderr: false
             continueOnError: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,11 @@ stages:
             displayName: Pwd
             failOnStderr: false
             continueOnError: true
+          # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-a-job-scoped-variable-from-a-script
+          - bash: |
+              export TAG="$(git tag -l --points-at HEAD)"
+              echo "##vso[task.setvariable variable=COMMIT_TAG]${TAG}"
+              echo $TAG
           # do not release same commit multiple times
           # upload both debug and release builds
           - task: GitHubRelease@0
@@ -73,3 +78,4 @@ stages:
               assetUploadMode: replace
               tagSource: manual
               tag: 2.0.$(Build.BuildId)
+            condition: eq( variables['COMMIT_TAG'], '' )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,3 +62,14 @@ stages:
             displayName: Pwd
             failOnStderr: false
             continueOnError: true
+          # do not release same commit multiple times
+          # upload both debug and release builds
+          - task: GitHubRelease@0
+            inputs:
+              action: edit
+              gitHubConnection: artemii235
+              isPreRelease: true
+              assets: 'upload/*'
+              assetUploadMode: replace
+              tagSource: manual
+              tag: 2.0.$(Build.BuildId)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,6 +56,8 @@ stages:
           name: Default
           demands: agent.os -equals Linux
         steps:
+          - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+            enabled: false
           - bash: echo 1
             displayName: Echo
             failOnStderr: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,7 @@ stages:
 
   - stage: Release
     displayName: Release
+    condition: eq(variables['build.sourceBranch'], 'refs/heads/mm2')
     jobs:
       - template: azure-pipelines-release-stage-job.yml  # Template reference
         parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ stages:
   - stage: Release
     displayName: Release
     jobs:
-      - job: Test Release stage
+      - job: release
         pool:
           name: Default
           demands: agent.os -equals Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,9 +56,7 @@ stages:
           name: Default
           demands: agent.os -equals Linux
         steps:
-          - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
-            enabled: false
-          - bash: echo 1
-            displayName: Echo
+          - bash: pwd
+            displayName: Pwd
             failOnStderr: false
             continueOnError: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,29 +19,29 @@ trigger:
 
 stages:
   - stage: Build
-    displayName: Build
+    displayName: Build and test Debug
     jobs:
-      - template: azure-pipelines-job.yml  # Template reference
+      - template: azure-pipelines-build-stage-job.yml  # Template reference
         parameters:
-          name: 'MM2_Linux'
+          name: 'MM2_Build_Linux'
           os: 'Linux'
           bob_passphrase: 'BOB_PASSPHRASE_LINUX'
           bob_userpass: 'BOB_USERPASS_LINUX'
           alice_passphrase: 'ALICE_PASSPHRASE_LINUX'
           alice_userpass: 'ALICE_USERPASS_LINUX'
 
-      - template: azure-pipelines-job.yml  # Template reference
+      - template: azure-pipelines-build-stage-job.yml  # Template reference
         parameters:
-          name: 'MM2_MacOS'
+          name: 'MM2_Build_MacOS'
           os: 'Darwin'
           bob_passphrase: 'BOB_PASSPHRASE_MAC'
           bob_userpass: 'BOB_USERPASS_MAC'
           alice_passphrase: 'ALICE_PASSPHRASE_MAC'
           alice_userpass: 'ALICE_USERPASS_MAC'
 
-      - template: azure-pipelines-job.yml  # Template reference
+      - template: azure-pipelines-build-stage-job.yml  # Template reference
         parameters:
-          name: 'MM2_Windows'
+          name: 'MM2_Build_Windows'
           os: 'Windows_NT'
           bob_passphrase: 'BOB_PASSPHRASE_WIN'
           bob_userpass: 'BOB_USERPASS_WIN'
@@ -51,42 +51,17 @@ stages:
   - stage: Release
     displayName: Release
     jobs:
-      - job: release
-        pool:
-          name: Default
-          demands: agent.os -equals Darwin
-        # release only mm2 branch
-        steps:
-          # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-a-job-scoped-variable-from-a-script
-          - bash: |
-              export SHORT_HASH="$(git rev-parse --short=9 HEAD)"
-              echo "##vso[task.setvariable variable=COMMIT_HASH]${SHORT_HASH}"
-              export TAG="$(git tag -l --points-at HEAD)"
-              echo "##vso[task.setvariable variable=COMMIT_TAG]${TAG}"
-            displayName: Setup ENV
-          - powershell: |
-              .\marketmaker_build_depends.cmd
-            displayName: Build Windows deps
-            condition: eq( variables['Agent.OS'], 'Windows_NT' )
-          - bash: |
-              echo 2.0.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_$(Agent.OS)_Release > MM_VERSION
-              cat MM_VERSION
-              touch mm2src/common/build.rs
-              cargo build --features native --release -vv
-          - bash: |
-              zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release target/release/mm2 -j
-            displayName: 'Prepare debug build upload Linux/MacOS'
-            condition: ne( variables['Agent.OS'], 'Windows_NT' )
-          - powershell: |
-              7z a .\upload\mm2-$(COMMIT_HASH)-$(Agent.OS)-Release.zip .\target\release\mm2.exe .\target\debug\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
-            displayName: 'Prepare debug build upload Windows'
-          - task: GitHubRelease@0
-            inputs:
-              action: edit
-              gitHubConnection: artemii235
-              isPreRelease: true
-              assets: 'upload/*'
-              assetUploadMode: replace
-              tagSource: manual
-              tag: 2.0.$(Build.BuildId)
-            condition: eq( variables['COMMIT_TAG'], '' )
+      - template: azure-pipelines-release-stage-job.yml  # Template reference
+        parameters:
+          name: 'MM2_Release_Linux'
+          os: 'Linux'
+
+      - template: azure-pipelines-release-stage-job.yml  # Template reference
+        parameters:
+          name: 'MM2_Release_MacOS'
+          os: 'Darwin'
+
+      - template: azure-pipelines-release-stage-job.yml  # Template reference
+        parameters:
+          name: 'MM2_Release_Windows'
+          os: 'Windows_NT'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,30 +17,33 @@ trigger:
       - etomic_build/*
       - iguana/Readme.md
 
-jobs:
-  - template: azure-pipelines-job.yml  # Template reference
-    parameters:
-      name: 'MM2_Linux'
-      os: 'Linux'
-      bob_passphrase: 'BOB_PASSPHRASE_LINUX'
-      bob_userpass: 'BOB_USERPASS_LINUX'
-      alice_passphrase: 'ALICE_PASSPHRASE_LINUX'
-      alice_userpass: 'ALICE_USERPASS_LINUX'
+stages:
+  - stage: Build
+    displayName: Build
+    jobs:
+      - template: azure-pipelines-job.yml  # Template reference
+        parameters:
+          name: 'MM2_Linux'
+          os: 'Linux'
+          bob_passphrase: 'BOB_PASSPHRASE_LINUX'
+          bob_userpass: 'BOB_USERPASS_LINUX'
+          alice_passphrase: 'ALICE_PASSPHRASE_LINUX'
+          alice_userpass: 'ALICE_USERPASS_LINUX'
 
-  - template: azure-pipelines-job.yml  # Template reference
-    parameters:
-      name: 'MM2_MacOS'
-      os: 'Darwin'
-      bob_passphrase: 'BOB_PASSPHRASE_MAC'
-      bob_userpass: 'BOB_USERPASS_MAC'
-      alice_passphrase: 'ALICE_PASSPHRASE_MAC'
-      alice_userpass: 'ALICE_USERPASS_MAC'
+      - template: azure-pipelines-job.yml  # Template reference
+        parameters:
+          name: 'MM2_MacOS'
+          os: 'Darwin'
+          bob_passphrase: 'BOB_PASSPHRASE_MAC'
+          bob_userpass: 'BOB_USERPASS_MAC'
+          alice_passphrase: 'ALICE_PASSPHRASE_MAC'
+          alice_userpass: 'ALICE_USERPASS_MAC'
 
-  - template: azure-pipelines-job.yml  # Template reference
-    parameters:
-      name: 'MM2_Windows'
-      os: 'Windows_NT'
-      bob_passphrase: 'BOB_PASSPHRASE_WIN'
-      bob_userpass: 'BOB_USERPASS_WIN'
-      alice_passphrase: 'ALICE_PASSPHRASE_WIN'
-      alice_userpass: 'ALICE_USERPASS_WIN'
+      - template: azure-pipelines-job.yml  # Template reference
+        parameters:
+          name: 'MM2_Windows'
+          os: 'Windows_NT'
+          bob_passphrase: 'BOB_PASSPHRASE_WIN'
+          bob_userpass: 'BOB_USERPASS_WIN'
+          alice_passphrase: 'ALICE_PASSPHRASE_WIN'
+          alice_userpass: 'ALICE_USERPASS_WIN'

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -26,6 +26,7 @@ bytes = "0.4"
 # Using the `chrono` because the `time` formatting has serious limits, like the lack of subsecond support, IIRC.
 chrono = "0.4"
 crossbeam = "0.7"
+findshlibs = "0.5"
 fomat-macros = "0.2"
 futures01 = { version = "0.1", package = "futures" }
 futures = { version = ">=0.3.0-alpha.16, <0.4", package = "futures-preview", features = ["compat", "async-await", "nightly"] }

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -82,6 +82,8 @@ pub mod lift_body {
 
 use atomic::Atomic;
 use bigdecimal::BigDecimal;
+#[cfg(all(feature = "native", not(windows)))]
+use findshlibs::{Segment, SharedLibrary, TargetSharedLibrary, IterationControl};
 use futures01::{future, task::Task, Future};
 #[cfg(not(feature = "native"))]
 use futures::task::{Context, Poll as Poll03};
@@ -306,11 +308,16 @@ fn trace_name_buf() -> PaMutexGuard<'static, [u8; 128]> {
 
 /// Formats a stack frame.
 /// Some common and less than useful frames are skipped.
-pub fn stack_trace_frame (buf: &mut dyn Write, symbol: &backtrace::Symbol) {
-    let filename = match symbol.filename() {Some (path) => path, None => return};
-    let filename = match filename.components().rev().next() {Some (c) => c.as_os_str().to_string_lossy(), None => return};
-    let lineno = match symbol.lineno() {Some (lineno) => lineno, None => return};
-    let name = match symbol.name() {Some (name) => name, None => return};
+pub fn stack_trace_frame (instr_ptr: *mut c_void, buf: &mut dyn Write, symbol: &backtrace::Symbol) {
+    let filename = match symbol.filename() {
+        Some (path) => match path.components().rev().next() {
+            Some (c) => c.as_os_str().to_string_lossy(),
+            None => "??".into(),
+        },
+        None => "??".into(),
+    };
+    let lineno = match symbol.lineno() {Some (lineno) => lineno, None => 0};
+    let name = match symbol.name() {Some (name) => name, None => SymbolName::new(&[])};
     let mut name_buf = trace_name_buf();
     let name = gstring! (name_buf, {
         let _ = write! (name_buf, "{}", name);  // NB: `fmt` is different from `SymbolName::as_str`.
@@ -346,7 +353,7 @@ pub fn stack_trace_frame (buf: &mut dyn Write, symbol: &backtrace::Symbol) {
     if name.starts_with ("tokio_executor::") {return}
     if name.starts_with ("tokio_timer::") {return}
 
-    let _ = writeln! (buf, "  {}:{}] {}", filename, lineno, name);
+    let _ = writeln! (buf, "  {}:{}] {} {:?}", filename, lineno, name, instr_ptr);
 }
 
 /// Generates a string with the current stack trace.
@@ -359,18 +366,42 @@ pub fn stack_trace_frame (buf: &mut dyn Write, symbol: &backtrace::Symbol) {
 /// * `format` - Generates the string representation of a frame.
 /// * `output` - Function used to print the stack trace.
 ///              Printing immediately, without buffering, should make the tracing somewhat more reliable.
-pub fn stack_trace (format: &mut dyn FnMut (&mut dyn Write, &backtrace::Symbol), output: &mut dyn FnMut (&str)) {
+pub fn stack_trace (format: &mut dyn FnMut (*mut c_void, &mut dyn Write, &backtrace::Symbol), output: &mut dyn FnMut (&str)) {
     // cf. https://github.com/rust-lang/rust/pull/64154 (standard library backtrace)
 
     backtrace::trace (|frame| {
         backtrace::resolve (frame.ip(), |symbol| {
             let mut trace_buf = trace_buf();
             let trace = gstring! (trace_buf, {
-              format (trace_buf, symbol);
+            // frame.ip() is next instruction pointer typically so offset(-1) points to current instruction
+              format (frame.ip().wrapping_offset(-1), trace_buf, symbol);
             });
             output (trace);
         });
         true
+    });
+
+    if cfg!(all(feature = "native", not(windows))) {
+        output_pc_mem_addr(output)
+    }
+}
+
+#[cfg(all(feature = "native", not(windows)))]
+fn output_pc_mem_addr(output: &mut dyn FnMut (&str)) {
+    TargetSharedLibrary::each(|shlib| {
+        let mut trace_buf = trace_buf();
+        let name = gstring! (trace_buf, {
+            let _ = write! (trace_buf, "Virtual memory addresses of {}", shlib.name().to_string_lossy());
+        });
+        output(name);
+        for seg in shlib.segments() {
+            let segment = gstring! (trace_buf, {
+                let _ = write! (trace_buf, "  {}:{}", seg.name(), seg.actual_virtual_memory_address(shlib));
+            });
+            output(segment);
+        }
+        // First TargetSharedLibrary is initial executable, we are not interested in other libs
+        IterationControl::Break
     });
 }
 
@@ -429,7 +460,7 @@ pub fn is_a_test_drill() -> bool {
 
     let mut trace = String::with_capacity (1024);
     stack_trace (
-        &mut |mut fwr, sym| {if let Some (name) = sym.name() {let _ = witeln! (fwr, (name));}},
+        &mut |_ptr, mut fwr, sym| {if let Some (name) = sym.name() {let _ = witeln! (fwr, (name));}},
         &mut |tr| {trace.push_str (tr)});
 
     if trace.contains ("\nmm2::main\n") || trace.contains ("\nmm2::run_lp_main\n") {return false}
@@ -1159,6 +1190,8 @@ pub fn block_on<F> (f: F) -> F::Output where F: Future03 {
 
 #[cfg(feature = "native")]
 pub use gstuff::{now_ms, now_float};
+use backtrace::SymbolName;
+
 #[cfg(not(feature = "native"))]
 pub fn now_ms() -> u64 {
     #[cfg_attr(feature = "w-bindgen", wasm_bindgen(raw_module = "../../../js/defined-in-js.js"))]

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -381,9 +381,8 @@ pub fn stack_trace (format: &mut dyn FnMut (*mut c_void, &mut dyn Write, &backtr
         true
     });
 
-    if cfg!(all(feature = "native", not(windows))) {
-        output_pc_mem_addr(output)
-    }
+    #[cfg(all(feature = "native", not(windows)))]
+    output_pc_mem_addr(output)
 }
 
 #[cfg(all(feature = "native", not(windows)))]


### PR DESCRIPTION
Print items with their instruction pointers to backtrace even if symbolication fails in order to be able to symbolicate the trace using debug symbols that are also published with release.
Also print load addresses of mm2 binary segments on Linux and MacOS.
Windows debug symbols stripping is not required at least now because it's binary size is much less than Linux/MacOS.