### PR TITLE
Remove ETOMIC, PIZZA and BEER coins #657

### DIFF
--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -1,5 +1,5 @@
 use bigdecimal::BigDecimal;
-use common::{block_on, slurp_url};
+use common::block_on;
 use common::mm_ctx::MmCtxBuilder;
 use common::privkey::key_pair_from_seed;
 use crate::{
@@ -112,7 +112,7 @@ fn test_extract_secret() {
 
 #[test]
 fn test_generate_transaction() {
-    let client = electrum_client_for_test(&["test1.cipig.net:10025"]);
+    let client = electrum_client_for_test(&["electrum1.cipig.net:10017"]);
     let coin: UtxoCoin = utxo_coin_for_test(client.into(), None).into();
     let unspents = vec![UnspentInfo {
         value: 10000000000,
@@ -182,7 +182,7 @@ fn test_generate_transaction() {
 
 #[test]
 fn test_addresses_from_script() {
-    let client = electrum_client_for_test(&["test1.cipig.net:10025", "test2.cipig.net:10025"]);
+    let client = electrum_client_for_test(&["electrum1.cipig.net:10017", "electrum2.cipig.net:10017"]);
     let coin = utxo_coin_for_test(client.into(), None);
     // P2PKH
     let script: Script = "76a91405aab5342166f8594baf17a7d9bef5d56744332788ac".into();
@@ -308,20 +308,21 @@ fn test_wait_for_payment_spend_timeout_electrum() {
 
 #[test]
 fn test_search_for_swap_tx_spend_electrum_was_spent() {
-    let client = electrum_client_for_test(&["test1.cipig.net:10025", "test2.cipig.net:10025"]);
-    let coin = utxo_coin_for_test(client.into(), Some("spice describe gravity federal blast come thank unfair canal monkey style afraid"));
-    // raw tx bytes of https://etomic.explorer.dexstats.info/tx/c514b3163d66636ebc3574817cb5853d5ab39886183de71ffedf5c5768570a6b
-    let payment_tx_bytes = unwrap!(hex::decode("0400008085202f89013ac014d4926c8b435f7a5c58f38975d14f1aba597b1eef2dfdc093457678eb83010000006a47304402204ddb9b10237a1267a02426d923528213ad1e0b62d45be7d9629e2909f099d90c02205eecadecf6fd09cb8465170eb878c5d54e563f067b64e23c418da0f6519ca354012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffff02809698000000000017a914bbd726b74f27b476d5d932e903b5893fd4e8bd2187acdaaa87010000001976a91405aab5342166f8594baf17a7d9bef5d56744332788ac2771515d000000000000000000000000000000"));
+    let secret = [0; 32];
+    let client = electrum_client_for_test(&["electrum1.cipig.net:10017", "electrum2.cipig.net:10017"]);
+    let coin: UtxoCoin = utxo_coin_for_test(client.into(), Some("spice describe gravity federal blast come thank unfair canal monkey style afraid")).into();
 
-    // raw tx bytes of https://etomic.explorer.dexstats.info/tx/e72be40bab15f3914e70507e863e26b8ccfaa75a9861d6fe706b39cab1272617
-    let spend_tx_bytes = unwrap!(hex::decode("0400008085202f89016b0a5768575cdffe1fe73d188698b35a3d85b57c817435bc6e63663d16b314c500000000d8483045022100d3cf75d26d977c0358e46c5db3753aa332ba12130b36b24b541cb90416f4606102201d805c5bdfc4d630cb78adb63239911c97a09c41125af37be219e876610f15f201209ac4a742e81a47dc26a3ddf83de84783fdb49c2322c4a3fdafc0613bf3335c40004c6b6304218f515db1752102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ac6782012088a914954f5a3f3b5de4410e5e1a82949410de95a4b6ba882102631dcf1d4b1b693aa8c2751afc68e4794b1e5996566cfc701a663f8b7bbbe640ac68ffffffff0198929800000000001976a91464ae8510aac9546d5e7704e31ce177451386455588ac3963515d000000000000000000000000000000"));
+    // raw tx bytes of https://rick.kmd.dev/tx/ba881ecca15b5d4593f14f25debbcdfe25f101fd2e9cf8d0b5d92d19813d4424
+    let payment_tx_bytes = unwrap!(hex::decode("0400008085202f8902e115acc1b9e26a82f8403c9f81785445cc1285093b63b6246cf45aabac5e0865000000006b483045022100ca578f2d6bae02f839f71619e2ced54538a18d7aa92bd95dcd86ac26479ec9f802206552b6c33b533dd6fc8985415a501ebec89d1f5c59d0c923d1de5280e9827858012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffffb0721bf69163f7a5033fb3d18ba5768621d8c1347ebaa2fddab0d1f63978ea78020000006b483045022100a3309f99167982e97644dbb5cd7279b86630b35fc34855e843f2c5c0cafdc66d02202a8c3257c44e832476b2e2a723dad1bb4ec1903519502a49b936c155cae382ee012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffff0300e1f5050000000017a91443fde927a77b3c1d104b78155dc389078c4571b0870000000000000000166a14b8bcb07f6344b42ab04250c86a6e8b75d3fdbbc64b8cd736000000001976a91405aab5342166f8594baf17a7d9bef5d56744332788acba0ce35e000000000000000000000000000000"));
+
+    // raw tx bytes of https://rick.kmd.dev/tx/cea8028f93f7556ce0ef96f14b8b5d88ef2cd29f428df5936e02e71ca5b0c795
+    let spend_tx_bytes = unwrap!(hex::decode("0400008085202f890124443d81192dd9b5d0f89c2efd01f125fecdbbde254ff193455d5ba1cc1e88ba00000000d74730440220519d3eed69815a16357ff07bf453b227654dc85b27ffc22a77abe077302833ec02205c27f439ddc542d332504112871ecac310ea710b99e1922f48eb179c045e44ee01200000000000000000000000000000000000000000000000000000000000000000004c6b6304a9e5e25eb1752102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ac6782012088a914b8bcb07f6344b42ab04250c86a6e8b75d3fdbbc6882102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ac68ffffffff0118ddf505000000001976a91405aab5342166f8594baf17a7d9bef5d56744332788acbffee25e000000000000000000000000000000"));
     let spend_tx = TransactionEnum::UtxoTx(unwrap!(deserialize(spend_tx_bytes.as_slice())));
 
-    let found = unwrap!(unwrap!(coin.search_for_swap_tx_spend(
-        1565626145,
-        coin.key_pair.public(),
-        &unwrap!(Public::from_slice(&unwrap!(hex::decode("02631dcf1d4b1b693aa8c2751afc68e4794b1e5996566cfc701a663f8b7bbbe640")))),
-        &unwrap!(hex::decode("954f5a3f3b5de4410e5e1a82949410de95a4b6ba")),
+    let found = unwrap!(unwrap!(coin.search_for_swap_tx_spend_my(
+        1591928233,
+        &*coin.my_public_key(),
+        &*dhash160(&secret),
         &payment_tx_bytes,
         0
     )));
@@ -330,25 +331,25 @@ fn test_search_for_swap_tx_spend_electrum_was_spent() {
 
 #[test]
 fn test_search_for_swap_tx_spend_electrum_was_refunded() {
-    let client = electrum_client_for_test(&["test1.cipig.net:10025", "test2.cipig.net:10025"]);
-    let coin = utxo_coin_for_test(client.into(), Some("spice describe gravity federal blast come thank unfair canal monkey style afraid"));
+    let secret = [0; 20];
+    let client = electrum_client_for_test(&["electrum1.cipig.net:10017", "electrum2.cipig.net:10017"]);
+    let coin: UtxoCoin = utxo_coin_for_test(client.into(), Some("spice describe gravity federal blast come thank unfair canal monkey style afraid")).into();
 
-    // raw tx bytes of https://etomic.explorer.dexstats.info/tx/c9a47cc6e80a98355cd4e69d436eae6783cbee5991756caa6e64a0743442fa96
-    let payment_tx_bytes = unwrap!(hex::decode("0400008085202f8901887e809b10738b1625b7f47fd5d2201f32e8a4c6c0aaefc3b9ab6c07dc6a5925010000006a47304402203966f49ba8acc9fcc0e53e7b917ca5599ce6054a0c2d22752c57a3dc1b0fc83502206fde12c869da20a21cedd5bbc4bcd12977d25ff4b00e0999de5ac4254668e891012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffff02809698000000000017a9147e9456f37fa53cf9053e192ea4951d2c8b58647c8784631684010000001976a91405aab5342166f8594baf17a7d9bef5d56744332788ac0fb3525d000000000000000000000000000000"));
+    // raw tx bytes of https://rick.kmd.dev/tx/78ea7839f6d1b0dafda2ba7e34c1d8218676a58bd1b33f03a5f76391f61b72b0
+    let payment_tx_bytes = unwrap!(hex::decode("0400008085202f8902bf17bf7d1daace52e08f732a6b8771743ca4b1cb765a187e72fd091a0aabfd52000000006a47304402203eaaa3c4da101240f80f9c5e9de716a22b1ec6d66080de6a0cca32011cd77223022040d9082b6242d6acf9a1a8e658779e1c655d708379862f235e8ba7b8ca4e69c6012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffffff023ca13c0e9e085dd13f481f193e8a3e8fd609020936e98b5587342d994f4d020000006b483045022100c0ba56adb8de923975052312467347d83238bd8d480ce66e8b709a7997373994022048507bcac921fdb2302fa5224ce86e41b7efc1a2e20ae63aa738dfa99b7be826012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffff0300e1f5050000000017a9141ee6d4c38a3c078eab87ad1a5e4b00f21259b10d870000000000000000166a1400000000000000000000000000000000000000001b94d736000000001976a91405aab5342166f8594baf17a7d9bef5d56744332788ac2d08e35e000000000000000000000000000000"));
 
-    // raw tx bytes of https://etomic.explorer.dexstats.info/tx/a5f11bdb657ee834a4c410e2001beccce0374bfa3f662bd890fd3d01b0b3d101
-    let spend_tx_bytes = unwrap!(hex::decode("0400008085202f890196fa423474a0646eaa6c759159eecb8367ae6e439de6d45c35980ae8c67ca4c900000000c4483045022100969c3b2c1ab630b67a6ee74316c9356e38872276a070d126da1d731503bb6e3e02204398d8c23cb59c2caddc33ce9c9716c54b11574126a3c3350a17043f3751696d01514c786304cf93525db1752102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ac6782012088a92102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3882102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ac68feffffff0198929800000000001976a91405aab5342166f8594baf17a7d9bef5d56744332788ac01a5525d000000000000000000000000000000"));
-    let spend_tx = TransactionEnum::UtxoTx(unwrap!(deserialize(spend_tx_bytes.as_slice())));
+    // raw tx bytes of https://rick.kmd.dev/tx/65085eacab5af46c24b6633b098512cc455478819f3c40f8826ae2b9c1ac15e1
+    let refund_tx_bytes = unwrap!(hex::decode("0400008085202f8901b0721bf69163f7a5033fb3d18ba5768621d8c1347ebaa2fddab0d1f63978ea7800000000b6473044022052e06c1abf639148229a3991fdc6da15fe51c97577f4fda351d9c606c7cf53670220780186132d67d354564cae710a77d94b6bb07dcbd7162a13bebee261ffc0963601514c6b63041dfae25eb1752102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ac6782012088a9140000000000000000000000000000000000000000882102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ac68feffffff0118ddf505000000001976a91405aab5342166f8594baf17a7d9bef5d56744332788ace6fae25e000000000000000000000000000000"));
+    let refund_tx = TransactionEnum::UtxoTx(unwrap!(deserialize(refund_tx_bytes.as_slice())));
 
-    let found = unwrap!(unwrap!(coin.search_for_swap_tx_spend(
-        1565692879,
+    let found = unwrap!(unwrap!(coin.search_for_swap_tx_spend_my(
+        1591933469,
         coin.key_pair.public(),
-        &unwrap!(Public::from_slice(&unwrap!(hex::decode("02031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3")))),
-        &unwrap!(hex::decode("02031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3")),
+        &secret,
         &payment_tx_bytes,
         0
     )));
-    assert_eq!(FoundSwapTxSpend::Refunded(spend_tx), found);
+    assert_eq!(FoundSwapTxSpend::Refunded(refund_tx), found);
 }
 
 #[test]
@@ -546,7 +547,7 @@ fn test_withdraw_impl_sat_per_kb_fee_max() {
 #[test]
 fn test_utxo_lock() {
     // send several transactions concurrently to check that they are not using same inputs
-    let client = electrum_client_for_test(&["test1.cipig.net:10025", "test2.cipig.net:10025"]);
+    let client = electrum_client_for_test(&["electrum1.cipig.net:10017", "electrum2.cipig.net:10017"]);
     let coin: UtxoCoin = utxo_coin_for_test(client.into(), None).into();
     let output = TransactionOutput {
         value: 1000000,

--- a/mm2src/common/for_tests.rs
+++ b/mm2src/common/for_tests.rs
@@ -446,8 +446,8 @@ pub fn mm_spat (local_start: LocalStart, conf_mod: &dyn Fn(Json)->Json) -> (&'st
             "passphrase": passphrase,
             "rpccors": "http://localhost:4000",
             "coins": [
-                {"coin": "BEER", "asset": "BEER", "rpcport": 8923},
-                {"coin": "PIZZA", "asset": "PIZZA", "rpcport": 11116}
+                {"coin":"RICK","asset":"RICK","rpcport":8923},
+                {"coin":"MORTY","asset":"MORTY","rpcport":11608},
             ],
             "i_am_seed": true,
             "rpc_password": "pass",

--- a/mm2src/common/mm_metrics.rs
+++ b/mm2src/common/mm_metrics.rs
@@ -805,7 +805,7 @@ mod tests {
         for expected in expected["metrics"].as_array().unwrap() {
             let index = actual.iter()
                 .position(|metric| metric == expected)
-                .expect(&format!("Couldn't find expected metric: {:?}", expected));
+                .expect(&format!("Couldn't find expected metric: {:?} in {:?}", expected, actual));
             actual.remove(index);
         }
 

--- a/mm2src/mm2_tests.rs
+++ b/mm2src/mm2_tests.rs
@@ -33,18 +33,6 @@ use super::lp_main;
 // "Tests in your src files should be unit tests, and tests in tests/ should be integration-style tests."
 // - https://doc.rust-lang.org/cargo/guide/tests.html
 
-/// Enables BEER, PIZZA, ETOMIC and ETH.
-/// Returns the RPC replies containing the corresponding wallet addresses.
-#[cfg(feature = "native")]
-fn enable_coins(mm: &MarketMakerIt) -> Vec<(&'static str, Json)> {
-    let mut replies = Vec::new();
-    replies.push (("BEER", block_on (enable_native (mm, "BEER", vec![]))));
-    replies.push (("PIZZA", block_on (enable_native (mm, "PIZZA", vec![]))));
-    replies.push (("ETOMIC", block_on (enable_native (mm, "ETOMIC", vec![]))));
-    replies.push (("ETH", block_on (enable_native (mm, "ETH", vec!["https://ropsten.infura.io/v3/c01c1b4cf66642528547624e1d6d9d6b"]))));
-    replies
-}
-
 async fn enable_coins_eth_electrum(mm: &MarketMakerIt, eth_urls: Vec<&str>) -> HashMap<&'static str, Json> {
     let mut replies = HashMap::new();
     replies.insert ("RICK", enable_electrum (mm, "RICK", vec!["electrum1.cipig.net:10017","electrum2.cipig.net:10017","electrum3.cipig.net:10017"]) .await);
@@ -82,9 +70,9 @@ fn test_rpc() {
 
     let no_method = unwrap! (block_on (mm.rpc (json! ({
         "userpass": mm.userpass,
-        "coin": "BEER",
-        "ipaddr": "test1.cipig.net",
-        "port": 10022
+        "coin": "RICK",
+        "ipaddr": "electrum1.cipig.net",
+        "port": 10017
     }))));
     assert! (no_method.0.is_server_error());
     assert_eq!((no_method.2)[ACCESS_CONTROL_ALLOW_ORIGIN], "http://localhost:4000");
@@ -377,7 +365,7 @@ fn test_my_balance() {
     let (_dump_log, _dump_dashboard) = mm_dump (&mm.log_path);
     log!({"log path: {}", mm.log_path.display()});
     unwrap! (block_on (mm.wait_for_log (22., |log| log.contains (">>>>>>>>> DEX stats "))));
-    // Enable BEER.
+    // Enable RICK.
     let json = block_on(enable_electrum (&mm, "RICK", vec!["electrum1.cipig.net:10017","electrum2.cipig.net:10017","electrum3.cipig.net:10017"]));
     let balance_on_enable = unwrap!(json["balance"].as_str());
     assert_eq!(balance_on_enable, "7.777");
@@ -591,7 +579,7 @@ fn test_rpc_password_from_json() {
 #[cfg(feature = "native")]
 fn test_rpc_password_from_json_no_userpass() {
     let coins = json!([
-        {"coin":"BEER","asset":"BEER","rpcport":8923,"txversion":4},
+        {"coin":"RICK","asset":"RICK","rpcport":8923,"txversion":4},
     ]);
 
     let mut mm = unwrap! (MarketMakerIt::start (
@@ -610,8 +598,8 @@ fn test_rpc_password_from_json_no_userpass() {
     unwrap! (block_on (mm.wait_for_log (22., |log| log.contains (">>>>>>>>> DEX stats "))));
     let electrum = unwrap! (block_on (mm.rpc (json! ({
         "method": "electrum",
-        "coin": "BEER",
-        "urls": ["test2.cipig.net:10022"],
+        "coin": "RICK",
+        "urls": ["electrum2.cipig.net:10017"],
     }))));
 
     // electrum call must return 500 status code
@@ -698,7 +686,6 @@ async fn trade_base_rel_electrum (pairs: Vec<(&'static str, &'static str)>) {
     let coins = json! ([
         {"coin":"RICK","asset":"RICK","required_confirmations":0,"txversion":4,"overwintered":1},
         {"coin":"MORTY","asset":"MORTY","required_confirmations":0,"txversion":4,"overwintered":1},
-        {"coin":"ETOMIC","asset":"ETOMIC","required_confirmations":0,"txversion":4,"overwintered":1},
         {"coin":"ETH","name":"ethereum","etomic":"0x0000000000000000000000000000000000000000"},
         {"coin":"JST","name":"jst","etomic":"0x2b294F029Fde858b2c62184e8390591755521d8E"}
     ]);
@@ -916,222 +903,10 @@ pub extern fn trade_test_electrum_and_eth_coins (cb_id: i32) {
     use std::ptr::null;
 
     common::executor::spawn (async move {
-        // BEER and ETOMIC electrums are sometimes down, or blockchains stuck (cf. a5d593).
-        //let pairs = vec! [("BEER", "ETOMIC"), ("ETH", "JST")];
         let pairs = vec![("ETH", "JST")];
         trade_base_rel_electrum (pairs) .await;
         unsafe {call_back (cb_id, null(), 0)}
     })
-}
-
-#[cfg(feature = "native")]
-fn trade_base_rel_native(base: &str, rel: &str) {
-    let (bob_file_passphrase, bob_file_userpass) = from_env_file (unwrap! (slurp (&".env.seed")));
-    let (alice_file_passphrase, alice_file_userpass) = from_env_file (unwrap! (slurp (&".env.client")));
-
-    let bob_passphrase = unwrap! (var ("BOB_PASSPHRASE") .ok().or (bob_file_passphrase), "No BOB_PASSPHRASE or .env.seed/PASSPHRASE");
-    let bob_userpass = unwrap! (var ("BOB_USERPASS") .ok().or (bob_file_userpass), "No BOB_USERPASS or .env.seed/USERPASS");
-    let alice_passphrase = unwrap! (var ("ALICE_PASSPHRASE") .ok().or (alice_file_passphrase), "No ALICE_PASSPHRASE or .env.client/PASSPHRASE");
-    let alice_userpass = unwrap! (var ("ALICE_USERPASS") .ok().or (alice_file_userpass), "No ALICE_USERPASS or .env.client/USERPASS");
-
-    let coins = json! ([
-        {"coin":"BEER","asset":"BEER"},
-        {"coin":"PIZZA","asset":"PIZZA"},
-        {"coin":"ETOMIC","asset":"ETOMIC"},
-        {"coin":"ETH","name":"ethereum","etomic":"0x0000000000000000000000000000000000000000","rpcport":80}
-    ]);
-
-    let mut mm_bob = unwrap! (MarketMakerIt::start (
-        json! ({
-            "gui": "nogui",
-            "netid": 9000,
-            "dht": "on",  // Enable DHT without delay.
-            "myipaddr": env::var ("BOB_TRADE_IP") .ok(),
-            "rpcip": env::var ("BOB_TRADE_IP") .ok(),
-            "canbind": env::var ("BOB_TRADE_PORT") .ok().map (|s| unwrap! (s.parse::<i64>())),
-            "passphrase": bob_passphrase,
-            "coins": coins,
-        }),
-        bob_userpass,
-        match var ("LOCAL_THREAD_MM") {Ok (ref e) if e == "bob" => Some (local_start()), _ => None}
-    ));
-
-    let (_bob_dump_log, _bob_dump_dashboard) = mm_dump (&mm_bob.log_path);
-    log! ({"Bob log path: {}", mm_bob.log_path.display()});
-
-    // Both Alice and Bob might try to bind on the "0.0.0.0:47773" DHT port in this test
-    // (because the local "127.0.0.*:47773" addresses aren't that useful for DHT).
-    // We want to give Bob a headstart in acquiring the port,
-    // because Alice will then be able to directly reach it (thanks to "seednode").
-    // Direct communication is not required in this test, but it's nice to have.
-    // The port differs for another netid, should be 43804 for 9000
-    unwrap! (block_on (mm_bob.wait_for_log (9., |log| log.contains ("preferred port 43804 drill true"))));
-
-    let mut mm_alice = unwrap! (MarketMakerIt::start (
-        json! ({
-            "gui": "nogui",
-            "netid": 9000,
-            "dht": "on",  // Enable DHT without delay.
-            "myipaddr": env::var ("ALICE_TRADE_IP") .ok(),
-            "rpcip": env::var ("ALICE_TRADE_IP") .ok(),
-            "passphrase": alice_passphrase,
-            "coins": coins,
-            // We're using the open (non-NAT) netid 9000 seed instead, 195.201.42.102 // "seednode": fomat!((mm_bob.ip))
-        }),
-        alice_userpass,
-        match var ("LOCAL_THREAD_MM") {Ok (ref e) if e == "alice" => Some (local_start()), _ => None}
-    ));
-
-    let (_alice_dump_log, _alice_dump_dashboard) = mm_dump (&mm_alice.log_path);
-    log! ({"Alice log path: {}", mm_alice.log_path.display()});
-
-    // wait until both nodes RPC API is active
-    unwrap! (block_on (mm_bob.wait_for_log (22., |log| log.contains (">>>>>>>>> DEX stats "))));
-    unwrap! (block_on (mm_alice.wait_for_log (22., |log| log.contains (">>>>>>>>> DEX stats "))));
-
-    // Enable coins on Bob side. Print the replies in case we need the "smartaddress".
-    log! ({"enable_coins (bob): {:?}", enable_coins (&mm_bob)});
-    // Enable coins on Alice side. Print the replies in case we need the "smartaddress".
-    log! ({"enable_coins (alice): {:?}", enable_coins (&mm_alice)});
-
-    // Both the Taker and the Maker should connect to the netid 9000 open (non-NAT) seed node.
-    // NB: Long wayt as there might be delays in the seed node from us reusing the 127.0.0.* IPs with different keys.
-    unwrap! (block_on (mm_bob.wait_for_log (999., |log| log.contains ("set pubkey for "))));
-    unwrap! (block_on (mm_alice.wait_for_log (999., |log| log.contains ("set pubkey for "))));
-
-    // issue sell request on Bob side by setting base/rel price
-    log! ("Issue bob sell request");
-    let rc = unwrap! (block_on (mm_bob.rpc (json! ({
-        "userpass": mm_bob.userpass,
-        "method": "setprice",
-        "base": base,
-        "rel": rel,
-        "price": 0.9
-    }))));
-    assert! (rc.0.is_success(), "!setprice: {}", rc.1);
-
-    // issue base/rel buy request from Alice side
-    thread::sleep (Duration::from_secs (2));
-    log! ("Issue alice buy request");
-    let rc = unwrap! (block_on (mm_alice.rpc (json! ({
-        "userpass": mm_alice.userpass,
-        "method": "buy",
-        "base": base,
-        "rel": rel,
-        "relvolume": 0.1,
-        "price": 1
-    }))));
-    assert! (rc.0.is_success(), "!buy: {}", rc.1);
-
-    // ensure the swap started
-    unwrap! (block_on (mm_alice.wait_for_log (99., |log| log.contains ("Entering the taker_swap_loop"))));
-    unwrap! (block_on (mm_bob.wait_for_log (20., |log| log.contains ("Entering the maker_swap_loop"))));
-
-    // wait for swap to complete on both sides
-    unwrap! (block_on (mm_alice.wait_for_log (600., |log| log.contains ("Swap finished successfully"))));
-    unwrap! (block_on (mm_bob.wait_for_log (600., |log| log.contains ("Swap finished successfully"))));
-
-    unwrap! (block_on (mm_bob.stop()));
-    unwrap! (block_on (mm_alice.stop()));
-}
-
-/// Integration test for PIZZA/BEER and BEER/PIZZA trade
-/// This test is ignored because as of now it requires additional environment setup:
-/// PIZZA and ETOMIC daemons must be running and fully synced for swaps to be successful
-/// The trades can't be executed concurrently now for 2 reasons:
-/// 1. Bob node starts listening 47772 port on all interfaces so no more Bobs can be started at once
-/// 2. Current UTXO handling algo might result to conflicts between concurrently running nodes
-/// 
-/// Steps that are currently necessary to run this test:
-/// 
-/// Obtain the wallet binaries (komodod, komodo-cli) from the [Agama wallet](https://github.com/KomodoPlatform/Agama/releases/).
-/// (Or use the Docker image artempikulin/komodod-etomic).
-/// (Or compile them from [source](https://github.com/jl777/komodo/tree/dev))
-/// 
-/// Obtain ~/.zcash-params (c:/Users/$username/AppData/Roaming/ZcashParams on Windows).
-/// 
-/// Start the wallets
-/// 
-///     komodod -ac_name=PIZZA -ac_supply=100000000 -addnode=24.54.206.138 -addnode=78.47.196.146
-/// 
-/// and
-/// 
-///     komodod -ac_name=ETOMIC -ac_supply=100000000 -addnode=78.47.196.146
-/// 
-/// and (if you want to test BEER coin):
-///
-///     komodod -ac_name=BEER -ac_supply=100000000 -addnode=78.47.196.146 -addnode=43.245.162.106 -addnode=88.99.153.2 -addnode=94.130.173.120 -addnode=195.201.12.150 -addnode=23.152.0.28
-///
-/// Get rpcuser and rpcpassword from ETOMIC/ETOMIC.conf
-/// (c:/Users/$username/AppData/Roaming/Komodo/ETOMIC/ETOMIC.conf on Windows)
-/// and run
-/// 
-///     komodo-cli -ac_name=ETOMIC importaddress RKGn1jkeS7VNLfwY74esW7a8JFfLNj1Yoo
-/// 
-/// Share the wallet information with the test. On Windows:
-/// 
-///     set BOB_PASSPHRASE=...
-///     set BOB_USERPASS=...
-///     set ALICE_PASSPHRASE=...
-///     set ALICE_USERPASS=...
-/// 
-/// And run the test:
-/// 
-///     cargo test --features native trade_etomic_pizza -- --nocapture --ignored
-#[test]
-#[ignore]
-#[cfg(feature = "native")]
-fn trade_pizza_eth() {
-    trade_base_rel_native("PIZZA", "ETH");
-}
-
-#[test]
-#[ignore]
-#[cfg(feature = "native")]
-fn trade_eth_pizza() {
-    trade_base_rel_native("ETH", "PIZZA");
-}
-
-#[test]
-#[ignore]
-#[cfg(feature = "native")]
-fn trade_beer_eth() {
-    trade_base_rel_native("BEER", "ETH");
-}
-
-#[test]
-#[ignore]
-#[cfg(feature = "native")]
-fn trade_eth_beer() {
-    trade_base_rel_native("ETH", "BEER");
-}
-
-#[test]
-#[ignore]
-#[cfg(feature = "native")]
-fn trade_pizza_beer() {
-    trade_base_rel_native("PIZZA", "BEER");
-}
-
-#[test]
-#[ignore]
-#[cfg(feature = "native")]
-fn trade_beer_pizza() {
-    trade_base_rel_native("BEER", "PIZZA");
-}
-
-#[test]
-#[ignore]
-#[cfg(feature = "native")]
-fn trade_pizza_etomic() {
-    trade_base_rel_native("PIZZA", "ETOMIC");
-}
-
-#[test]
-#[ignore]
-#[cfg(feature = "native")]
-fn trade_etomic_pizza() {
-    trade_base_rel_native("ETOMIC", "PIZZA");
 }
 
 #[cfg(feature = "native")]
@@ -1174,7 +949,6 @@ fn test_withdraw_and_send() {
         {"coin":"RICK","asset":"RICK","rpcport":8923,"txversion":4,"overwintered":1,"txfee":1000},
         {"coin":"MORTY","asset":"MORTY","rpcport":8923,"txversion":4,"overwintered":1,"txfee":1000},
         {"coin":"MORTY_SEGWIT","asset":"MORTY_SEGWIT","txversion":4,"overwintered":1,"segwit":true,"txfee":1000},
-        {"coin":"ETOMIC","asset":"ETOMIC","txversion":4,"overwintered":1,"txfee":1000},
         {"coin":"ETH","name":"ethereum","etomic":"0x0000000000000000000000000000000000000000"},
         {"coin":"JST","name":"jst","etomic":"0x2b294F029Fde858b2c62184e8390591755521d8E"}
     ]);
@@ -1253,7 +1027,7 @@ fn test_withdraw_and_send() {
 #[test]
 #[cfg(feature = "native")]
 fn test_swap_status() {
-    let coins = json! ([{"coin":"BEER","asset":"BEER"},]);
+    let coins = json! ([{"coin":"RICk","asset":"RICK"},]);
 
     let mut mm = unwrap! (MarketMakerIt::start (
         json! ({
@@ -1406,15 +1180,14 @@ fn test_startup_passphrase() {
 
 /// MM2 should allow to issue several buy/sell calls in a row without delays.
 /// https://github.com/artemii235/SuperNET/issues/245
-/// TODO: Fix the test and delete the ignore attribute
 #[test]
-#[ignore]
 #[cfg(feature = "native")]
 fn test_multiple_buy_sell_no_delay() {
-    let coins = json!([
+    let coins = json! ([
         {"coin":"RICK","asset":"RICK","rpcport":8923,"txversion":4,"overwintered":1},
         {"coin":"MORTY","asset":"MORTY","rpcport":11608,"txversion":4,"overwintered":1},
-        {"coin":"ETOMIC","asset":"ETOMIC","txversion":4},
+        {"coin":"ETH","name":"ethereum","etomic":"0x0000000000000000000000000000000000000000"},
+        {"coin":"JST","name":"jst","etomic":"0x2b294F029Fde858b2c62184e8390591755521d8E"}
     ]);
 
     let (bob_file_passphrase, _bob_file_userpass) = from_env_file (unwrap! (slurp (&".env.seed")));
@@ -1438,9 +1211,7 @@ fn test_multiple_buy_sell_no_delay() {
     let (_dump_log, _dump_dashboard) = mm_dump (&mm.log_path);
     log!({"Log path: {}", mm.log_path.display()});
     unwrap! (block_on (mm.wait_for_log (22., |log| log.contains (">>>>>>>>> DEX stats "))));
-    log!([block_on (enable_electrum (&mm, "RICK", vec!["electrum1.cipig.net:10017","electrum2.cipig.net:10017","electrum3.cipig.net:10017"]))]);
-    log!([block_on (enable_electrum (&mm, "MORTY", vec!["electrum1.cipig.net:10018","electrum2.cipig.net:10018","electrum3.cipig.net:10018"]))]);
-    log!([block_on (enable_electrum (&mm, "ETOMIC", vec!["test1.cipig.net:10025", "test2.cipig.net:10025"]))]);
+    log!([block_on(enable_coins_eth_electrum(&mm, vec!["http://195.201.0.6:8565"]))]);
 
     let rc = unwrap! (block_on (mm.rpc (json! ({
         "userpass": mm.userpass,
@@ -1456,7 +1227,7 @@ fn test_multiple_buy_sell_no_delay() {
         "userpass": mm.userpass,
         "method": "buy",
         "base": "RICK",
-        "rel": "ETOMIC",
+        "rel": "ETH",
         "price": 1,
         "volume": 0.1,
     }))));
@@ -1480,20 +1251,20 @@ fn test_multiple_buy_sell_no_delay() {
     assert_eq!(0, asks.len(), "RICK/MORTY asks are not empty");
     assert_eq!(Json::from("0.1"), bids[0]["maxvolume"]);
 
-    log!("Get RICK/ETOMIC orderbook");
+    log!("Get RICK/ETH orderbook");
     let rc = unwrap! (block_on (mm.rpc (json! ({
         "userpass": mm.userpass,
         "method": "orderbook",
         "base": "RICK",
-        "rel": "ETOMIC",
+        "rel": "ETH",
     }))));
     assert! (rc.0.is_success(), "!orderbook: {}", rc.1);
 
     let bob_orderbook: Json = unwrap!(json::from_str(&rc.1));
-    log!("RICK/ETOMIC orderbook " [bob_orderbook]);
+    log!("RICK/ETH orderbook " [bob_orderbook]);
     let bids = bob_orderbook["bids"].as_array().unwrap();
-    assert!(bids.len() > 0, "RICK/ETOMIC bids are empty");
-    assert_eq!(asks.len(), 0, "RICK/ETOMIC asks are not empty");
+    assert!(bids.len() > 0, "RICK/ETH bids are empty");
+    assert_eq!(asks.len(), 0, "RICK/ETH asks are not empty");
     assert_eq!(Json::from("0.1"), bids[0]["maxvolume"]);
 }
 
@@ -2182,7 +1953,6 @@ fn test_fill_or_kill_taker_order_should_not_transform_to_maker() {
     let coins = json! ([
         {"coin":"RICK","asset":"RICK","required_confirmations":0,"txversion":4,"overwintered":1},
         {"coin":"MORTY","asset":"MORTY","required_confirmations":0,"txversion":4,"overwintered":1},
-        {"coin":"ETOMIC","asset":"ETOMIC","required_confirmations":0,"txversion":4,"overwintered":1},
         {"coin":"ETH","name":"ethereum","etomic":"0x0000000000000000000000000000000000000000"},
         {"coin":"JST","name":"jst","etomic":"0x2b294F029Fde858b2c62184e8390591755521d8E"}
     ]);

--- a/mm2src/ordermatch_tests.rs
+++ b/mm2src/ordermatch_tests.rs
@@ -731,8 +731,8 @@ fn prepare_for_cancel_by(ctx: &MmArc) {
 
     maker_orders.insert(Uuid::from_bytes([0; 16]), MakerOrder {
         uuid: Uuid::from_bytes([0; 16]),
-        base: "ETOMIC".into(),
-        rel: "BEER".into(),
+        base: "RICK".into(),
+        rel: "MORTY".into(),
         created_at: now_ms(),
         matches: HashMap::new(),
         max_base_vol: 0.into(),
@@ -745,8 +745,8 @@ fn prepare_for_cancel_by(ctx: &MmArc) {
     });
     maker_orders.insert(Uuid::from_bytes([1; 16]), MakerOrder {
         uuid: Uuid::from_bytes([1; 16]),
-        base: "BEER".into(),
-        rel: "ETOMIC".into(),
+        base: "MORTY".into(),
+        rel: "RICK".into(),
         created_at: now_ms(),
         matches: HashMap::new(),
         max_base_vol: 0.into(),
@@ -759,8 +759,8 @@ fn prepare_for_cancel_by(ctx: &MmArc) {
     });
     maker_orders.insert(Uuid::from_bytes([2; 16]), MakerOrder {
         uuid: Uuid::from_bytes([2; 16]),
-        base: "BEER".into(),
-        rel: "PIZZA".into(),
+        base: "MORTY".into(),
+        rel: "ETH".into(),
         created_at: now_ms(),
         matches: HashMap::new(),
         max_base_vol: 0.into(),
@@ -775,8 +775,8 @@ fn prepare_for_cancel_by(ctx: &MmArc) {
         matches: HashMap::new(),
         created_at: now_ms(),
         request: TakerRequest {
-            base: "ETOMIC".into(),
-            rel: "BEER".into(),
+            base: "RICK".into(),
+            rel: "MORTY".into(),
             uuid: Uuid::from_bytes([3; 16]),
             action: TakerAction::Buy,
             base_amount: 0.into(),
@@ -804,7 +804,7 @@ fn test_cancel_by_single_coin() {
         MockResult::Return(())
     });
 
-    let (cancelled, _) = unwrap!(cancel_orders_by(&ctx, CancelBy::Coin { ticker: "ETOMIC".into() }));
+    let (cancelled, _) = unwrap!(cancel_orders_by(&ctx, CancelBy::Coin { ticker: "RICK".into() }));
     assert!(cancelled.contains(&Uuid::from_bytes([0; 16])));
     assert!(cancelled.contains(&Uuid::from_bytes([1; 16])));
     assert!(!cancelled.contains(&Uuid::from_bytes([2; 16])));
@@ -824,8 +824,8 @@ fn test_cancel_by_pair() {
     });
 
     let (cancelled, _) = unwrap!(cancel_orders_by(&ctx, CancelBy::Pair{
-        base: "ETOMIC".into(),
-        rel: "BEER".into(),
+        base: "RICK".into(),
+        rel: "MORTY".into(),
     }));
     assert!(cancelled.contains(&Uuid::from_bytes([0; 16])));
     assert!(!cancelled.contains(&Uuid::from_bytes([1; 16])));


### PR DESCRIPTION
* Replace the coins with RICK, MORTY, ETH in each of the tests
* Replace testN.cipig.net with electrumN.cipig.net urls and corresponding 10022, 10024, 10025 ports with 10017, 10018
* Change the test_search_for_swap_tx_spend_electrum_was_spent and test_search_for_swap_tx_spend_electrum_was_refunded tests: replace ETOMIC to RICK swaps