### PR TITLE
Set explicit 10 seconds timeout for P2P requests in our behavior.

### DIFF
--- a/mm2src/lp_ordermatch.rs
+++ b/mm2src/lp_ordermatch.rs
@@ -235,9 +235,6 @@ async fn process_maker_order_updated(
 ///
 /// The function locks [`MmCtx::p2p_ctx`] and [`MmCtx::ordermatch_ctx`]
 async fn request_and_fill_orderbook(ctx: &MmArc, base: &str, rel: &str) -> Result<(), String> {
-    let ordermatch_ctx = OrdermatchContext::from_ctx(&ctx).unwrap();
-    let mut orderbook = ordermatch_ctx.orderbook.lock().await;
-
     let request = OrdermatchRequest::GetOrderbook {
         base: base.to_string(),
         rel: rel.to_string(),
@@ -248,6 +245,9 @@ async fn request_and_fill_orderbook(ctx: &MmArc, base: &str, rel: &str) -> Resul
         Some((GetOrderbookRes { pubkey_orders }, _peer_id)) => pubkey_orders,
         None => return Ok(()),
     };
+
+    let ordermatch_ctx = OrdermatchContext::from_ctx(&ctx).unwrap();
+    let mut orderbook = ordermatch_ctx.orderbook.lock().await;
 
     let alb_pair = alb_ordered_pair(base, rel);
     for (pubkey, GetOrderbookPubkeyItem { orders, .. }) in pubkey_orders {

--- a/mm2src/mm2_libp2p/src/atomicdex_behaviour/tests.rs
+++ b/mm2src/mm2_libp2p/src/atomicdex_behaviour/tests.rs
@@ -55,6 +55,7 @@ impl Node {
     async fn send_cmd(&mut self, cmd: AdexBehaviourCmd) { self.cmd_tx.send(cmd).await.unwrap(); }
 
     async fn wait_peers(&mut self, number: usize) {
+        let mut attempts = 0;
         loop {
             let (tx, rx) = oneshot::channel();
             self.cmd_tx
@@ -69,6 +70,10 @@ impl Node {
                     async_std::task::sleep(Duration::from_millis(500)).await;
                 },
                 Err(e) => panic!("{}", e),
+            }
+            attempts += 1;
+            if attempts >= 10 {
+                panic!("wait_peers {} attempts exceeded", attempts);
             }
         }
     }


### PR DESCRIPTION
Do not hold orderbook lock during GetOrderbook request.
#910 