### PR TITLE
Split maker and taker coin in stats DB to ticker and platform.

### DIFF
--- a/mm2src/database.rs
+++ b/mm2src/database.rs
@@ -65,11 +65,14 @@ fn migration_2(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> {
 
 fn migration_3() -> Vec<(&'static str, Vec<String>)> { vec![(stats_swaps::ADD_STARTED_AT_INDEX, vec![])] }
 
+fn migration_4() -> Vec<(&'static str, Vec<String>)> { stats_swaps::add_and_split_tickers() }
+
 fn statements_for_migration(ctx: &MmArc, current_migration: i64) -> Option<Vec<(&'static str, Vec<String>)>> {
     match current_migration {
         1 => Some(migration_1(ctx)),
         2 => Some(migration_2(ctx)),
         3 => Some(migration_3()),
+        4 => Some(migration_4()),
         _ => None,
     }
 }

--- a/mm2src/database/stats_swaps.rs
+++ b/mm2src/database/stats_swaps.rs
@@ -22,24 +22,40 @@ const CREATE_STATS_SWAPS_TABLE: &str = "CREATE TABLE IF NOT EXISTS stats_swaps (
 
 const INSERT_STATS_SWAP: &str = "INSERT INTO stats_swaps (
     maker_coin,
+    maker_coin_ticker,
+    maker_coin_platform,
     taker_coin,
-    uuid, 
-    started_at, 
-    finished_at, 
-    maker_amount, 
+    taker_coin_ticker,
+    taker_coin_platform,
+    uuid,
+    started_at,
+    finished_at,
+    maker_amount,
     taker_amount,
     is_success
-) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
 
 const ADD_SPLIT_TICKERS: &[&str] = &[
     "ALTER TABLE stats_swaps ADD COLUMN maker_coin_ticker VARCHAR(255) NOT NULL DEFAULT '';",
     "ALTER TABLE stats_swaps ADD COLUMN maker_coin_platform VARCHAR(255) NOT NULL DEFAULT '';",
     "ALTER TABLE stats_swaps ADD COLUMN taker_coin_ticker VARCHAR(255) NOT NULL DEFAULT '';",
     "ALTER TABLE stats_swaps ADD COLUMN taker_coin_platform VARCHAR(255) NOT NULL DEFAULT '';",
-    "UPDATE stats_swaps SET maker_coin_ticker = substr(maker_coin, 0, instr(maker_coin, '-'));",
-    "UPDATE stats_swaps SET maker_coin_platform = substr(maker_coin, instr(maker_coin, '-')+1);",
-    "UPDATE stats_swaps SET taker_coin_ticker = substr(taker_coin, 0, instr(taker_coin, '-'));",
-    "UPDATE stats_swaps SET taker_coin_platform = substr(taker_coin, instr(taker_coin, '-')+1);",
+    "UPDATE stats_swaps SET maker_coin_ticker = CASE instr(maker_coin, '-') \
+        WHEN 0 THEN maker_coin \
+        ELSE substr(maker_coin, 0, instr(maker_coin, '-')) \
+        END;",
+    "UPDATE stats_swaps SET maker_coin_platform = CASE instr(maker_coin, '-') \
+        WHEN 0 THEN '' \
+        ELSE substr(maker_coin, instr(maker_coin, '-') + 1) \
+        END;",
+    "UPDATE stats_swaps SET taker_coin_ticker = CASE instr(taker_coin, '-') \
+        WHEN 0 THEN taker_coin \
+        ELSE substr(taker_coin, 0, instr(taker_coin, '-')) \
+        END;",
+    "UPDATE stats_swaps SET taker_coin_platform = CASE instr(taker_coin, '-') \
+        WHEN 0 THEN '' \
+        ELSE substr(taker_coin, instr(taker_coin, '-') + 1) \
+        END;",
 ];
 
 pub const ADD_STARTED_AT_INDEX: &str = "CREATE INDEX timestamp_index ON stats_swaps (started_at);";
@@ -117,6 +133,13 @@ pub fn create_and_fill_stats_swaps_from_json_statements(ctx: &MmArc) -> Vec<(&'s
     result
 }
 
+fn split_coin(coin: &str) -> (String, String) {
+    let mut split = coin.split('-');
+    let ticker = split.next().expect("split returns empty string at least").into();
+    let platform = split.next().map_or("".into(), |platform| platform.into());
+    (ticker, platform)
+}
+
 fn insert_stats_maker_swap_sql(swap: &MakerSavedSwap) -> Option<(&'static str, Vec<String>)> {
     let swap_data = match swap.swap_data() {
         Ok(d) => d,
@@ -135,9 +158,17 @@ fn insert_stats_maker_swap_sql(swap: &MakerSavedSwap) -> Option<(&'static str, V
     let is_success = swap
         .is_success()
         .expect("is_success can return error only when swap is not finished");
+
+    let (maker_coin_ticker, maker_coin_platform) = split_coin(&swap_data.maker_coin);
+    let (taker_coin_ticker, taker_coin_platform) = split_coin(&swap_data.taker_coin);
+
     let params = vec![
         swap_data.maker_coin.clone(),
+        maker_coin_ticker,
+        maker_coin_platform,
         swap_data.taker_coin.clone(),
+        taker_coin_ticker,
+        taker_coin_platform,
         swap.uuid.to_string(),
         swap_data.started_at.to_string(),
         finished_at,
@@ -166,9 +197,17 @@ fn insert_stats_taker_swap_sql(swap: &TakerSavedSwap) -> Option<(&'static str, V
     let is_success = swap
         .is_success()
         .expect("is_success can return error only when swap is not finished");
+
+    let (maker_coin_ticker, maker_coin_platform) = split_coin(&swap_data.maker_coin);
+    let (taker_coin_ticker, taker_coin_platform) = split_coin(&swap_data.taker_coin);
+
     let params = vec![
         swap_data.maker_coin.clone(),
+        maker_coin_ticker,
+        maker_coin_platform,
         swap_data.taker_coin.clone(),
+        taker_coin_ticker,
+        taker_coin_platform,
         swap.uuid.to_string(),
         swap_data.started_at.to_string(),
         finished_at,
@@ -210,5 +249,28 @@ pub fn add_swap_to_index(conn: &Connection, swap: &SavedSwap) {
 }
 
 pub fn add_and_split_tickers() -> Vec<(&'static str, Vec<String>)> {
-    ADD_SPLIT_TICKERS.into_iter().map(|sql| (*sql, vec![])).collect()
+    ADD_SPLIT_TICKERS.iter().map(|sql| (*sql, vec![])).collect()
+}
+
+#[test]
+fn test_split_coin() {
+    let input = "";
+    let expected = ("".into(), "".into());
+    let actual = split_coin(input);
+    assert_eq!(expected, actual);
+
+    let input = "RICK";
+    let expected = ("RICK".into(), "".into());
+    let actual = split_coin(input);
+    assert_eq!(expected, actual);
+
+    let input = "RICK-BEP20";
+    let expected = ("RICK".into(), "BEP20".into());
+    let actual = split_coin(input);
+    assert_eq!(expected, actual);
+
+    let input = "RICK-";
+    let expected = ("RICK".into(), "".into());
+    let actual = split_coin(input);
+    assert_eq!(expected, actual);
 }

--- a/mm2src/database/stats_swaps.rs
+++ b/mm2src/database/stats_swaps.rs
@@ -31,12 +31,16 @@ const INSERT_STATS_SWAP: &str = "INSERT INTO stats_swaps (
     is_success
 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
 
-const ADD_SPLIT_TICKERS: &str = r#"
-    ALTER TABLE stats_swaps ADD COLUMN maker_coin_ticker VARCHAR(255) NOT NULL DEFAULT ""
-    ALTER TABLE stats_swaps ADD COLUMN maker_coin_platform VARCHAR(255) NOT NULL DEFAULT ""   
-    ALTER TABLE stats_swaps ADD COLUMN taker_coin_ticker VARCHAR(255) NOT NULL DEFAULT ""
-    ALTER TABLE stats_swaps ADD COLUMN taker_coin_platform VARCHAR(255) NOT NULL DEFAULT ""
-"#;
+const ADD_SPLIT_TICKERS: &[&str] = &[
+    "ALTER TABLE stats_swaps ADD COLUMN maker_coin_ticker VARCHAR(255) NOT NULL DEFAULT '';",
+    "ALTER TABLE stats_swaps ADD COLUMN maker_coin_platform VARCHAR(255) NOT NULL DEFAULT '';",
+    "ALTER TABLE stats_swaps ADD COLUMN taker_coin_ticker VARCHAR(255) NOT NULL DEFAULT '';",
+    "ALTER TABLE stats_swaps ADD COLUMN taker_coin_platform VARCHAR(255) NOT NULL DEFAULT '';",
+    "UPDATE stats_swaps SET maker_coin_ticker = substr(maker_coin, 0, instr(maker_coin, '-'));",
+    "UPDATE stats_swaps SET maker_coin_platform = substr(maker_coin, instr(maker_coin, '-')+1);",
+    "UPDATE stats_swaps SET taker_coin_ticker = substr(taker_coin, 0, instr(taker_coin, '-'));",
+    "UPDATE stats_swaps SET taker_coin_platform = substr(taker_coin, instr(taker_coin, '-')+1);",
+];
 
 pub const ADD_STARTED_AT_INDEX: &str = "CREATE INDEX timestamp_index ON stats_swaps (started_at);";
 
@@ -205,4 +209,6 @@ pub fn add_swap_to_index(conn: &Connection, swap: &SavedSwap) {
     };
 }
 
-pub fn add_and_split_tickers() -> Vec<(&'static str, Vec<String>)> { vec![(ADD_SPLIT_TICKERS, vec![])] }
+pub fn add_and_split_tickers() -> Vec<(&'static str, Vec<String>)> {
+    ADD_SPLIT_TICKERS.into_iter().map(|sql| (*sql, vec![])).collect()
+}

--- a/mm2src/database/stats_swaps.rs
+++ b/mm2src/database/stats_swaps.rs
@@ -31,6 +31,13 @@ const INSERT_STATS_SWAP: &str = "INSERT INTO stats_swaps (
     is_success
 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)";
 
+const ADD_SPLIT_TICKERS: &str = r#"
+    ALTER TABLE stats_swaps ADD COLUMN maker_coin_ticker VARCHAR(255) NOT NULL DEFAULT ""
+    ALTER TABLE stats_swaps ADD COLUMN maker_coin_platform VARCHAR(255) NOT NULL DEFAULT ""   
+    ALTER TABLE stats_swaps ADD COLUMN taker_coin_ticker VARCHAR(255) NOT NULL DEFAULT ""
+    ALTER TABLE stats_swaps ADD COLUMN taker_coin_platform VARCHAR(255) NOT NULL DEFAULT ""
+"#;
+
 pub const ADD_STARTED_AT_INDEX: &str = "CREATE INDEX timestamp_index ON stats_swaps (started_at);";
 
 const SELECT_ID_BY_UUID: &str = "SELECT id FROM stats_swaps WHERE uuid = ?1";
@@ -197,3 +204,5 @@ pub fn add_swap_to_index(conn: &Connection, swap: &SavedSwap) {
         error!("Error {} on query {} with params {:?}", e, sql, params);
     };
 }
+
+pub fn add_and_split_tickers() -> Vec<(&'static str, Vec<String>)> { vec![(ADD_SPLIT_TICKERS, vec![])] }


### PR DESCRIPTION
It will make DB processing easier since aggregators mostly do not differ the coins by different platforms.
#909 