### PR TITLE
Refactor WithdrawError::AmountTooLow

### DIFF
--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -559,10 +559,14 @@ async fn withdraw_impl(ctx: MmArc, coin: EthCoin, req: WithdrawRequest) -> Withd
         },
     };
     let total_fee = gas * gas_price;
+    let total_fee_dec = u256_to_big_decimal(total_fee, coin.decimals)?;
 
     if req.max && coin.coin_type == EthCoinType::Eth {
         if eth_value < total_fee || wei_amount < total_fee {
-            return MmError::err(WithdrawError::AmountIsTooSmall { amount: eth_value_dec });
+            return MmError::err(WithdrawError::AmountTooLow {
+                amount: eth_value_dec,
+                threshold: total_fee_dec,
+            });
         }
         eth_value -= total_fee;
         wei_amount -= total_fee;

--- a/mm2src/coins/qrc20.rs
+++ b/mm2src/coins/qrc20.rs
@@ -1160,12 +1160,6 @@ async fn qrc20_withdraw(coin: Qrc20Coin, req: WithdrawRequest) -> WithdrawResult
         (amount, qrc20_balance.clone())
     } else {
         let amount_sat = wei_from_big_decimal(&req.amount, coin.utxo.decimals)?;
-        if amount_sat.is_zero() {
-            return MmError::err(WithdrawError::AmountIsTooSmall {
-                amount: req.amount.clone(),
-            });
-        }
-
         if req.amount > qrc20_balance {
             return MmError::err(WithdrawError::NotSufficientBalance {
                 coin: coin.ticker().to_owned(),

--- a/mm2src/lp_swap/check_balance.rs
+++ b/mm2src/lp_swap/check_balance.rs
@@ -201,8 +201,8 @@ pub enum CheckBalanceError {
     },
     #[display(
         fmt = "The volume {} of the {} coin less than minimum transaction amount {}",
-        coin,
         volume,
+        coin,
         threshold
     )]
     VolumeTooLow {

--- a/mm2src/lp_swap/trade_preimage.rs
+++ b/mm2src/lp_swap/trade_preimage.rs
@@ -211,8 +211,8 @@ pub enum TradePreimageRpcError {
     },
     #[display(
         fmt = "The volume {} of the {} coin less than minimum transaction amount {}",
-        coin,
         volume,
+        coin,
         threshold
     )]
     VolumeTooLow {

--- a/mm2src/mm2_tests/structs.rs
+++ b/mm2src/mm2_tests/structs.rs
@@ -522,8 +522,9 @@ pub mod withdraw_error {
 
     #[derive(Debug, Deserialize, PartialEq)]
     #[serde(deny_unknown_fields)]
-    pub struct AmountIsTooSmall {
+    pub struct AmountTooLow {
         pub amount: BigDecimal,
+        pub threshold: BigDecimal,
     }
 }
 


### PR DESCRIPTION
I decided to refactor a bit the `WithdrawError::AmountTooLow` error type when filling out the docs.

* Rename `WithdrawError::AmountIsTooSmall` to `WithdrawError::AmountTooLow`
* Add the 'threshold' filed to `WithdrawError::AmountTooLow`
* Fix error description of `TradePreimageRpcError::VolumeTooLow`