### PR TITLE
Ensure that trade_preimage will not succeed on input that will fail on buy/sell/setprice

### DIFF
--- a/mm2src/docker_tests.rs
+++ b/mm2src/docker_tests.rs
@@ -2053,11 +2053,12 @@ mod docker_tests {
         })))
         .unwrap();
         assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
-        let actual: RpcErrorResponse<trade_preimage_error::VolumeIsTooSmall> = json::from_str(&rc.1).unwrap();
-        assert_eq!(actual.error_type, "VolumeIsTooSmall");
+        let actual: RpcErrorResponse<trade_preimage_error::VolumeTooLow> = json::from_str(&rc.1).unwrap();
+        assert_eq!(actual.error_type, "VolumeTooLow");
         // Min MYCOIN trading volume is 0.0001.
         let volume_threshold = BigDecimal::from(1) / BigDecimal::from(10_000);
-        let expected = trade_preimage_error::VolumeIsTooSmall {
+        let expected = trade_preimage_error::VolumeTooLow {
+            coin: "MYCOIN".to_owned(),
             volume: low_volume.clone(),
             threshold: volume_threshold,
         };
@@ -2077,11 +2078,12 @@ mod docker_tests {
         })))
         .unwrap();
         assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
-        let actual: RpcErrorResponse<trade_preimage_error::VolumeIsTooSmall> = json::from_str(&rc.1).unwrap();
-        assert_eq!(actual.error_type, "VolumeIsTooSmall");
+        let actual: RpcErrorResponse<trade_preimage_error::VolumeTooLow> = json::from_str(&rc.1).unwrap();
+        assert_eq!(actual.error_type, "VolumeTooLow");
         // Min MYCOIN trading volume is 0.0001.
         let volume_threshold = BigDecimal::from(1) / BigDecimal::from(10_000);
-        let expected = trade_preimage_error::VolumeIsTooSmall {
+        let expected = trade_preimage_error::VolumeTooLow {
+            coin: "MYCOIN".to_owned(),
             volume: low_volume,
             threshold: volume_threshold,
         };
@@ -2107,11 +2109,12 @@ mod docker_tests {
         })))
         .unwrap();
         assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
-        let actual: RpcErrorResponse<trade_preimage_error::VolumeIsTooSmall> = json::from_str(&rc.1).unwrap();
-        assert_eq!(actual.error_type, "VolumeIsTooSmall");
+        let actual: RpcErrorResponse<trade_preimage_error::VolumeTooLow> = json::from_str(&rc.1).unwrap();
+        assert_eq!(actual.error_type, "VolumeTooLow");
         // Min MYCOIN1 trading volume is 0.0001.
         let volume_threshold = BigDecimal::from(1) / BigDecimal::from(10_000);
-        let expected = trade_preimage_error::VolumeIsTooSmall {
+        let expected = trade_preimage_error::VolumeTooLow {
+            coin: "MYCOIN1".to_owned(),
             volume: low_rel_volume,
             threshold: volume_threshold,
         };

--- a/mm2src/docker_tests/qrc20_tests.rs
+++ b/mm2src/docker_tests/qrc20_tests.rs
@@ -1485,6 +1485,7 @@ fn test_trade_preimage_dynamic_fee_not_sufficient_balance() {
             "base": "QTUM",
             "rel": "MYCOIN",
             "swap_method": "setprice",
+            "price": 1,
             "volume": qtum_balance,
         },
     })))
@@ -1496,6 +1497,68 @@ fn test_trade_preimage_dynamic_fee_not_sufficient_balance() {
     assert_eq!(data.coin, "QTUM");
     assert_eq!(data.available, qtum_balance);
     assert!(data.required > qtum_balance);
+}
+
+/// If we try to deduct a transaction fee from `output = 0.00073`, the remaining value less than `dust = 0.000728`,
+/// so we have to receive the `NotSufficientBalance` error.
+#[test]
+fn test_trade_preimage_deduct_fee_from_output_failed() {
+    wait_for_estimate_smart_fee(30).expect("!wait_for_estimate_smart_fee");
+    // generate QTUM coin with the dynamic fee and fill the wallet by 0.00073 Qtums (that is little greater than dust 0.000728)
+    let qtum_balance = MmNumber::from("0.00073").to_decimal();
+    let (_ctx, _coin, priv_key) = generate_qtum_coin_with_random_privkey("QTUM", qtum_balance.clone(), Some(0));
+
+    let confpath = unsafe { QTUM_CONF_PATH.as_ref().expect("Qtum config is not set yet") };
+    let coins = json! ([
+        {"coin":"MYCOIN","asset":"MYCOIN","txversion":4,"overwintered":1,"txfee":1000,"protocol":{"type":"UTXO"}},
+        {"coin":"QTUM","decimals":8,"pubtype":120,"p2shtype":110,"wiftype":128,"segwit":true,"txfee":0,"txfee_volatility_percent":0.1,
+        "mm2":1,"mature_confirmations":500,"network":"regtest","confpath":confpath,"protocol":{"type":"UTXO"}},
+    ]);
+    let mut mm = MarketMakerIt::start(
+        json! ({
+            "gui": "nogui",
+            "netid": 9000,
+            "dht": "on",  // Enable DHT without delay.
+            "passphrase": format!("0x{}", hex::encode(priv_key)),
+            "coins": coins,
+            "rpc_password": "pass",
+            "i_am_see": true,
+        }),
+        "pass".to_string(),
+        None,
+    )
+    .unwrap();
+    let (_alice_dump_log, _alice_dump_dashboard) = mm_dump(&mm.log_path);
+    block_on(mm.wait_for_log(22., |log| log.contains(">>>>>>>>> DEX stats "))).unwrap();
+
+    log!([block_on(enable_native(&mm, "MYCOIN", &[]))]);
+    log!([block_on(enable_native(&mm, "QTUM", &[]))]);
+
+    let rc = block_on(mm.rpc(json!({
+        "userpass": mm.userpass,
+        "mmrpc": "2.0",
+        "method": "trade_preimage",
+        "params": {
+            "base": "QTUM",
+            "rel": "MYCOIN",
+            "swap_method": "setprice",
+            "price": 1,
+            "max": true,
+        },
+    })))
+    .unwrap();
+    assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
+    let actual: RpcErrorResponse<trade_preimage_error::NotSufficientBalance> = json::from_str(&rc.1).unwrap();
+    assert_eq!(actual.error_type, "NotSufficientBalance");
+    let trade_preimage_error::NotSufficientBalance {
+        coin: actual_coin,
+        available: actual_available,
+        required: actual_required,
+        ..
+    } = actual.error_data.expect("Expected NotSufficientBalance error data");
+    assert_eq!(actual_coin, "QTUM");
+    assert_eq!(actual_available, qtum_balance);
+    assert!(actual_required > qtum_balance);
 }
 
 #[test]

--- a/mm2src/lp_ordermatch.rs
+++ b/mm2src/lp_ordermatch.rs
@@ -1269,7 +1269,7 @@ pub struct MakerOrder {
     conf_settings: Option<OrderConfirmationsSettings>,
 }
 
-struct MakerOrderBuilder<'a> {
+pub struct MakerOrderBuilder<'a> {
     max_base_vol: MmNumber,
     min_base_vol: Option<MmNumber>,
     price: MmNumber,
@@ -1278,7 +1278,7 @@ struct MakerOrderBuilder<'a> {
     conf_settings: Option<OrderConfirmationsSettings>,
 }
 
-enum MakerOrderBuildError {
+pub enum MakerOrderBuildError {
     BaseEqualRel,
     /// Max base vol too low with threshold
     MaxBaseVolTooLow {
@@ -1411,7 +1411,7 @@ fn validate_max_vol(
 }
 
 impl<'a> MakerOrderBuilder<'a> {
-    fn new(base_coin: &'a MmCoinEnum, rel_coin: &'a MmCoinEnum) -> MakerOrderBuilder<'a> {
+    pub fn new(base_coin: &'a MmCoinEnum, rel_coin: &'a MmCoinEnum) -> MakerOrderBuilder<'a> {
         MakerOrderBuilder {
             base_coin,
             rel_coin,
@@ -1422,28 +1422,28 @@ impl<'a> MakerOrderBuilder<'a> {
         }
     }
 
-    fn with_max_base_vol(mut self, vol: MmNumber) -> Self {
+    pub fn with_max_base_vol(mut self, vol: MmNumber) -> Self {
         self.max_base_vol = vol;
         self
     }
 
-    fn with_min_base_vol(mut self, vol: Option<MmNumber>) -> Self {
+    pub fn with_min_base_vol(mut self, vol: Option<MmNumber>) -> Self {
         self.min_base_vol = vol;
         self
     }
 
-    fn with_price(mut self, price: MmNumber) -> Self {
+    pub fn with_price(mut self, price: MmNumber) -> Self {
         self.price = price;
         self
     }
 
-    fn with_conf_settings(mut self, conf_settings: OrderConfirmationsSettings) -> Self {
+    pub fn with_conf_settings(mut self, conf_settings: OrderConfirmationsSettings) -> Self {
         self.conf_settings = Some(conf_settings);
         self
     }
 
     /// Build MakerOrder
-    fn build(self) -> Result<MakerOrder, MakerOrderBuildError> {
+    pub fn build(self) -> Result<MakerOrder, MakerOrderBuildError> {
         if self.base_coin.ticker() == self.rel_coin.ticker() {
             return Err(MakerOrderBuildError::BaseEqualRel);
         }

--- a/mm2src/lp_ordermatch.rs
+++ b/mm2src/lp_ordermatch.rs
@@ -925,7 +925,7 @@ impl TakerRequest {
     fn get_rel_amount(&self) -> &MmNumber { &self.rel_amount }
 }
 
-struct TakerOrderBuilder<'a> {
+pub struct TakerOrderBuilder<'a> {
     base_coin: &'a MmCoinEnum,
     rel_coin: &'a MmCoinEnum,
     base_amount: MmNumber,
@@ -939,7 +939,7 @@ struct TakerOrderBuilder<'a> {
     timeout: u64,
 }
 
-enum TakerOrderBuildError {
+pub enum TakerOrderBuildError {
     BaseEqualRel,
     /// Base amount too low with threshold
     BaseAmountTooLow {
@@ -1000,7 +1000,7 @@ impl fmt::Display for TakerOrderBuildError {
 }
 
 impl<'a> TakerOrderBuilder<'a> {
-    fn new(base_coin: &'a MmCoinEnum, rel_coin: &'a MmCoinEnum) -> TakerOrderBuilder<'a> {
+    pub fn new(base_coin: &'a MmCoinEnum, rel_coin: &'a MmCoinEnum) -> TakerOrderBuilder<'a> {
         TakerOrderBuilder {
             base_coin,
             rel_coin,
@@ -1016,27 +1016,27 @@ impl<'a> TakerOrderBuilder<'a> {
         }
     }
 
-    fn with_base_amount(mut self, vol: MmNumber) -> Self {
+    pub fn with_base_amount(mut self, vol: MmNumber) -> Self {
         self.base_amount = vol;
         self
     }
 
-    fn with_rel_amount(mut self, vol: MmNumber) -> Self {
+    pub fn with_rel_amount(mut self, vol: MmNumber) -> Self {
         self.rel_amount = vol;
         self
     }
 
-    fn with_min_volume(mut self, vol: Option<MmNumber>) -> Self {
+    pub fn with_min_volume(mut self, vol: Option<MmNumber>) -> Self {
         self.min_volume = vol;
         self
     }
 
-    fn with_action(mut self, action: TakerAction) -> Self {
+    pub fn with_action(mut self, action: TakerAction) -> Self {
         self.action = action;
         self
     }
 
-    fn with_match_by(mut self, match_by: MatchBy) -> Self {
+    pub fn with_match_by(mut self, match_by: MatchBy) -> Self {
         self.match_by = match_by;
         self
     }
@@ -1046,23 +1046,23 @@ impl<'a> TakerOrderBuilder<'a> {
         self
     }
 
-    fn with_conf_settings(mut self, settings: OrderConfirmationsSettings) -> Self {
+    pub fn with_conf_settings(mut self, settings: OrderConfirmationsSettings) -> Self {
         self.conf_settings = Some(settings);
         self
     }
 
-    fn with_sender_pubkey(mut self, sender_pubkey: H256Json) -> Self {
+    pub fn with_sender_pubkey(mut self, sender_pubkey: H256Json) -> Self {
         self.sender_pubkey = sender_pubkey;
         self
     }
 
-    fn with_timeout(mut self, timeout: u64) -> Self {
+    pub fn with_timeout(mut self, timeout: u64) -> Self {
         self.timeout = timeout;
         self
     }
 
     /// Validate fields and build
-    fn build(self) -> Result<TakerOrder, TakerOrderBuildError> {
+    pub fn build(self) -> Result<TakerOrder, TakerOrderBuildError> {
         let min_base_amount = self.base_coin.min_trading_vol();
         let min_rel_amount = self.rel_coin.min_trading_vol();
 
@@ -1182,7 +1182,7 @@ impl Default for OrderType {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct TakerOrder {
+pub struct TakerOrder {
     created_at: u64,
     request: TakerRequest,
     matches: HashMap<Uuid, TakerMatch>,

--- a/mm2src/lp_swap/check_balance.rs
+++ b/mm2src/lp_swap/check_balance.rs
@@ -198,10 +198,10 @@ pub enum CheckBalanceError {
         required: BigDecimal,
         locked_by_swaps: Option<BigDecimal>,
     },
-    #[display(fmt = "Max volume {} less than minimum transaction amount", volume)]
-    MaxVolumeLessThanDust { volume: BigDecimal },
-    #[display(fmt = "The volume {} is too small", volume)]
-    VolumeIsTooSmall { volume: BigDecimal },
+    #[display(fmt = "Max volume {} less than minimum transaction amount {}", volume, threshold)]
+    MaxVolumeLessThanDust { volume: BigDecimal, threshold: BigDecimal },
+    #[display(fmt = "The volume {} less than minimum transaction amount {}", volume, threshold)]
+    VolumeIsTooSmall { volume: BigDecimal, threshold: BigDecimal },
     #[display(fmt = "Transport error: {}", _0)]
     Transport(String),
     #[display(fmt = "Internal error: {}", _0)]
@@ -253,10 +253,16 @@ impl CheckBalanceError {
                     }
                 }
             },
-            TradePreimageError::UpperBoundAmountIsTooSmall { amount } => {
-                CheckBalanceError::MaxVolumeLessThanDust { volume: amount }
+            TradePreimageError::UpperBoundAmountIsTooSmall { amount, threshold } => {
+                CheckBalanceError::MaxVolumeLessThanDust {
+                    volume: amount,
+                    threshold,
+                }
             },
-            TradePreimageError::AmountIsTooSmall { amount } => CheckBalanceError::VolumeIsTooSmall { volume: amount },
+            TradePreimageError::AmountIsTooSmall { amount, threshold } => CheckBalanceError::VolumeIsTooSmall {
+                volume: amount,
+                threshold,
+            },
             TradePreimageError::Transport(transport) => CheckBalanceError::Transport(transport),
             TradePreimageError::InternalError(internal) => CheckBalanceError::InternalError(internal),
         }

--- a/mm2src/lp_swap/check_balance.rs
+++ b/mm2src/lp_swap/check_balance.rs
@@ -199,8 +199,17 @@ pub enum CheckBalanceError {
         required: BigDecimal,
         locked_by_swaps: Option<BigDecimal>,
     },
-    #[display(fmt = "The volume {} less than minimum transaction amount {}", volume, threshold)]
-    VolumeIsTooSmall { volume: BigDecimal, threshold: BigDecimal },
+    #[display(
+        fmt = "The volume {} of the {} coin less than minimum transaction amount {}",
+        coin,
+        volume,
+        threshold
+    )]
+    VolumeTooLow {
+        coin: String,
+        volume: BigDecimal,
+        threshold: BigDecimal,
+    },
     #[display(fmt = "Transport error: {}", _0)]
     Transport(String),
     #[display(fmt = "Internal error: {}", _0)]
@@ -251,7 +260,8 @@ impl CheckBalanceError {
                     }
                 }
             },
-            TradePreimageError::AmountIsTooSmall { amount, threshold } => CheckBalanceError::VolumeIsTooSmall {
+            TradePreimageError::AmountIsTooSmall { amount, threshold } => CheckBalanceError::VolumeTooLow {
+                coin: ticker.to_owned(),
                 volume: amount,
                 threshold,
             },

--- a/mm2src/lp_swap/maker_swap.rs
+++ b/mm2src/lp_swap/maker_swap.rs
@@ -9,6 +9,7 @@ use super::{broadcast_my_swap_status, broadcast_swap_message_every, check_other_
             TransactionIdentifier, WAIT_CONFIRM_INTERVAL};
 
 use crate::mm2::lp_network::subscribe_to_topic;
+use crate::mm2::lp_ordermatch::{MakerOrderBuilder, OrderConfirmationsSettings};
 use crate::mm2::MM_VERSION;
 use atomic::Atomic;
 use bigdecimal::BigDecimal;
@@ -1490,7 +1491,7 @@ pub async fn check_balance_for_maker_swap(
     swap_uuid: Option<&Uuid>,
     prepared_params: Option<MakerSwapPreparedParams>,
     stage: FeeApproxStage,
-) -> Result<(), String> {
+) -> CheckBalanceResult<()> {
     let (maker_payment_trade_fee, taker_payment_spend_trade_fee) = match prepared_params {
         Some(MakerSwapPreparedParams {
             maker_payment_trade_fee,
@@ -1498,19 +1499,22 @@ pub async fn check_balance_for_maker_swap(
         }) => (maker_payment_trade_fee, taker_payment_spend_trade_fee),
         None => {
             let preimage_value = TradePreimageValue::Exact(volume.to_decimal());
-            let maker_payment_trade_fee = try_s!(
-                my_coin
-                    .get_sender_trade_fee(preimage_value, stage.clone())
-                    .compat()
-                    .await
-            );
-            let taker_payment_spend_trade_fee = try_s!(other_coin.get_receiver_trade_fee(stage).compat().await);
+            let maker_payment_trade_fee = my_coin
+                .get_sender_trade_fee(preimage_value, stage.clone())
+                .compat()
+                .await
+                .mm_err(|e| CheckBalanceError::from_trade_preimage_error(e, my_coin.ticker()))?;
+            let taker_payment_spend_trade_fee = other_coin
+                .get_receiver_trade_fee(stage)
+                .compat()
+                .await
+                .mm_err(|e| CheckBalanceError::from_trade_preimage_error(e, other_coin.ticker()))?;
             (maker_payment_trade_fee, taker_payment_spend_trade_fee)
         },
     };
 
-    try_s!(check_my_coin_balance_for_swap(ctx, my_coin, swap_uuid, volume, maker_payment_trade_fee, None).await);
-    try_s!(check_other_coin_balance_for_swap(ctx, other_coin, swap_uuid, taker_payment_spend_trade_fee).await);
+    check_my_coin_balance_for_swap(ctx, my_coin, swap_uuid, volume, maker_payment_trade_fee, None).await?;
+    check_other_coin_balance_for_swap(ctx, other_coin, swap_uuid, taker_payment_spend_trade_fee).await?;
     Ok(())
 }
 
@@ -1533,9 +1537,11 @@ pub async fn maker_swap_trade_preimage(
         let balance = base_coin.my_spendable_balance().compat().await?;
         calc_max_maker_vol(&ctx, &base_coin, &balance, FeeApproxStage::TradePreimage).await?
     } else {
+        let threshold = base_coin.min_trading_vol().to_decimal();
         if req.volume.is_zero() {
             return MmError::err(TradePreimageRpcError::VolumeIsTooSmall {
                 volume: req.volume.to_decimal(),
+                threshold,
             });
         }
         req.volume
@@ -1552,6 +1558,40 @@ pub async fn maker_swap_trade_preimage(
         .compat()
         .await
         .mm_err(|e| TradePreimageRpcError::from_trade_preimage_error(e, rel_coin.ticker()))?;
+
+    if req.max {
+        // Note the `calc_max_maker_vol` returns [`CheckBalanceError::NotSufficientBalance`] error if the balance of `base_coin` is not sufficient.
+        // So we have to check the balance of the other coin only.
+        check_other_coin_balance_for_swap(ctx, &rel_coin, None, rel_coin_fee.clone()).await?
+    } else {
+        let prepared_params = MakerSwapPreparedParams {
+            maker_payment_trade_fee: base_coin_fee.clone(),
+            taker_payment_spend_trade_fee: rel_coin_fee.clone(),
+        };
+        check_balance_for_maker_swap(
+            ctx,
+            &base_coin,
+            &rel_coin,
+            volume.clone(),
+            None,
+            Some(prepared_params),
+            FeeApproxStage::TradePreimage,
+        )
+        .await?
+    }
+
+    let conf_settings = OrderConfirmationsSettings {
+        base_confs: base_coin.required_confirmations(),
+        base_nota: base_coin.requires_notarization(),
+        rel_confs: rel_coin.required_confirmations(),
+        rel_nota: rel_coin.requires_notarization(),
+    };
+    let builder = MakerOrderBuilder::new(&base_coin, &rel_coin)
+        .with_max_base_vol(volume.clone())
+        .with_price(req.price)
+        .with_conf_settings(conf_settings);
+    // perform an additional validation
+    let _order = builder.build()?;
 
     let volume = if req.max { Some(volume) } else { None };
     Ok(MakerTradePreimage {

--- a/mm2src/lp_swap/taker_swap.rs
+++ b/mm2src/lp_swap/taker_swap.rs
@@ -1,13 +1,14 @@
 use super::check_balance::{check_my_coin_balance_for_swap, CheckBalanceError, CheckBalanceResult,
                            TakerFeeAdditionalInfo};
 use super::pubkey_banning::ban_pubkey_on_failed_swap;
-use super::trade_preimage::{TradePreimageMethod, TradePreimageRequest, TradePreimageRpcError, TradePreimageRpcResult};
+use super::trade_preimage::{TradePreimageRequest, TradePreimageRpcError, TradePreimageRpcResult};
 use super::{broadcast_my_swap_status, broadcast_swap_message_every, check_other_coin_balance_for_swap,
             dex_fee_amount_from_taker_coin, dex_fee_rate, dex_fee_threshold, get_locked_amount, my_swap_file_path,
             my_swaps_dir, recv_swap_msg, swap_topic, AtomicSwap, LockedAmount, MySwapInfo, NegotiationDataMsg,
             RecoveredSwap, RecoveredSwapAction, SavedSwap, SavedTradeFee, SwapConfirmationsSettings, SwapError,
             SwapMsg, SwapsContext, TransactionIdentifier, WAIT_CONFIRM_INTERVAL};
 use crate::mm2::lp_network::subscribe_to_topic;
+use crate::mm2::lp_ordermatch::{MatchBy, OrderConfirmationsSettings, TakerAction, TakerOrderBuilder};
 use crate::mm2::MM_VERSION;
 use atomic::Atomic;
 use bigdecimal::BigDecimal;
@@ -1478,25 +1479,27 @@ pub async fn check_balance_for_taker_swap(
     swap_uuid: Option<&Uuid>,
     prepared_params: Option<TakerSwapPreparedParams>,
     stage: FeeApproxStage,
-) -> Result<(), String> {
+) -> CheckBalanceResult<()> {
     let params = match prepared_params {
         Some(params) => params,
         None => {
             let dex_fee = dex_fee_amount_from_taker_coin(my_coin, other_coin.ticker(), &volume);
-            let fee_to_send_dex_fee = try_s!(
-                my_coin
-                    .get_fee_to_send_taker_fee(dex_fee.to_decimal(), stage.clone())
-                    .compat()
-                    .await
-            );
+            let fee_to_send_dex_fee = my_coin
+                .get_fee_to_send_taker_fee(dex_fee.to_decimal(), stage.clone())
+                .compat()
+                .await
+                .mm_err(|e| CheckBalanceError::from_trade_preimage_error(e, my_coin.ticker()))?;
             let preimage_value = TradePreimageValue::Exact(volume.to_decimal());
-            let taker_payment_trade_fee = try_s!(
-                my_coin
-                    .get_sender_trade_fee(preimage_value, stage.clone())
-                    .compat()
-                    .await
-            );
-            let maker_payment_spend_trade_fee = try_s!(other_coin.get_receiver_trade_fee(stage).compat().await);
+            let taker_payment_trade_fee = my_coin
+                .get_sender_trade_fee(preimage_value, stage.clone())
+                .compat()
+                .await
+                .mm_err(|e| CheckBalanceError::from_trade_preimage_error(e, my_coin.ticker()))?;
+            let maker_payment_spend_trade_fee = other_coin
+                .get_receiver_trade_fee(stage)
+                .compat()
+                .await
+                .mm_err(|e| CheckBalanceError::from_trade_preimage_error(e, other_coin.ticker()))?;
             TakerSwapPreparedParams {
                 dex_fee,
                 fee_to_send_dex_fee,
@@ -1511,21 +1514,17 @@ pub async fn check_balance_for_taker_swap(
         fee_to_send_dex_fee: params.fee_to_send_dex_fee,
     };
 
-    try_s!(
-        check_my_coin_balance_for_swap(
-            ctx,
-            my_coin,
-            swap_uuid,
-            volume,
-            params.taker_payment_trade_fee,
-            Some(taker_fee)
-        )
-        .await
-    );
+    check_my_coin_balance_for_swap(
+        ctx,
+        my_coin,
+        swap_uuid,
+        volume,
+        params.taker_payment_trade_fee,
+        Some(taker_fee),
+    )
+    .await?;
     if !params.maker_payment_spend_trade_fee.paid_from_trading_vol {
-        try_s!(
-            check_other_coin_balance_for_swap(ctx, other_coin, swap_uuid, params.maker_payment_spend_trade_fee).await
-        );
+        check_other_coin_balance_for_swap(ctx, other_coin, swap_uuid, params.maker_payment_spend_trade_fee).await?;
     }
     Ok(())
 }
@@ -1542,18 +1541,18 @@ pub struct TakerTradePreimage {
 }
 
 pub async fn taker_swap_trade_preimage(
-    _ctx: &MmArc,
+    ctx: &MmArc,
     req: TradePreimageRequest,
     base_coin: MmCoinEnum,
     rel_coin: MmCoinEnum,
 ) -> TradePreimageRpcResult<TakerTradePreimage> {
-    let (my_coin, other_coin) = match req.swap_method {
-        TradePreimageMethod::SetPrice => {
-            let error = "Internal error: expected 'sell' or 'buy' method".to_owned();
-            return MmError::err(TradePreimageRpcError::InternalError(error));
-        },
-        TradePreimageMethod::Sell => (base_coin, rel_coin),
-        TradePreimageMethod::Buy => (rel_coin, base_coin),
+    let action = req
+        .swap_method
+        .into_taker_action()
+        .map_to_mm(TradePreimageRpcError::InternalError)?;
+    let (my_coin, other_coin) = match action {
+        TakerAction::Sell => (base_coin.clone(), rel_coin.clone()),
+        TakerAction::Buy => (rel_coin.clone(), base_coin.clone()),
     };
     let my_coin_ticker = my_coin.ticker();
     let other_coin_ticker = other_coin.ticker();
@@ -1565,14 +1564,13 @@ pub async fn taker_swap_trade_preimage(
         });
     }
 
+    let base_amount = req.volume.clone();
+    let rel_amount = req.price * req.volume;
+
     let stage = FeeApproxStage::TradePreimage;
-    let my_coin_volume = match req.swap_method {
-        TradePreimageMethod::SetPrice => {
-            let error = "Expected 'sell' or 'buy' method".to_owned();
-            return MmError::err(TradePreimageRpcError::InternalError(error));
-        },
-        TradePreimageMethod::Sell => req.volume,
-        TradePreimageMethod::Buy => req.price * req.volume,
+    let my_coin_volume = match action {
+        TakerAction::Sell => base_amount.clone(),
+        TakerAction::Buy => rel_amount.clone(),
     };
 
     let dex_amount = dex_fee_amount_from_taker_coin(&my_coin, other_coin_ticker, &my_coin_volume);
@@ -1595,14 +1593,47 @@ pub async fn taker_swap_trade_preimage(
         .await
         .mm_err(|e| TradePreimageRpcError::from_trade_preimage_error(e, my_coin_ticker))?;
     let other_coin_trade_fee = other_coin
-        .get_receiver_trade_fee(stage)
+        .get_receiver_trade_fee(stage.clone())
         .compat()
         .await
         .mm_err(|e| TradePreimageRpcError::from_trade_preimage_error(e, other_coin_ticker))?;
 
-    let (base_coin_fee, rel_coin_fee) = match req.swap_method {
-        TradePreimageMethod::Sell => (my_coin_trade_fee, other_coin_trade_fee),
-        _ => (other_coin_trade_fee, my_coin_trade_fee),
+    let prepared_params = TakerSwapPreparedParams {
+        dex_fee: dex_amount,
+        fee_to_send_dex_fee: fee_to_send_taker_fee.clone(),
+        taker_payment_trade_fee: my_coin_trade_fee.clone(),
+        maker_payment_spend_trade_fee: other_coin_trade_fee.clone(),
+    };
+    check_balance_for_taker_swap(
+        ctx,
+        &my_coin,
+        &other_coin,
+        my_coin_volume.clone(),
+        None,
+        Some(prepared_params),
+        stage,
+    )
+    .await?;
+
+    let conf_settings = OrderConfirmationsSettings {
+        base_confs: base_coin.required_confirmations(),
+        base_nota: base_coin.requires_notarization(),
+        rel_confs: rel_coin.required_confirmations(),
+        rel_nota: rel_coin.requires_notarization(),
+    };
+    let our_public_id = ctx.public_id().expect("!ctx.public_id()");
+    let order_builder = TakerOrderBuilder::new(&base_coin, &rel_coin)
+        .with_base_amount(base_amount)
+        .with_rel_amount(rel_amount)
+        .with_action(action.clone())
+        .with_match_by(MatchBy::Any)
+        .with_conf_settings(conf_settings)
+        .with_sender_pubkey(H256Json::from(our_public_id.bytes));
+    let _ = order_builder.build()?;
+
+    let (base_coin_fee, rel_coin_fee) = match action {
+        TakerAction::Sell => (my_coin_trade_fee, other_coin_trade_fee),
+        TakerAction::Buy => (other_coin_trade_fee, my_coin_trade_fee),
     };
     Ok(TakerTradePreimage {
         base_coin_fee,

--- a/mm2src/lp_swap/taker_swap.rs
+++ b/mm2src/lp_swap/taker_swap.rs
@@ -1565,16 +1565,6 @@ pub async fn taker_swap_trade_preimage(
         });
     }
 
-    if req.price.is_zero() {
-        return MmError::err(TradePreimageRpcError::ZeroPrice);
-    }
-
-    if req.volume.is_zero() {
-        return MmError::err(TradePreimageRpcError::VolumeIsTooSmall {
-            volume: req.volume.to_decimal(),
-        });
-    }
-
     let stage = FeeApproxStage::TradePreimage;
     let my_coin_volume = match req.swap_method {
         TradePreimageMethod::SetPrice => {
@@ -1747,6 +1737,7 @@ pub fn max_taker_vol_from_available(
     if &max_vol <= min_tx_amount {
         return MmError::err(CheckBalanceError::MaxVolumeLessThanDust {
             volume: max_vol.to_decimal(),
+            threshold: min_tx_amount.to_decimal(),
         });
     }
     Ok(max_vol)

--- a/mm2src/lp_swap/trade_preimage.rs
+++ b/mm2src/lp_swap/trade_preimage.rs
@@ -310,7 +310,6 @@ impl From<MakerOrderBuildError> for TradePreimageRpcError {
                 price: actual.to_decimal(),
                 threshold: threshold.to_decimal(),
             },
-            // TODO consider separating the VolIsTooSmall into BaseVolIsTooSmall and RelVolIsTooSmall
             MakerOrderBuildError::RelVolTooLow { actual, threshold } => TradePreimageRpcError::VolumeIsTooSmall {
                 volume: actual.to_decimal(),
                 threshold: threshold.to_decimal(),

--- a/mm2src/lp_swap/trade_preimage.rs
+++ b/mm2src/lp_swap/trade_preimage.rs
@@ -209,8 +209,6 @@ pub enum TradePreimageRpcError {
         #[serde(skip_serializing_if = "Option::is_none")]
         locked_by_swaps: Option<BigDecimal>,
     },
-    #[display(fmt = "Max volume {} less than minimum transaction amount {}", volume, threshold)]
-    MaxVolumeLessThanDust { volume: BigDecimal, threshold: BigDecimal },
     #[display(fmt = "The volume {} less than minimum transaction amount {}", volume, threshold)]
     VolumeIsTooSmall { volume: BigDecimal, threshold: BigDecimal },
     #[display(fmt = "No such coin {}", coin)]
@@ -234,7 +232,6 @@ impl HttpStatusCode for TradePreimageRpcError {
         match self {
             TradePreimageRpcError::NotSufficientBalance { .. }
             | TradePreimageRpcError::NotSufficientBaseCoinBalance { .. }
-            | TradePreimageRpcError::MaxVolumeLessThanDust { .. }
             | TradePreimageRpcError::VolumeIsTooSmall { .. }
             | TradePreimageRpcError::NoSuchCoin { .. }
             | TradePreimageRpcError::CoinIsWalletOnly { .. }
@@ -283,9 +280,6 @@ impl From<CheckBalanceError> for TradePreimageRpcError {
                 available,
                 required,
                 locked_by_swaps,
-            },
-            CheckBalanceError::MaxVolumeLessThanDust { volume, threshold } => {
-                TradePreimageRpcError::MaxVolumeLessThanDust { volume, threshold }
             },
             CheckBalanceError::VolumeIsTooSmall { volume, threshold } => {
                 TradePreimageRpcError::VolumeIsTooSmall { volume, threshold }

--- a/mm2src/mm2_tests/structs.rs
+++ b/mm2src/mm2_tests/structs.rs
@@ -541,7 +541,8 @@ pub mod trade_preimage_error {
 
     #[derive(Debug, Deserialize, PartialEq)]
     #[serde(deny_unknown_fields)]
-    pub struct VolumeIsTooSmall {
+    pub struct VolumeTooLow {
+        pub coin: String,
         pub volume: BigDecimal,
         pub threshold: BigDecimal,
     }

--- a/mm2src/mm2_tests/structs.rs
+++ b/mm2src/mm2_tests/structs.rs
@@ -543,6 +543,7 @@ pub mod trade_preimage_error {
     #[serde(deny_unknown_fields)]
     pub struct VolumeIsTooSmall {
         pub volume: BigDecimal,
+        pub threshold: BigDecimal,
     }
 
     #[derive(Debug, Deserialize, PartialEq)]
@@ -556,5 +557,12 @@ pub mod trade_preimage_error {
     pub struct InvalidParam {
         pub param: String,
         pub reason: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub struct PriceTooLow {
+        pub price: BigDecimal,
+        pub threshold: BigDecimal,
     }
 }


### PR DESCRIPTION
* GenerateTxError::OutputValueLessThanDust converts to TradePreimageError::InternalError the value is upper bound
* Fix invalid required field in NotSufficientBalance error generated by calc_max_maker_vol