### PR TITLE
Add peer discovery/exchange working on top of request response also using reserved gossipsub topic.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,15 +22,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 
 [[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array 0.14.2",
+]
+
+[[package]]
+name = "aes"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
+dependencies = [
+ "aes-soft 0.4.0",
+ "aesni 0.7.0",
+ "block-cipher",
+]
+
+[[package]]
 name = "aes-ctr"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e5b0458ea3beae0d1d8c0f3946564f8e10f90646cf78c06b4351052058d1ee"
 dependencies = [
- "aes-soft",
- "aesni",
+ "aes-soft 0.3.3",
+ "aesni 0.6.0",
  "ctr",
- "stream-cipher",
+ "stream-cipher 0.3.2",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "block-cipher",
+ "ghash",
+ "subtle 2.2.3",
 ]
 
 [[package]]
@@ -45,6 +78,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-soft"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
+dependencies = [
+ "block-cipher",
+ "byteorder",
+ "opaque-debug",
+]
+
+[[package]]
 name = "aesni"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,7 +96,17 @@ checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
 dependencies = [
  "block-cipher-trait",
  "opaque-debug",
- "stream-cipher",
+ "stream-cipher 0.3.2",
+]
+
+[[package]]
+name = "aesni"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
+dependencies = [
+ "block-cipher",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -360,6 +414,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
+dependencies = [
+ "byte-tools 0.3.1",
+ "byteorder",
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +491,15 @@ dependencies = [
  "block-padding",
  "byte-tools 0.3.1",
  "byteorder",
+ "generic-array 0.14.2",
+]
+
+[[package]]
+name = "block-cipher"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
+dependencies = [
  "generic-array 0.14.2",
 ]
 
@@ -570,6 +646,29 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "chacha20"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086c0f07ac275808b7bf9a39f2fd013aae1498be83632814c8c4e0bd53f2dc58"
+dependencies = [
+ "stream-cipher 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b0c90556d8e3fec7cf18d84a2f53d27b21288f2fe481b830fadcf809e48205"
+dependencies = [
+ "aead",
+ "chacha20",
+ "poly1305",
+ "stream-cipher 0.4.1",
+ "zeroize",
+]
 
 [[package]]
 name = "chain"
@@ -963,6 +1062,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array 0.14.2",
+ "subtle 2.2.3",
+]
+
+[[package]]
 name = "ct-logs"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,7 +1087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
 dependencies = [
  "block-cipher-trait",
- "stream-cipher",
+ "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -1692,6 +1801,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2377,7 @@ dependencies = [
  "libp2p-core-derive",
  "libp2p-dns",
  "libp2p-mplex",
+ "libp2p-noise",
  "libp2p-ping",
  "libp2p-request-response",
  "libp2p-secio",
@@ -2338,6 +2457,27 @@ dependencies = [
  "log 0.4.8",
  "parking_lot 0.10.2",
  "unsigned-varint 0.4.0",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.23.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+dependencies = [
+ "bytes 0.5.5",
+ "curve25519-dalek",
+ "futures 0.3.5",
+ "lazy_static",
+ "libp2p-core",
+ "log 0.4.8",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2 0.8.2",
+ "snow",
+ "static_assertions",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -3250,6 +3390,25 @@ name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+
+[[package]]
+name = "poly1305"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b42192ab143ed7619bf888a7f9c6733a9a2153b218e2cd557cfdb52fbf9bb1"
+dependencies = [
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
+dependencies = [
+ "cfg-if",
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -4180,6 +4339,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "snow"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32bf8474159a95551661246cda4976e89356999e3cbfef36f493dacc3fae1e8e"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "ring",
+ "rustc_version",
+ "sha2 0.9.0",
+ "subtle 2.2.3",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "socket2"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4232,6 +4409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
 dependencies = [
  "generic-array 0.12.3",
+]
+
+[[package]]
+name = "stream-cipher"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f8ed9974042b8c3672ff3030a69fcc03b74c47c3d1ecb7755e8a3626011e88"
+dependencies = [
+ "generic-array 0.14.2",
 ]
 
 [[package]]
@@ -4922,6 +5108,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array 0.14.2",
+ "subtle 2.2.3",
+]
+
+[[package]]
 name = "unsigned-varint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5290,6 +5486,17 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.5.1",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,21 +36,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
- "aes-soft 0.4.0",
- "aesni 0.7.0",
+ "aes-soft",
+ "aesni",
  "block-cipher",
-]
-
-[[package]]
-name = "aes-ctr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e5b0458ea3beae0d1d8c0f3946564f8e10f90646cf78c06b4351052058d1ee"
-dependencies = [
- "aes-soft 0.3.3",
- "aesni 0.6.0",
- "ctr",
- "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -68,17 +56,6 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
-dependencies = [
- "block-cipher-trait",
- "byteorder",
- "opaque-debug",
-]
-
-[[package]]
-name = "aes-soft"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
@@ -86,17 +63,6 @@ dependencies = [
  "block-cipher",
  "byteorder",
  "opaque-debug",
-]
-
-[[package]]
-name = "aesni"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
-dependencies = [
- "block-cipher-trait",
- "opaque-debug",
- "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -201,7 +167,7 @@ dependencies = [
  "futures-io",
  "futures-timer 3.0.2",
  "kv-log-macro",
- "log 0.4.8",
+ "log 0.4.11",
  "memchr",
  "num_cpus",
  "once_cell",
@@ -254,7 +220,7 @@ dependencies = [
  "async-std",
  "base64 0.11.0",
  "byteorder",
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "env_logger 0.7.1",
  "fnv",
  "futures 0.3.5",
@@ -263,7 +229,7 @@ dependencies = [
  "libp2p-plaintext",
  "libp2p-swarm",
  "libp2p-yamux",
- "log 0.4.8",
+ "log 0.4.11",
  "lru",
  "prost",
  "prost-build",
@@ -375,7 +341,7 @@ dependencies = [
  "clap",
  "env_logger 0.6.2",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "peeking_take_while",
  "proc-macro2 0.3.5",
  "quote 0.5.2",
@@ -504,15 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
-dependencies = [
- "generic-array 0.12.3",
-]
-
-[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,12 +540,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
-dependencies = [
- "loom",
-]
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bzip2"
@@ -653,7 +607,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "086c0f07ac275808b7bf9a39f2fd013aae1498be83632814c8c4e0bd53f2dc58"
 dependencies = [
- "stream-cipher 0.4.1",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -666,7 +620,7 @@ dependencies = [
  "aead",
  "chacha20",
  "poly1305",
- "stream-cipher 0.4.1",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -1081,16 +1035,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
-dependencies = [
- "block-cipher-trait",
- "stream-cipher 0.3.2",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,7 +1182,7 @@ checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.8",
+ "log 0.4.11",
  "regex",
  "termcolor",
 ]
@@ -1251,7 +1195,7 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.8",
+ "log 0.4.11",
  "regex",
  "termcolor",
 ]
@@ -1713,7 +1657,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures 0.3.5",
  "memchr",
  "pin-project",
@@ -1724,19 +1668,6 @@ name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
-name = "generator"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
-dependencies = [
- "cc",
- "libc",
- "log 0.4.8",
- "rustc_version",
- "winapi 0.3.8",
-]
 
 [[package]]
 name = "generic-array"
@@ -1874,7 +1805,7 @@ dependencies = [
  "futures 0.1.29",
  "http 0.1.21",
  "indexmap",
- "log 0.4.8",
+ "log 0.4.11",
  "slab 0.4.2",
  "string",
  "tokio-io",
@@ -1886,14 +1817,14 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
  "http 0.2.1",
  "indexmap",
- "log 0.4.8",
+ "log 0.4.11",
  "slab 0.4.2",
  "tokio 0.2.22",
  "tokio-util",
@@ -2023,7 +1954,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -2046,7 +1977,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "http 0.2.1",
 ]
 
@@ -2080,7 +2011,7 @@ dependencies = [
  "httparse",
  "iovec",
  "itoa",
- "log 0.4.8",
+ "log 0.4.11",
  "net2",
  "rustc_version",
  "time",
@@ -2101,7 +2032,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2110,7 +2041,7 @@ dependencies = [
  "http-body 0.3.1",
  "httparse",
  "itoa",
- "log 0.4.8",
+ "log 0.4.11",
  "pin-project",
  "socket2",
  "time",
@@ -2125,11 +2056,11 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "ct-logs",
  "futures-util",
  "hyper 0.13.6",
- "log 0.4.8",
+ "log 0.4.11",
  "rustls 0.17.0",
  "rustls-native-certs",
  "tokio 0.2.22",
@@ -2314,7 +2245,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ff57d6d215f7ca7eb35a9a64d656ba4d9d2bef114d741dc08048e75e2f5d418"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -2366,11 +2297,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.23.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.25.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
  "atomic",
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures 0.3.5",
  "lazy_static",
  "libp2p-core",
@@ -2380,7 +2311,6 @@ dependencies = [
  "libp2p-noise",
  "libp2p-ping",
  "libp2p-request-response",
- "libp2p-secio",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-websocket",
@@ -2394,8 +2324,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.21.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.22.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2406,7 +2336,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "lazy_static",
  "libsecp256k1 0.3.5",
- "log 0.4.8",
+ "log 0.4.11",
  "multihash",
  "multistream-select",
  "parity-multiaddr",
@@ -2428,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.20.2"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
  "quote 1.0.7",
  "syn 1.0.33",
@@ -2436,40 +2366,40 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.21.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.22.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.21.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.22.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "futures 0.3.5",
  "futures_codec",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
  "parking_lot 0.10.2",
  "unsigned-varint 0.4.0",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.23.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.24.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "curve25519-dalek",
  "futures 0.3.5",
  "lazy_static",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2482,13 +2412,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.21.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.22.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.8",
+ "log 0.4.11",
  "rand 0.7.3",
  "void",
  "wasm-timer",
@@ -2496,14 +2426,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.21.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.22.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures 0.3.5",
  "futures_codec",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
  "prost",
  "prost-build",
  "rw-stream-sink",
@@ -2513,54 +2443,31 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.2.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.3.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
  "async-trait",
+ "bytes 0.5.6",
  "futures 0.3.5",
  "libp2p-core",
  "libp2p-swarm",
+ "log 0.4.11",
+ "minicbor",
+ "rand 0.7.3",
  "smallvec 1.4.0",
+ "unsigned-varint 0.5.0",
  "wasm-timer",
 ]
 
 [[package]]
-name = "libp2p-secio"
-version = "0.21.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
-dependencies = [
- "aes-ctr",
- "ctr",
- "futures 0.3.5",
- "hmac 0.7.1",
- "js-sys",
- "lazy_static",
- "libp2p-core",
- "log 0.4.8",
- "parity-send-wrapper",
- "pin-project",
- "prost",
- "prost-build",
- "quicksink",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2 0.8.2",
- "static_assertions",
- "twofish",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "libp2p-swarm"
-version = "0.21.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.22.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
+ "either",
  "futures 0.3.5",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
  "rand 0.7.3",
  "smallvec 1.4.0",
  "void",
@@ -2569,29 +2476,29 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.21.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.22.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "get_if_addrs",
  "ipnet",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
  "socket2",
  "tokio 0.2.22",
 ]
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.22.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.23.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
  "async-tls",
  "either",
  "futures 0.3.5",
  "libp2p-core",
- "log 0.4.8",
+ "log 0.4.11",
  "quicksink",
  "rustls 0.18.1",
  "rw-stream-sink",
@@ -2603,8 +2510,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.21.0"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.22.0"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -2680,27 +2587,16 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls 0.1.2",
 ]
 
 [[package]]
@@ -2798,6 +2694,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc03ad6f8f548db7194a5ff5a6f96342ecae4e3ef67d2bf18bacc0e245cd041"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c214bf3d90099b52f3e4b328ae0fe34837fd0fab683ad1e10fceb4629106df48"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,7 +2743,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.8",
+ "log 0.4.11",
  "miow",
  "net2",
  "slab 0.4.2",
@@ -2933,7 +2849,7 @@ dependencies = [
  "lazy_static",
  "libp2p",
  "libsecp256k1 0.3.5",
- "log 0.4.8",
+ "log 0.4.11",
  "num-bigint",
  "num-rational",
  "rand 0.7.3",
@@ -2990,11 +2906,11 @@ checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 [[package]]
 name = "multistream-select"
 version = "0.8.2"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures 0.3.5",
- "log 0.4.8",
+ "log 0.4.11",
  "pin-project",
  "smallvec 1.4.0",
  "unsigned-varint 0.4.0",
@@ -3008,7 +2924,7 @@ checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.8",
+ "log 0.4.11",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -3187,8 +3103,8 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.1"
-source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#a999a753fb70fc104d54f3801254bd17061646e8"
+version = "0.9.2"
+source = "git+https://github.com/KomodoPlatform/rust-libp2p.git#6de9eee334646f83a0e9376c2b2002787d6e9dd6"
 dependencies = [
  "arrayref",
  "bs58",
@@ -3201,12 +3117,6 @@ dependencies = [
  "unsigned-varint 0.4.0",
  "url 2.1.1",
 ]
-
-[[package]]
-name = "parity-send-wrapper"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 
 [[package]]
 name = "parking"
@@ -3471,7 +3381,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "prost-derive",
 ]
 
@@ -3481,10 +3391,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "heck",
  "itertools 0.8.2",
- "log 0.4.8",
+ "log 0.4.11",
  "multimap",
  "petgraph",
  "prost",
@@ -3512,7 +3422,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "prost",
 ]
 
@@ -3539,7 +3449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 dependencies = [
  "env_logger 0.7.1",
- "log 0.4.8",
+ "log 0.4.11",
  "rand 0.7.3",
  "rand_core 0.5.1",
 ]
@@ -3912,7 +3822,7 @@ source = "git+https://github.com/artemii235/parity-bitcoin.git#1b129897cd4eb6308
 dependencies = [
  "chain",
  "keys",
- "log 0.4.8",
+ "log 0.4.11",
  "primitives",
  "rustc-hex 2.1.0",
  "script",
@@ -3974,7 +3884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 dependencies = [
  "base64 0.11.0",
- "log 0.4.8",
+ "log 0.4.11",
  "ring",
  "sct",
  "webpki",
@@ -3987,7 +3897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
  "base64 0.12.3",
- "log 0.4.8",
+ "log 0.4.11",
  "ring",
  "sct",
  "webpki",
@@ -4065,7 +3975,7 @@ dependencies = [
  "blake2b_simd 0.4.1",
  "chain",
  "keys",
- "log 0.4.8",
+ "log 0.4.11",
  "primitives",
  "serialization",
 ]
@@ -4375,11 +4285,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85457366ae0c6ce56bf05a958aef14cd38513c236568618edbcd9a8c52cb80b0"
 dependencies = [
  "base64 0.12.3",
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "flate2",
  "futures 0.3.5",
  "httparse",
- "log 0.4.8",
+ "log 0.4.11",
  "rand 0.7.3",
  "sha-1",
 ]
@@ -4401,15 +4311,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stream-cipher"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
-dependencies = [
- "generic-array 0.12.3",
-]
 
 [[package]]
 name = "stream-cipher"
@@ -4537,7 +4438,7 @@ name = "tc_cli_client"
 version = "0.2.0"
 source = "git+https://github.com/artemii235/testcontainers-rs.git#65e738093488f1b37185af0f1d3cf0ffd23e840d"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4551,7 +4452,7 @@ source = "git+https://github.com/artemii235/testcontainers-rs.git#65e738093488f1
 dependencies = [
  "hex 0.3.2",
  "hmac 0.7.1",
- "log 0.4.8",
+ "log 0.4.11",
  "rand 0.7.3",
  "sha2 0.8.2",
  "tc_core",
@@ -4563,7 +4464,7 @@ version = "0.3.0"
 source = "git+https://github.com/artemii235/testcontainers-rs.git#65e738093488f1b37185af0f1d3cf0ffd23e840d"
 dependencies = [
  "debug_stub_derive",
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -4571,7 +4472,7 @@ name = "tc_dynamodb_local"
 version = "0.2.0"
 source = "git+https://github.com/artemii235/testcontainers-rs.git#65e738093488f1b37185af0f1d3cf0ffd23e840d"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "tc_core",
 ]
 
@@ -4596,7 +4497,7 @@ name = "tc_parity_parity"
 version = "0.5.0"
 source = "git+https://github.com/artemii235/testcontainers-rs.git#65e738093488f1b37185af0f1d3cf0ffd23e840d"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "tc_core",
 ]
 
@@ -4605,7 +4506,7 @@ name = "tc_postgres"
 version = "0.2.0"
 source = "git+https://github.com/artemii235/testcontainers-rs.git#65e738093488f1b37185af0f1d3cf0ffd23e840d"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "tc_core",
 ]
 
@@ -4778,7 +4679,7 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
@@ -4821,7 +4722,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
  "iovec",
- "log 0.4.8",
+ "log 0.4.11",
  "mio",
  "scoped-tls 0.1.2",
  "tokio 0.1.22",
@@ -4870,7 +4771,7 @@ checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -4882,7 +4783,7 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "mio",
  "num_cpus",
  "parking_lot 0.9.0",
@@ -4939,7 +4840,7 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "num_cpus",
  "slab 0.4.2",
  "tokio-executor",
@@ -4975,7 +4876,7 @@ checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.29",
- "log 0.4.8",
+ "log 0.4.11",
  "mio",
  "tokio-codec",
  "tokio-io",
@@ -4992,7 +4893,7 @@ dependencies = [
  "futures 0.1.29",
  "iovec",
  "libc",
- "log 0.4.8",
+ "log 0.4.11",
  "mio",
  "mio-uds",
  "tokio-codec",
@@ -5006,10 +4907,10 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "log 0.4.8",
+ "log 0.4.11",
  "pin-project-lite",
  "tokio 0.2.22",
 ]
@@ -5025,17 +4926,6 @@ name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
-
-[[package]]
-name = "twofish"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
-dependencies = [
- "block-cipher-trait",
- "byteorder",
- "opaque-debug",
-]
 
 [[package]]
 name = "typenum"
@@ -5129,8 +5019,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669d776983b692a906c881fcd0cfb34271a48e197e4d6cb8df32b05bfc3d3fa5"
 dependencies = [
- "bytes 0.5.5",
+ "bytes 0.5.6",
  "futures_codec",
+]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a98e44fc6af1e18c3a06666d829b4fd8d2714fb2dbffe8ab99d5dc7ea6baa628"
+dependencies = [
+ "futures-io",
+ "futures-util",
 ]
 
 [[package]]
@@ -5220,7 +5120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
  "futures 0.1.29",
- "log 0.4.8",
+ "log 0.4.11",
  "try-lock",
 ]
 
@@ -5230,7 +5130,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
  "try-lock",
 ]
 
@@ -5260,7 +5160,7 @@ checksum = "ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.8",
+ "log 0.4.11",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "syn 1.0.33",
@@ -5370,7 +5270,7 @@ dependencies = [
  "ethereum-types",
  "futures 0.1.29",
  "jsonrpc-core",
- "log 0.4.8",
+ "log 0.4.11",
  "parking_lot 0.7.1",
  "rustc-hex 1.0.0",
  "serde",
@@ -5515,7 +5415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd37e58a1256a0b328ce9c67d8b62ecdd02f4803ba443df478835cb1a41a637c"
 dependencies = [
  "futures 0.3.5",
- "log 0.4.8",
+ "log 0.4.11",
  "nohash-hasher",
  "parking_lot 0.10.2",
  "rand 0.7.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,7 +2800,6 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_bytes 0.11.5",
- "serde_derive",
  "sha2 0.9.0",
  "tokio 0.2.22",
  "void",

--- a/mm2src/gossipsub/src/behaviour.rs
+++ b/mm2src/gossipsub/src/behaviour.rs
@@ -65,6 +65,9 @@ pub struct Gossipsub {
     /// Relayers to which we forward the messages
     relayers_mesh: HashSet<PeerId>,
 
+    /// Peers included our node to their relayers mesh
+    included_to_relayers_mesh: HashSet<PeerId>,
+
     /// Overlay network of connected peers - Maps topics to connected gossipsub peers.
     mesh: HashMap<TopicHash, Vec<PeerId>>,
 
@@ -119,6 +122,7 @@ impl Gossipsub {
             peer_connections: HashMap::new(),
             connected_relayers: HashSet::new(),
             relayers_mesh: HashSet::new(),
+            included_to_relayers_mesh: HashSet::new(),
         }
     }
 
@@ -524,10 +528,32 @@ impl Gossipsub {
             info!("IAmRelayer: Adding peer: {:?} to the relayers list", peer_id);
             self.connected_relayers.insert(peer_id.clone());
             if self.relayers_mesh.len() < self.config.mesh_n_low {
-                self.relayers_mesh.insert(peer_id.clone());
+                self.add_peers_to_relayers_mesh(vec![peer_id.clone()]);
             }
         }
         debug!("Completed IAmRelayer handling for peer: {:?}", peer_id);
+    }
+
+    /// Handles IncludedToRelayersMesh message
+    fn handle_included_to_relayers_mesh(&mut self, peer_id: &PeerId, is_included: bool) {
+        if self.is_relay() {
+            debug!(
+                "Handling IncludedToRelayersMesh message for peer: {:?}, is_included: {}",
+                peer_id, is_included
+            );
+            if is_included {
+                debug!("Adding peer {:?} to included_to_relayers_mesh", peer_id);
+                self.included_to_relayers_mesh.insert(peer_id.clone());
+            } else {
+                debug!("Removing peer {:?} from included_to_relayers_mesh", peer_id);
+                self.included_to_relayers_mesh.remove(peer_id);
+            }
+        } else {
+            debug!(
+                "Ignoring IncludedToRelayersMesh message for peer: {:?}, is_included: {}",
+                peer_id, is_included
+            );
+        }
     }
 
     /// Handles a newly received GossipsubMessage.
@@ -854,11 +880,11 @@ impl Gossipsub {
         let mut recipient_peers = HashSet::new();
 
         if self.config.i_am_relay {
-            // relayer simply forwards the message to topic peers
+            // relayer simply forwards the message to topic peers that included the relayer to their relayers mesh
             for topic in &message.topics {
                 if let Some(topic_peers) = self.topic_peers.get(&topic) {
                     for peer_id in topic_peers {
-                        if peer_id != source {
+                        if peer_id != source && self.included_to_relayers_mesh.contains(peer_id) {
                             recipient_peers.insert(peer_id.clone());
                         }
                     }
@@ -1019,18 +1045,65 @@ impl Gossipsub {
 
     pub fn get_all_peer_topics(&self) -> &HashMap<PeerId, Vec<TopicHash>> { &self.peer_topics }
 
+    /// Adds peers to relayers mesh and notifies them they are added
+    fn add_peers_to_relayers_mesh(&mut self, peers: Vec<PeerId>) {
+        for peer in &peers {
+            self.events.push_back(NetworkBehaviourAction::NotifyHandler {
+                peer_id: peer.clone(),
+                handler: NotifyHandler::All,
+                event: Arc::new(GossipsubRpc {
+                    subscriptions: Vec::new(),
+                    messages: Vec::new(),
+                    control_msgs: vec![GossipsubControlAction::IncludedToRelayersMesh(true)],
+                }),
+            });
+        }
+        self.relayers_mesh.extend(peers);
+    }
+
+    /// Cleans up relayers mesh so it contains mesh_n peers
+    fn clean_up_relayers_mesh(&mut self) {
+        let mesh_n = self.config.mesh_n;
+        let mut removed = Vec::with_capacity(self.relayers_mesh.len() - mesh_n);
+        self.relayers_mesh = self
+            .relayers_mesh
+            .drain()
+            .enumerate()
+            .filter_map(|(i, peer)| {
+                if i < mesh_n {
+                    Some(peer)
+                } else {
+                    removed.push(peer);
+                    None
+                }
+            })
+            .collect();
+
+        for peer in removed {
+            self.events.push_back(NetworkBehaviourAction::NotifyHandler {
+                peer_id: peer,
+                handler: NotifyHandler::All,
+                event: Arc::new(GossipsubRpc {
+                    subscriptions: Vec::new(),
+                    messages: Vec::new(),
+                    control_msgs: vec![GossipsubControlAction::IncludedToRelayersMesh(false)],
+                }),
+            });
+        }
+    }
+
     fn maintain_relayers_mesh(&mut self) {
         if self.relayers_mesh.len() < self.config.mesh_n_low {
             debug!(
                 "HEARTBEAT: relayers low. Contains: {:?} needs: {:?}",
                 self.relayers_mesh.len(),
-                self.config.mesh_n_low,
+                self.config.mesh_n,
             );
             let required = self.config.mesh_n - self.relayers_mesh.len();
             // get `n` relays that are not in the `relayers_mesh`
             let to_add =
                 Self::get_random_relays(&self.connected_relayers, required, |p| !self.relayers_mesh.contains(p));
-            self.relayers_mesh.extend(to_add);
+            self.add_peers_to_relayers_mesh(to_add);
         }
 
         if self.relayers_mesh.len() > self.config.mesh_n_high {
@@ -1039,14 +1112,7 @@ impl Gossipsub {
                 self.relayers_mesh.len(),
                 self.config.mesh_n,
             );
-            let mesh_n = self.config.mesh_n;
-            self.relayers_mesh = self
-                .relayers_mesh
-                .drain()
-                .enumerate()
-                .filter(|(i, _)| i < &mesh_n)
-                .map(|(_, relay)| relay)
-                .collect();
+            self.clean_up_relayers_mesh();
         }
     }
 
@@ -1199,6 +1265,9 @@ impl NetworkBehaviour for Gossipsub {
                 GossipsubControlAction::Graft { topic_hash } => graft_msgs.push(topic_hash),
                 GossipsubControlAction::Prune { topic_hash } => prune_msgs.push(topic_hash),
                 GossipsubControlAction::IAmRelay(is_relay) => self.handle_i_am_relay(&propagation_source, is_relay),
+                GossipsubControlAction::IncludedToRelayersMesh(is_included) => {
+                    self.handle_included_to_relayers_mesh(&propagation_source, is_included)
+                },
             }
         }
         if !ihave_msgs.is_empty() {

--- a/mm2src/gossipsub/src/behaviour.rs
+++ b/mm2src/gossipsub/src/behaviour.rs
@@ -31,7 +31,6 @@ use log::{debug, error, info, trace, warn};
 use lru::LruCache;
 use rand;
 use rand::{seq::SliceRandom, thread_rng};
-use std::time::Duration;
 use std::{collections::{HashMap, HashSet, VecDeque},
           iter,
           sync::Arc,
@@ -86,15 +85,11 @@ pub struct Gossipsub {
     heartbeat: Interval,
 
     peer_connections: HashMap<PeerId, Vec<ConnectedPoint>>,
-
-    keep_connection_to: Vec<Multiaddr>,
-
-    dial_attempts: HashMap<Multiaddr, Instant>,
 }
 
 impl Gossipsub {
     /// Creates a `Gossipsub` struct given a set of parameters specified by `gs_config`.
-    pub fn new(local_peer_id: PeerId, gs_config: GossipsubConfig, keep_connection_to: Vec<Multiaddr>) -> Self {
+    pub fn new(local_peer_id: PeerId, gs_config: GossipsubConfig) -> Self {
         let local_peer_id = if gs_config.no_source_id {
             PeerId::from_bytes(crate::config::IDENTITY_SOURCE.to_vec()).expect("Valid peer id")
         } else {
@@ -122,8 +117,6 @@ impl Gossipsub {
                 gs_config.heartbeat_interval,
             ),
             peer_connections: HashMap::new(),
-            keep_connection_to,
-            dial_attempts: HashMap::new(),
             connected_relayers: HashSet::new(),
             relayers_mesh: HashSet::new(),
         }
@@ -768,8 +761,6 @@ impl Gossipsub {
         self.maintain_relayers_mesh();
         // shift the memcache
         self.mcache.shift();
-
-        self.keep_connections();
         debug!("Completed Heartbeat");
     }
 
@@ -1028,43 +1019,6 @@ impl Gossipsub {
 
     pub fn get_all_peer_topics(&self) -> &HashMap<PeerId, Vec<TopicHash>> { &self.peer_topics }
 
-    pub fn is_connected_to_addr(&self, addr: &Multiaddr) -> bool {
-        for points in self.peer_connections.values() {
-            for point in points {
-                match point {
-                    ConnectedPoint::Dialer { address } => {
-                        if address == addr {
-                            return true;
-                        }
-                    },
-                    ConnectedPoint::Listener { send_back_addr, .. } => {
-                        if send_back_addr == addr {
-                            return true;
-                        }
-                    },
-                }
-            }
-        }
-
-        false
-    }
-
-    fn keep_connections(&mut self) {
-        for addr in &self.keep_connection_to {
-            if !self.is_connected_to_addr(addr) {
-                let now = Instant::now();
-                if let Some(last_dial) = self.dial_attempts.get(addr) {
-                    if *last_dial > now - Duration::from_secs(30) {
-                        continue;
-                    }
-                }
-                self.events
-                    .push_back(NetworkBehaviourAction::DialAddress { address: addr.clone() });
-                self.dial_attempts.insert(addr.clone(), now);
-            }
-        }
-    }
-
     fn maintain_relayers_mesh(&mut self) {
         if self.relayers_mesh.len() < self.config.mesh_n_low {
             debug!(
@@ -1095,6 +1049,8 @@ impl Gossipsub {
                 .collect();
         }
     }
+
+    pub fn is_relay(&self) -> bool { self.config.i_am_relay }
 }
 
 impl NetworkBehaviour for Gossipsub {

--- a/mm2src/gossipsub/src/behaviour.rs
+++ b/mm2src/gossipsub/src/behaviour.rs
@@ -1083,7 +1083,7 @@ impl Gossipsub {
             debug!(
                 "HEARTBEAT: relayers high. Contains: {:?} needs: {:?}",
                 self.relayers_mesh.len(),
-                self.config.mesh_n_high,
+                self.config.mesh_n,
             );
             let mesh_n = self.config.mesh_n;
             self.relayers_mesh = self

--- a/mm2src/gossipsub/src/behaviour.rs
+++ b/mm2src/gossipsub/src/behaviour.rs
@@ -1051,6 +1051,8 @@ impl Gossipsub {
     }
 
     pub fn is_relay(&self) -> bool { self.config.i_am_relay }
+
+    pub fn connected_relayers(&self) -> Vec<PeerId> { self.connected_relayers.iter().cloned().collect() }
 }
 
 impl NetworkBehaviour for Gossipsub {

--- a/mm2src/gossipsub/src/behaviour.rs
+++ b/mm2src/gossipsub/src/behaviour.rs
@@ -1219,6 +1219,7 @@ impl NetworkBehaviour for Gossipsub {
 
         self.relayers_mesh.remove(id);
         self.connected_relayers.remove(id);
+        self.included_to_relayers_mesh.remove(id);
         // remove peer from peer_topics
         let was_in = self.peer_topics.remove(id);
         debug_assert!(was_in.is_some());

--- a/mm2src/gossipsub/src/behaviour.rs
+++ b/mm2src/gossipsub/src/behaviour.rs
@@ -1025,7 +1025,7 @@ impl Gossipsub {
         }
     }
 
-    pub fn get_mesh_relays(&self) -> Vec<PeerId> { self.relayers_mesh.iter().cloned().collect() }
+    pub fn get_relayers_mesh(&self) -> Vec<PeerId> { self.relayers_mesh.iter().cloned().collect() }
 
     pub fn get_mesh_peers(&self, topic: &TopicHash) -> Vec<PeerId> {
         self.mesh.get(&topic).cloned().unwrap_or_else(|| vec![])
@@ -1045,6 +1045,8 @@ impl Gossipsub {
 
     pub fn get_all_peer_topics(&self) -> &HashMap<PeerId, Vec<TopicHash>> { &self.peer_topics }
 
+    pub fn get_config(&self) -> &GossipsubConfig { &self.config }
+
     /// Adds peers to relayers mesh and notifies them they are added
     fn add_peers_to_relayers_mesh(&mut self, peers: Vec<PeerId>) {
         for peer in &peers {
@@ -1061,7 +1063,7 @@ impl Gossipsub {
         self.relayers_mesh.extend(peers);
     }
 
-    /// Cleans up relayers mesh so it contains mesh_n peers
+    /// Cleans up relayers mesh so it remains mesh_n peers
     fn clean_up_relayers_mesh(&mut self) {
         let mesh_n = self.config.mesh_n;
         let mut removed = Vec::with_capacity(self.relayers_mesh.len() - mesh_n);

--- a/mm2src/gossipsub/src/behaviour/tests.rs
+++ b/mm2src/gossipsub/src/behaviour/tests.rs
@@ -36,7 +36,7 @@ mod tests {
         // generate a default GossipsubConfig
         let gs_config = GossipsubConfig::default();
         // create a gossipsub struct
-        let mut gs: Gossipsub = Gossipsub::new(PeerId::random(), gs_config, vec![]);
+        let mut gs: Gossipsub = Gossipsub::new(PeerId::random(), gs_config);
 
         let mut topic_hashes = vec![];
 
@@ -523,7 +523,7 @@ mod tests {
         // generate a default GossipsubConfig
         let gs_config = GossipsubConfig::default();
         // create a gossipsub struct
-        let mut gs: Gossipsub = Gossipsub::new(PeerId::random(), gs_config, vec![]);
+        let mut gs: Gossipsub = Gossipsub::new(PeerId::random(), gs_config);
 
         // create a topic and fill it with some peers
         let topic_hash = Topic::new("Test".into()).no_hash().clone();

--- a/mm2src/gossipsub/src/handler.rs
+++ b/mm2src/gossipsub/src/handler.rs
@@ -36,7 +36,7 @@ use std::{borrow::Cow,
 /// Protocol Handler that manages a single long-lived substream with a peer.
 pub struct GossipsubHandler {
     /// Upgrade configuration for the gossipsub protocol.
-    listen_protocol: SubstreamProtocol<ProtocolConfig>,
+    listen_protocol: SubstreamProtocol<ProtocolConfig, ()>,
 
     /// The single long-lived outbound substream.
     outbound_substream: Option<OutboundSubstreamState>,
@@ -46,6 +46,10 @@ pub struct GossipsubHandler {
 
     /// Queue of values that we want to send to the remote.
     send_queue: SmallVec<[GossipsubRpc; 16]>,
+
+    /// Flag indicating that an outbound substream is being established to prevent duplicate
+    /// requests.
+    outbound_substream_establishing: bool,
 
     /// Flag determining whether to maintain the connection to the peer.
     keep_alive: KeepAlive,
@@ -81,11 +85,12 @@ impl GossipsubHandler {
     /// Builds a new `GossipsubHandler`.
     pub fn new(protocol_id: impl Into<Cow<'static, [u8]>>, max_transmit_size: usize) -> Self {
         GossipsubHandler {
-            listen_protocol: SubstreamProtocol::new(ProtocolConfig::new(protocol_id, max_transmit_size)),
+            listen_protocol: SubstreamProtocol::new(ProtocolConfig::new(protocol_id, max_transmit_size), ()),
             inbound_substream: None,
             outbound_substream: None,
             send_queue: SmallVec::new(),
             keep_alive: KeepAlive::Yes,
+            outbound_substream_establishing: false,
         }
     }
 }
@@ -93,11 +98,12 @@ impl GossipsubHandler {
 impl Default for GossipsubHandler {
     fn default() -> Self {
         GossipsubHandler {
-            listen_protocol: SubstreamProtocol::new(ProtocolConfig::default()),
+            listen_protocol: SubstreamProtocol::new(ProtocolConfig::default(), ()),
             inbound_substream: None,
             outbound_substream: None,
             send_queue: SmallVec::new(),
             keep_alive: KeepAlive::Yes,
+            outbound_substream_establishing: false,
         }
     }
 }
@@ -109,12 +115,16 @@ impl ProtocolsHandler for GossipsubHandler {
     type InboundProtocol = ProtocolConfig;
     type OutboundProtocol = ProtocolConfig;
     type OutboundOpenInfo = GossipsubRpc;
+    type InboundOpenInfo = ();
 
-    fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol> { self.listen_protocol.clone() }
+    fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
+        self.listen_protocol.clone()
+    }
 
     fn inject_fully_negotiated_inbound(
         &mut self,
         substream: <Self::InboundProtocol as InboundUpgrade<NegotiatedSubstream>>::Output,
+        _info: Self::InboundOpenInfo,
     ) {
         // new inbound substream. Replace the current one, if it exists.
         trace!("New inbound substream request");
@@ -126,6 +136,7 @@ impl ProtocolsHandler for GossipsubHandler {
         substream: <Self::OutboundProtocol as OutboundUpgrade<NegotiatedSubstream>>::Output,
         message: Self::OutboundOpenInfo,
     ) {
+        self.outbound_substream_establishing = false;
         // Should never establish a new outbound substream if one already exists.
         // If this happens, an outbound message is not sent.
         if self.outbound_substream.is_some() {
@@ -144,6 +155,7 @@ impl ProtocolsHandler for GossipsubHandler {
         _: Self::OutboundOpenInfo,
         _: ProtocolsHandlerUpgrErr<<Self::OutboundProtocol as OutboundUpgrade<NegotiatedSubstream>>::Error>,
     ) {
+        self.outbound_substream_establishing = false;
         // Ignore upgrade errors for now.
         // If a peer doesn't support this protocol, this will just ignore them, but not disconnect
         // them.
@@ -157,12 +169,12 @@ impl ProtocolsHandler for GossipsubHandler {
         cx: &mut Context,
     ) -> Poll<ProtocolsHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::OutEvent, Self::Error>> {
         // determine if we need to create the stream
-        if !self.send_queue.is_empty() && self.outbound_substream.is_none() {
+        if !self.send_queue.is_empty() && self.outbound_substream.is_none() && !self.outbound_substream_establishing {
             let message = self.send_queue.remove(0);
             self.send_queue.shrink_to_fit();
+            self.outbound_substream_establishing = true;
             return Poll::Ready(ProtocolsHandlerEvent::OutboundSubstreamRequest {
-                protocol: self.listen_protocol.clone(),
-                info: message,
+                protocol: self.listen_protocol.clone().map_info(|()| message),
             });
         }
 

--- a/mm2src/gossipsub/src/protocol.rs
+++ b/mm2src/gossipsub/src/protocol.rs
@@ -139,6 +139,7 @@ impl Encoder for GossipsubCodec {
             graft: Vec::new(),
             prune: Vec::new(),
             iamrelay: None,
+            included_to_relayers_mesh: None,
         };
 
         let empty_control_msg = item.control_msgs.is_empty();
@@ -176,6 +177,9 @@ impl Encoder for GossipsubCodec {
                 },
                 GossipsubControlAction::IAmRelay(is_relay) => {
                     control.iamrelay = Some(is_relay);
+                },
+                GossipsubControlAction::IncludedToRelayersMesh(is_included) => {
+                    control.included_to_relayers_mesh = Some(is_included);
                 },
             }
         }
@@ -273,6 +277,12 @@ impl Decoder for GossipsubCodec {
             if let Some(is_relay) = rpc_control.iamrelay {
                 control_msgs.extend(iter::once(GossipsubControlAction::IAmRelay(is_relay)));
             }
+
+            if let Some(is_included_to_relayers_mesh) = rpc_control.included_to_relayers_mesh {
+                control_msgs.extend(iter::once(GossipsubControlAction::IncludedToRelayersMesh(
+                    is_included_to_relayers_mesh,
+                )));
+            }
         }
 
         Ok(Some(GossipsubRpc {
@@ -368,4 +378,6 @@ pub enum GossipsubControlAction {
         topic_hash: TopicHash,
     },
     IAmRelay(bool),
+    /// Whether the node included or excluded from other node relayers mesh
+    IncludedToRelayersMesh(bool),
 }

--- a/mm2src/gossipsub/src/rpc.proto
+++ b/mm2src/gossipsub/src/rpc.proto
@@ -27,6 +27,7 @@ message ControlMessage {
 	repeated ControlGraft graft = 3;
 	repeated ControlPrune prune = 4;
 	optional bool iamrelay = 5;
+	optional bool included_to_relayers_mesh = 6;
 }
 
 message ControlIHave {
@@ -42,9 +43,13 @@ message ControlGraft {
 	optional string topic_id = 1;
 }
 
+message ControlGraftRelay {}
+
 message ControlPrune {
 	optional string topic_id = 1;
 }
+
+message ControlPruneRelay {}
 
 // topicID = hash(topicDescriptor); (not the topic.name)
 message TopicDescriptor {

--- a/mm2src/gossipsub/tests/smoke.rs
+++ b/mm2src/gossipsub/tests/smoke.rs
@@ -139,7 +139,7 @@ fn build_node() -> (Multiaddr, Swarm<Gossipsub>) {
         .boxed();
 
     let peer_id = public_key.clone().into_peer_id();
-    let behaviour = Gossipsub::new(peer_id.clone(), GossipsubConfig::default(), vec![]);
+    let behaviour = Gossipsub::new(peer_id.clone(), GossipsubConfig::default());
     let mut swarm = Swarm::new(transport, behaviour, peer_id);
 
     let port = 1 + random::<u64>();

--- a/mm2src/lp_network.rs
+++ b/mm2src/lp_network.rs
@@ -29,9 +29,11 @@ use futures::compat::Future01CompatExt;
 use futures::future::FutureExt;
 use futures::{SinkExt, StreamExt};
 use futures01::{future, Future};
-use mm2_libp2p::{atomicdex_behaviour::{AdexBehaviourCmd, AdexBehaviourEvent, AdexCmdTx, AdexEventRx, AdexResponse},
+use mm2_libp2p::{atomicdex_behaviour::{AdexBehaviourCmd, AdexBehaviourEvent, AdexCmdTx, AdexEventRx, AdexResponse,
+                                       AdexResponseChannel},
                  decode_signed, encode_and_sign, GossipsubMessage, MessageId, PeerId, PublicKey, TOPIC_SEPARATOR};
 #[cfg(test)] use mocktopus::macros::*;
+use serde::de;
 use serde_bencode::de::from_bytes as bdecode;
 use serde_bencode::ser::to_bytes as bencode;
 use serde_json::{self as json, Value as Json};
@@ -41,8 +43,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::mm2::{lp_ordermatch, lp_swap};
-use mm2_libp2p::atomicdex_behaviour::AdexResponseChannel;
-use serde::de;
 
 #[derive(Eq, Debug, Deserialize, PartialEq, Serialize)]
 pub enum P2PRequest {

--- a/mm2src/lp_network.rs
+++ b/mm2src/lp_network.rs
@@ -75,7 +75,13 @@ pub async fn p2p_event_process_loop(ctx: MmArc, mut rx: AdexEventRx, i_am_relaye
     while !ctx.is_stopping() {
         match rx.next().await {
             Some(AdexBehaviourEvent::Message(peer_id, message_id, message)) => {
-                process_p2p_message(ctx.clone(), peer_id, message_id, message, i_am_relayer).await
+                spawn(process_p2p_message(
+                    ctx.clone(),
+                    peer_id,
+                    message_id,
+                    message,
+                    i_am_relayer,
+                ));
             },
             Some(AdexBehaviourEvent::PeerRequest {
                 peer_id,

--- a/mm2src/lp_ordermatch.rs
+++ b/mm2src/lp_ordermatch.rs
@@ -87,36 +87,51 @@ impl From<(new_protocol::MakerOrderCreated, Vec<u8>, String, String)> for PriceP
 }
 
 async fn process_order_keep_alive(
-    ctx: &MmArc,
+    ctx: MmArc,
     propagated_from_peer: String,
-    from_pubkey: &str,
-    keep_alive: &new_protocol::MakerOrderKeepAlive,
+    from_pubkey: String,
+    keep_alive: new_protocol::MakerOrderKeepAlive,
 ) -> bool {
     let ordermatch_ctx = OrdermatchContext::from_ctx(&ctx).unwrap();
-    let mut orderbook = ordermatch_ctx.orderbook.lock().await;
     let uuid = keep_alive.uuid.into();
-    if let Some(order) = orderbook.find_order_by_uuid_and_pubkey(&uuid, from_pubkey) {
+    if let Some(order) = ordermatch_ctx
+        .orderbook
+        .lock()
+        .await
+        .find_order_by_uuid_and_pubkey(&uuid, &from_pubkey)
+    {
         order.timestamp = keep_alive.timestamp;
         return true;
     }
 
     if let Some(mut order) = ordermatch_ctx.inactive_orders.lock().await.remove(&uuid) {
         order.timestamp = keep_alive.timestamp;
-        orderbook.insert_or_update_order(uuid, order);
+        ordermatch_ctx
+            .orderbook
+            .lock()
+            .await
+            .insert_or_update_order(uuid, order);
         return true;
     }
 
     log!("Couldn't find an order " [uuid] ", try request it from peers");
-    match request_order(ctx.clone(), uuid, propagated_from_peer, from_pubkey).await {
-        Ok(Some(order)) => {
-            orderbook.insert_or_update_order(uuid, order);
-            return true;
-        },
-        Ok(None) => log!("None of peers responded to the GetOrder request"),
-        Err(e) => log!("Error on GetOrder request: "(e)),
-    }
-
-    log!("Skip the order "[uuid]);
+    // TODO find a way to try to propagate a keep alive message to another peers in case we receive the requested order fast enough
+    // the problem of awaiting the request_order right in this fn is we're running on global messages processing loop
+    // that can be stuck entirely during single order request if there's any problem with requesting specific peer
+    spawn(async move {
+        match request_order(ctx, uuid, propagated_from_peer, &from_pubkey).await {
+            Ok(Some(order)) => {
+                ordermatch_ctx
+                    .orderbook
+                    .lock()
+                    .await
+                    .insert_or_update_order(uuid, order);
+            },
+            Ok(None) => log!("None of peers responded to the GetOrder request"),
+            Err(e) => log!("Error on GetOrder request: "(e)),
+        };
+        log!("Skip the order "[uuid]);
+    });
     false
 }
 
@@ -297,7 +312,7 @@ pub async fn process_msg(ctx: MmArc, _initial_topic: &str, from_peer: String, ms
                 true
             },
             new_protocol::OrdermatchMessage::MakerOrderKeepAlive(keep_alive) => {
-                process_order_keep_alive(&ctx, from_peer, &pubkey.to_hex(), &keep_alive).await
+                process_order_keep_alive(ctx, from_peer, pubkey.to_hex(), keep_alive).await
             },
             new_protocol::OrdermatchMessage::TakerRequest(taker_request) => {
                 let msg = TakerRequest::from_new_proto_and_pubkey(taker_request, pubkey.unprefixed().into());

--- a/mm2src/lp_ordermatch.rs
+++ b/mm2src/lp_ordermatch.rs
@@ -114,7 +114,7 @@ async fn process_order_keep_alive(
         Err(e) => log!("Error on GetOrder request: "(e)),
     }
 
-    log!("Skip the order " [uuid]);
+    log!("Skip the order "[uuid]);
     false
 }
 

--- a/mm2src/mm2_libp2p/Cargo.toml
+++ b/mm2src/mm2_libp2p/Cargo.toml
@@ -21,9 +21,8 @@ num-bigint = { version = "0.2", features = ["serde", "std"] }
 num-rational = { version = "0.2", features = ["serde", "bigint", "bigint-std"] }
 rand = { version = "0.7", features = ["std"] }
 rmp-serde = "0.14.3"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.5"
-serde_derive = "1.0"
 sha2 = "0.9.0"
 tokio = { version = "0.2.22", features = ["rt-threaded"] }
 void = "1.0"

--- a/mm2src/mm2_libp2p/Cargo.toml
+++ b/mm2src/mm2_libp2p/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.7.1"
 futures = { version = "0.3.1", package = "futures", features = ["compat", "async-await"] }
 hex = "0.4.2"
 lazy_static = "1.4.0"
-libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", default-features = false, features = ["dns", "mplex", "ping", "request-response", "secio", "tcp-tokio", "secp256k1", "websocket"] }
+libp2p = { git = "https://github.com/KomodoPlatform/rust-libp2p.git", default-features = false, features = ["dns", "mplex", "noise", "ping", "request-response", "tcp-tokio", "secp256k1", "websocket"] }
 libsecp256k1 = "0.3.5"
 log = "0.4.8"
 num-bigint = { version = "0.2", features = ["serde", "std"] }

--- a/mm2src/mm2_libp2p/src/adex_ping.rs
+++ b/mm2src/mm2_libp2p/src/adex_ping.rs
@@ -32,6 +32,7 @@ impl NetworkBehaviourEventProcess<PingEvent> for AdexPing {
     }
 }
 
+#[allow(clippy::new_without_default)]
 impl AdexPing {
     pub fn new() -> Self {
         AdexPing {

--- a/mm2src/mm2_libp2p/src/adex_ping.rs
+++ b/mm2src/mm2_libp2p/src/adex_ping.rs
@@ -1,0 +1,54 @@
+use libp2p::{ping::{Ping, PingConfig, PingEvent},
+             swarm::{DisconnectPeerHandler, NetworkBehaviourAction, NetworkBehaviourEventProcess, PollParameters},
+             NetworkBehaviour};
+use log::info;
+use std::{collections::VecDeque,
+          num::NonZeroU32,
+          task::{Context, Poll}};
+use void::Void;
+
+/// Wrapper around libp2p Ping behaviour that forcefully disconnects a peer using NetworkBehaviourAction::DisconnectPeer
+/// event.
+/// Libp2p has unclear ConnectionHandlers keep alive logic so in some cases even if Ping handlers emits Close event the
+/// connection is kept active which is undesirable.
+#[derive(NetworkBehaviour)]
+#[behaviour(out_event = "Void")]
+#[behaviour(poll_method = "poll_event")]
+pub struct AdexPing {
+    ping: Ping,
+    #[behaviour(ignore)]
+    events: VecDeque<NetworkBehaviourAction<Void, Void>>,
+}
+
+impl NetworkBehaviourEventProcess<PingEvent> for AdexPing {
+    fn inject_event(&mut self, event: PingEvent) {
+        if let Err(e) = event.result {
+            info!("Ping error {}. Disconnecting peer {}", e, event.peer);
+            self.events.push_back(NetworkBehaviourAction::DisconnectPeer {
+                peer_id: event.peer,
+                handler: DisconnectPeerHandler::All,
+            });
+        }
+    }
+}
+
+impl AdexPing {
+    pub fn new() -> Self {
+        AdexPing {
+            ping: Ping::new(PingConfig::new().with_max_failures(unsafe { NonZeroU32::new_unchecked(2) })),
+            events: VecDeque::new(),
+        }
+    }
+
+    fn poll_event(
+        &mut self,
+        _cx: &mut Context,
+        _params: &mut impl PollParameters,
+    ) -> Poll<NetworkBehaviourAction<Void, Void>> {
+        if let Some(event) = self.events.pop_front() {
+            return Poll::Ready(event);
+        }
+
+        Poll::Pending
+    }
+}

--- a/mm2src/mm2_libp2p/src/adex_ping.rs
+++ b/mm2src/mm2_libp2p/src/adex_ping.rs
@@ -9,7 +9,7 @@ use void::Void;
 
 /// Wrapper around libp2p Ping behaviour that forcefully disconnects a peer using NetworkBehaviourAction::DisconnectPeer
 /// event.
-/// Libp2p has unclear ConnectionHandlers keep alive logic so in some cases even if Ping handlers emits Close event the
+/// Libp2p has unclear ConnectionHandlers keep alive logic so in some cases even if Ping handler emits Close event the
 /// connection is kept active which is undesirable.
 #[derive(NetworkBehaviour)]
 #[behaviour(out_event = "Void")]

--- a/mm2src/mm2_libp2p/src/atomicdex_behaviour.rs
+++ b/mm2src/mm2_libp2p/src/atomicdex_behaviour.rs
@@ -39,6 +39,7 @@ struct SwarmRuntime(Runtime);
 pub const PEERS_TOPIC: &str = "PEERS";
 const CONNECTED_RELAYS_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 const ANNOUNCE_INTERVAL: Duration = Duration::from_secs(600);
+const ANNOUNCE_INITIAL_DELAY: Duration = Duration::from_secs(60);
 
 impl libp2p::core::Executor for &SwarmRuntime {
     fn exec(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) { self.0.spawn(future); }
@@ -582,7 +583,7 @@ pub fn start_gossipsub(
         Instant::now() + CONNECTED_RELAYS_CHECK_INTERVAL,
         CONNECTED_RELAYS_CHECK_INTERVAL,
     );
-    let mut announce_interval = Interval::new_at(Instant::now() + ANNOUNCE_INTERVAL, ANNOUNCE_INTERVAL);
+    let mut announce_interval = Interval::new_at(Instant::now() + ANNOUNCE_INITIAL_DELAY, ANNOUNCE_INTERVAL);
     let polling_fut = poll_fn(move |cx: &mut Context| {
         loop {
             match swarm.cmd_rx.poll_next_unpin(cx) {

--- a/mm2src/mm2_libp2p/src/atomicdex_behaviour.rs
+++ b/mm2src/mm2_libp2p/src/atomicdex_behaviour.rs
@@ -488,7 +488,6 @@ pub fn start_gossipsub(
     my_privkey: &mut [u8],
     i_am_relay: bool,
 ) -> (UnboundedSender<AdexBehaviourCmd>, AdexEventRx, PeerId) {
-    // Create a random PeerId
     let privkey = identity::secp256k1::SecretKey::from_bytes(my_privkey).unwrap();
     let local_key = identity::Keypair::Secp256k1(privkey.into());
     let local_peer_id = PeerId::from(local_key.public());

--- a/mm2src/mm2_libp2p/src/atomicdex_behaviour.rs
+++ b/mm2src/mm2_libp2p/src/atomicdex_behaviour.rs
@@ -466,17 +466,11 @@ fn announce_my_addresses(swarm: &mut AtomicDexSwarm) {
     let global_listeners: Vec<_> = Swarm::listeners(&swarm)
         .filter(|listener| {
             for protocol in listener.iter() {
-                if let Protocol::Ip4(ip) = &protocol {
-                    if ip.is_global() {
-                        return true;
-                    }
-                }
-
-                if let Protocol::Ip6(ip) = &protocol {
-                    if ip.is_global() {
-                        return true;
-                    }
-                }
+                match protocol {
+                    Protocol::Ip4(ip) => return ip.is_global(),
+                    Protocol::Ip6(ip) => return ip.is_global(),
+                    _ => (),
+                };
             }
             false
         })
@@ -551,7 +545,7 @@ pub fn start_gossipsub(
             .i_am_relay(i_am_relay)
             .mesh_n_low(mesh_n_low)
             .mesh_n(mesh_n)
-            .mesh_n(mesh_n_high)
+            .mesh_n_high(mesh_n_high)
             .manual_propagation()
             .max_transmit_size(1024 * 1024 - 100)
             .build();

--- a/mm2src/mm2_libp2p/src/atomicdex_behaviour.rs
+++ b/mm2src/mm2_libp2p/src/atomicdex_behaviour.rs
@@ -535,10 +535,15 @@ pub fn start_gossipsub(
             MessageId(s.finish().to_string())
         };
 
+        let (mesh_n_low, mesh_n, mesh_n_high) = if i_am_relay { (4, 6, 12) } else { (2, 3, 4) };
+
         // set custom gossipsub
         let gossipsub_config = GossipsubConfigBuilder::new()
             .message_id_fn(message_id_fn)
             .i_am_relay(i_am_relay)
+            .mesh_n_low(mesh_n_low)
+            .mesh_n(mesh_n)
+            .mesh_n(mesh_n_high)
             .manual_propagation()
             .max_transmit_size(1024 * 1024 - 100)
             .build();

--- a/mm2src/mm2_libp2p/src/lib.rs
+++ b/mm2src/mm2_libp2p/src/lib.rs
@@ -1,5 +1,8 @@
+#![feature(ip)]
+
 mod adex_ping;
 pub mod atomicdex_behaviour;
+mod peers_exchange;
 pub mod request_response;
 
 use secp256k1::{sign, verify, Message as SecpMessage, PublicKey as Secp256k1Pubkey, SecretKey, Signature};

--- a/mm2src/mm2_libp2p/src/lib.rs
+++ b/mm2src/mm2_libp2p/src/lib.rs
@@ -1,11 +1,10 @@
+mod adex_ping;
 pub mod atomicdex_behaviour;
 pub mod request_response;
 
 use secp256k1::{sign, verify, Message as SecpMessage, PublicKey as Secp256k1Pubkey, SecretKey, Signature};
-use serde::{de,
-            ser::{Serialize, Serializer}};
+use serde::{de, ser::Serializer, Deserialize, Serialize};
 use serde_bytes;
-use serde_derive::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 pub use atomicdex_behaviour::start_gossipsub;

--- a/mm2src/mm2_libp2p/src/peers_exchange.rs
+++ b/mm2src/mm2_libp2p/src/peers_exchange.rs
@@ -168,7 +168,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<PeersExchangeRequest, Pee
     fn inject_event(&mut self, event: RequestResponseEvent<PeersExchangeRequest, PeersExchangeResponse>) {
         match event {
             RequestResponseEvent::Message { message, .. } => match message {
-                RequestResponseMessage::Request { request, channel } => match request {
+                RequestResponseMessage::Request { request, channel, .. } => match request {
                     PeersExchangeRequest::GetKnownPeers { num } => {
                         let response = PeersExchangeResponse::KnownPeers {
                             peers: self.get_random_known_peers(num),
@@ -193,7 +193,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<PeersExchangeRequest, Pee
                 );
                 self.forget_peer(&peer);
             },
-            RequestResponseEvent::InboundFailure { peer, error } => {
+            RequestResponseEvent::InboundFailure { peer, error, .. } => {
                 error!(
                     "Inbound failure {:?} while processing request from peer {}",
                     error, peer

--- a/mm2src/mm2_libp2p/src/peers_exchange.rs
+++ b/mm2src/mm2_libp2p/src/peers_exchange.rs
@@ -67,6 +67,7 @@ pub struct PeersExchange {
     maintain_peers_interval: Interval,
 }
 
+#[allow(clippy::new_without_default)]
 impl PeersExchange {
     pub fn new() -> Self {
         let codec = Codec::default();

--- a/mm2src/mm2_libp2p/src/peers_exchange.rs
+++ b/mm2src/mm2_libp2p/src/peers_exchange.rs
@@ -1,0 +1,138 @@
+use crate::request_response::{Codec, Protocol};
+use libp2p::swarm::NetworkBehaviour;
+use libp2p::{multiaddr::Multiaddr,
+             request_response::{ProtocolSupport, RequestResponse, RequestResponseConfig, RequestResponseEvent,
+                                RequestResponseMessage},
+             swarm::{NetworkBehaviourAction, NetworkBehaviourEventProcess},
+             NetworkBehaviour, PeerId};
+use log::error;
+use rand::{seq::SliceRandom, thread_rng};
+use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
+use std::{collections::{HashMap, VecDeque},
+          iter};
+
+type PeersExchangeCodec = Codec<PeersExchangeRequest, PeersExchangeResponse>;
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub struct PeerIdSerde(PeerId);
+
+impl From<PeerId> for PeerIdSerde {
+    fn from(peer_id: PeerId) -> PeerIdSerde { PeerIdSerde(peer_id) }
+}
+
+impl Serialize for PeerIdSerde {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(self.0.as_bytes())
+    }
+}
+
+impl<'de> Deserialize<'de> for PeerIdSerde {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
+        let peer_id = PeerId::from_bytes(bytes).map_err(|_| serde::de::Error::custom("PeerId::from_bytes error"))?;
+        Ok(PeerIdSerde(peer_id))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum PeersExchangeRequest {
+    GetKnownPeers { num: usize },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum PeersExchangeResponse {
+    KnownPeers {
+        peers: HashMap<PeerIdSerde, Vec<Multiaddr>>,
+    },
+}
+
+/// Behaviour that requests known peers list from other peers at random
+#[derive(NetworkBehaviour)]
+pub struct PeersExchange {
+    request_response: RequestResponse<PeersExchangeCodec>,
+    #[behaviour(ignore)]
+    known_peers: Vec<PeerId>,
+    #[behaviour(ignore)]
+    events: VecDeque<NetworkBehaviourAction<(), ()>>,
+}
+
+impl PeersExchange {
+    pub fn new() -> Self {
+        let codec = Codec::default();
+        let protocol = iter::once((Protocol::Version1, ProtocolSupport::Full));
+        let config = RequestResponseConfig::default();
+        let request_response = RequestResponse::new(codec, protocol, config);
+        PeersExchange {
+            request_response,
+            known_peers: Vec::new(),
+            events: VecDeque::new(),
+        }
+    }
+
+    fn get_random_known_peers(&mut self, num: usize) -> HashMap<PeerIdSerde, Vec<Multiaddr>> {
+        let mut result = HashMap::with_capacity(num);
+        let mut rng = thread_rng();
+        let peer_ids = self.known_peers.choose_multiple(&mut rng, num).cloned();
+        for peer_id in peer_ids {
+            let addresses = self.request_response.addresses_of_peer(&peer_id);
+            result.insert(peer_id.into(), addresses);
+        }
+        result
+    }
+
+    fn forget_peer(&mut self, peer: &PeerId) {
+        self.known_peers.retain(|known_peer| known_peer != peer);
+        for address in self.request_response.addresses_of_peer(&peer) {
+            self.request_response.remove_address(&peer, &address);
+        }
+    }
+
+    pub fn add_peer_addresses(&mut self, peer: &PeerId, addresses: Vec<Multiaddr>) {
+        if !self.known_peers.contains(&peer) && !addresses.is_empty() {
+            self.known_peers.push(peer.clone());
+        }
+        for address in addresses {
+            self.request_response.add_address(&peer, address);
+        }
+    }
+}
+
+impl NetworkBehaviourEventProcess<RequestResponseEvent<PeersExchangeRequest, PeersExchangeResponse>> for PeersExchange {
+    fn inject_event(&mut self, event: RequestResponseEvent<PeersExchangeRequest, PeersExchangeResponse>) {
+        match event {
+            RequestResponseEvent::Message { message, .. } => match message {
+                RequestResponseMessage::Request { request, channel } => match request {
+                    PeersExchangeRequest::GetKnownPeers { num } => {
+                        let response = PeersExchangeResponse::KnownPeers {
+                            peers: self.get_random_known_peers(num),
+                        };
+                        self.request_response.send_response(channel, response);
+                    },
+                },
+                RequestResponseMessage::Response { response, .. } => match response {
+                    PeersExchangeResponse::KnownPeers { peers } => peers.into_iter().for_each(|(peer, addresses)| {
+                        self.add_peer_addresses(&peer.0, addresses);
+                    }),
+                },
+            },
+            RequestResponseEvent::OutboundFailure {
+                peer,
+                request_id,
+                error,
+            } => {
+                error!(
+                    "Outbound failure {:?} while requesting {:?} to peer {}",
+                    error, request_id, peer
+                );
+                self.forget_peer(&peer);
+            },
+            RequestResponseEvent::InboundFailure { peer, error } => {
+                error!(
+                    "Inbound failure {:?} while processing request from peer {}",
+                    error, peer
+                );
+                self.forget_peer(&peer);
+            },
+        }
+    }
+}

--- a/mm2src/mm2_libp2p/src/request_response.rs
+++ b/mm2src/mm2_libp2p/src/request_response.rs
@@ -157,7 +157,7 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<PeerRequest, PeerResponse
         };
 
         match message {
-            RequestResponseMessage::Request { request, channel } => {
+            RequestResponseMessage::Request { request, channel, .. } => {
                 debug!("Received a request from {:?} peer", peer_id);
                 self.process_request(peer_id, request, channel)
             },

--- a/mm2src/mm2_tests.rs
+++ b/mm2src/mm2_tests.rs
@@ -1853,7 +1853,7 @@ fn test_order_should_not_be_displayed_when_node_is_down() {
     assert_eq!(asks.len(), 1, "Alice RICK/MORTY orderbook must have exactly 1 ask");
 
     unwrap!(block_on(mm_bob.stop()));
-    thread::sleep(Duration::from_secs(61));
+    thread::sleep(Duration::from_secs(65));
 
     let rc = unwrap!(block_on(mm_alice.rpc(json! ({
         "userpass": mm_alice.userpass,

--- a/mm2src/ordermatch_tests.rs
+++ b/mm2src/ordermatch_tests.rs
@@ -1696,10 +1696,10 @@ fn test_process_order_keep_alive_requested_from_peer() {
 
     // process_order_keep_alive() should return true because an order should be requested from a peer.
     assert!(block_on(process_order_keep_alive(
-        &ctx,
+        ctx,
         peer.clone(),
-        &pubkey,
-        &keep_alive
+        pubkey.clone(),
+        keep_alive
     )));
 
     let mut orderbook = block_on(ordermatch_ctx.orderbook.lock());
@@ -1707,7 +1707,7 @@ fn test_process_order_keep_alive_requested_from_peer() {
     let actual = orderbook.find_order_by_uuid_and_pubkey(&uuid, &pubkey).unwrap();
     let expected: PricePingRequest = (order, initial_order_message, pubkey, peer).into();
 
-    // the exepcted.timestamp may be greater than actual.timestamp because of two now_ms() calls
+    // the expected.timestamp may be greater than actual.timestamp because of two now_ms() calls
     actual.timestamp = expected.timestamp;
     assert_eq!(actual, &expected);
 }


### PR DESCRIPTION
Some aspects are omitted intentionally to be implemented later, e.g.:
1. It's worth to sign the announced addresses messages.
1. Might make sense to "forget" the known peer or at least reduce it's "score" in case we failed to connect to announced address.
1. Need to save discovered peers state to DB and use it on restart.
1. Implement more methods of initial nodes discovery/bootstrap. Maybe borrow some concepts from bitcoin (https://developer.bitcoin.org/devguide/p2p_network.html#peer-discovery), also notable: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md