### PR TITLE
segwit backward compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,7 @@ dependencies = [
  "primitives",
  "rand 0.7.3",
  "rlp 0.3.0",
+ "rmp-serde",
  "rpc",
  "rust-ini",
  "rustls",

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -49,6 +49,7 @@ num-traits = "0.2"
 primitives = { path = "../mm2_bitcoin/primitives" }
 rand = { version = "0.7", features = ["std", "small_rng"] }
 rlp = { git = "https://github.com/artemii235/parity-common" }
+rmp-serde = "0.14.3"
 rpc = { path = "../mm2_bitcoin/rpc" }
 script = { path = "../mm2_bitcoin/script" }
 secp256k1_bindings = { version = "0.20", package = "secp256k1" }

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -1218,10 +1218,6 @@ impl MarketCoinOps for EthCoin {
         )
     }
 
-    fn address_from_pubkey_str(&self, pubkey: &str, _addr_format: &str) -> Result<String, String> {
-        addr_from_pubkey_str(pubkey)
-    }
-
     fn display_priv_key(&self) -> String { format!("{:#02x}", self.key_pair.secret()) }
 
     fn min_tx_amount(&self) -> BigDecimal { BigDecimal::from(0) }

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -1218,7 +1218,9 @@ impl MarketCoinOps for EthCoin {
         )
     }
 
-    fn address_from_pubkey_str(&self, pubkey: &str) -> Result<String, String> { addr_from_pubkey_str(pubkey) }
+    fn address_from_pubkey_str(&self, pubkey: &str, _addr_format: &str) -> Result<String, String> {
+        addr_from_pubkey_str(pubkey)
+    }
 
     fn display_priv_key(&self) -> String { format!("{:#02x}", self.key_pair.secret()) }
 
@@ -2917,6 +2919,10 @@ impl MmCoin for EthCoin {
     }
 
     fn mature_confirmations(&self) -> Option<u32> { None }
+
+    fn coin_protocol_info(&self) -> Option<Vec<u8>> { None }
+
+    fn is_coin_protocol_supported(&self, _info: &Option<Vec<u8>>) -> bool { true }
 }
 
 pub trait TryToAddress {

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -45,6 +45,7 @@ use futures::lock::{MappedMutexGuard as AsyncMappedMutexGuard, Mutex as AsyncMut
 use futures::{FutureExt, TryFutureExt};
 use futures01::Future;
 use http::{Response, StatusCode};
+use keys::AddressFormat as UtxoAddressFormat;
 use rpc::v1::types::Bytes as BytesJson;
 use serde::{Deserialize, Deserializer};
 use serde_json::{self as json, Value as Json};
@@ -1679,14 +1680,19 @@ pub async fn convert_utxo_address(ctx: MmArc, req: Json) -> Result<Response<Vec<
     Ok(try_s!(Response::builder().body(response)))
 }
 
-pub fn address_by_coin_conf_and_pubkey_str(coin: &str, conf: &Json, pubkey: &str) -> Result<String, String> {
+pub fn address_by_coin_conf_and_pubkey_str(
+    coin: &str,
+    conf: &Json,
+    pubkey: &str,
+    addr_format: UtxoAddressFormat,
+) -> Result<String, String> {
     let protocol: CoinProtocol = try_s!(json::from_value(conf["protocol"].clone()));
     match protocol {
         CoinProtocol::ERC20 { .. } | CoinProtocol::ETH => eth::addr_from_pubkey_str(pubkey),
         CoinProtocol::UTXO | CoinProtocol::QTUM | CoinProtocol::QRC20 { .. } => {
-            utxo::address_by_conf_and_pubkey_str(coin, conf, pubkey)
+            utxo::address_by_conf_and_pubkey_str(coin, conf, pubkey, addr_format)
         },
         #[cfg(all(not(target_arch = "wasm32"), feature = "zhtlc"))]
-        CoinProtocol::ZHTLC => utxo::address_by_conf_and_pubkey_str(coin, conf, pubkey),
+        CoinProtocol::ZHTLC => utxo::address_by_conf_and_pubkey_str(coin, conf, pubkey, addr_format),
     }
 }

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -342,8 +342,6 @@ pub trait MarketCoinOps {
 
     fn current_block(&self) -> Box<dyn Future<Item = u64, Error = String> + Send>;
 
-    fn address_from_pubkey_str(&self, pubkey: &str, addr_format: &str) -> Result<String, String>;
-
     fn display_priv_key(&self) -> String;
 
     /// Get the minimum amount to send.

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -341,7 +341,7 @@ pub trait MarketCoinOps {
 
     fn current_block(&self) -> Box<dyn Future<Item = u64, Error = String> + Send>;
 
-    fn address_from_pubkey_str(&self, pubkey: &str) -> Result<String, String>;
+    fn address_from_pubkey_str(&self, pubkey: &str, addr_format: &str) -> Result<String, String>;
 
     fn display_priv_key(&self) -> String;
 
@@ -887,6 +887,12 @@ pub trait MmCoin: SwapOps + MarketCoinOps + fmt::Debug + Send + Sync + 'static {
 
     /// The minimum number of confirmations at which a transaction is considered mature.
     fn mature_confirmations(&self) -> Option<u32>;
+
+    /// Get some of the coin config info in serialized format for p2p messaging.
+    fn coin_protocol_info(&self) -> Option<Vec<u8>>;
+
+    /// Check if serialized coin protocol info is supported by current version.
+    fn is_coin_protocol_supported(&self, info: &Option<Vec<u8>>) -> bool;
 }
 
 #[derive(Clone, Debug)]

--- a/mm2src/coins/qrc20.rs
+++ b/mm2src/coins/qrc20.rs
@@ -988,10 +988,6 @@ impl MarketCoinOps for Qrc20Coin {
         utxo_common::current_block(&self.utxo)
     }
 
-    fn address_from_pubkey_str(&self, pubkey: &str, addr_format: &str) -> Result<String, String> {
-        utxo_common::address_from_pubkey_str(self, pubkey, addr_format)
-    }
-
     fn display_priv_key(&self) -> String { utxo_common::display_priv_key(&self.utxo) }
 
     fn min_tx_amount(&self) -> BigDecimal { BigDecimal::from(0) }

--- a/mm2src/coins/qrc20.rs
+++ b/mm2src/coins/qrc20.rs
@@ -32,7 +32,7 @@ use futures::lock::MutexGuard as AsyncMutexGuard;
 use futures::{FutureExt, TryFutureExt};
 use futures01::Future;
 use keys::bytes::Bytes as ScriptBytes;
-use keys::{Address as UtxoAddress, Address, AddressFormat, Public};
+use keys::{Address as UtxoAddress, Address, Public};
 #[cfg(test)] use mocktopus::macros::*;
 use rpc::v1::types::{Bytes as BytesJson, Transaction as RpcTransaction, H160 as H160Json, H256 as H256Json};
 use script::{Builder as ScriptBuilder, Opcode, Script, TransactionInputSigner};
@@ -1167,15 +1167,10 @@ impl MmCoin for Qrc20Coin {
 
     fn mature_confirmations(&self) -> Option<u32> { Some(self.utxo.conf.mature_confirmations) }
 
-    fn coin_protocol_info(&self) -> Option<Vec<u8>> {
-        Some(serde_json::to_vec(&self.utxo.my_address.addr_format).unwrap())
-    }
+    fn coin_protocol_info(&self) -> Option<Vec<u8>> { utxo_common::coin_protocol_info(&self.utxo) }
 
     fn is_coin_protocol_supported(&self, info: &Option<Vec<u8>>) -> bool {
-        match info {
-            Some(format) => json::from_slice::<AddressFormat>(format).is_ok(),
-            None => !&self.utxo.my_address.addr_format.is_segwit(),
-        }
+        utxo_common::is_coin_protocol_supported(&self.utxo, info)
     }
 }
 

--- a/mm2src/coins/qrc20.rs
+++ b/mm2src/coins/qrc20.rs
@@ -32,7 +32,7 @@ use futures::lock::MutexGuard as AsyncMutexGuard;
 use futures::{FutureExt, TryFutureExt};
 use futures01::Future;
 use keys::bytes::Bytes as ScriptBytes;
-use keys::{Address as UtxoAddress, Address, Public};
+use keys::{Address as UtxoAddress, Address, AddressFormat, Public};
 #[cfg(test)] use mocktopus::macros::*;
 use rpc::v1::types::{Bytes as BytesJson, Transaction as RpcTransaction, H160 as H160Json, H256 as H256Json};
 use script::{Builder as ScriptBuilder, Opcode, Script, TransactionInputSigner};
@@ -988,8 +988,8 @@ impl MarketCoinOps for Qrc20Coin {
         utxo_common::current_block(&self.utxo)
     }
 
-    fn address_from_pubkey_str(&self, pubkey: &str) -> Result<String, String> {
-        utxo_common::address_from_pubkey_str(self, pubkey)
+    fn address_from_pubkey_str(&self, pubkey: &str, addr_format: &str) -> Result<String, String> {
+        utxo_common::address_from_pubkey_str(self, pubkey, addr_format)
     }
 
     fn display_priv_key(&self) -> String { utxo_common::display_priv_key(&self.utxo) }
@@ -1166,6 +1166,17 @@ impl MmCoin for Qrc20Coin {
     }
 
     fn mature_confirmations(&self) -> Option<u32> { Some(self.utxo.conf.mature_confirmations) }
+
+    fn coin_protocol_info(&self) -> Option<Vec<u8>> {
+        Some(serde_json::to_vec(&self.utxo.my_address.addr_format).unwrap())
+    }
+
+    fn is_coin_protocol_supported(&self, info: &Option<Vec<u8>>) -> bool {
+        match info {
+            Some(format) => json::from_slice::<AddressFormat>(format).is_ok(),
+            None => !&self.utxo.my_address.addr_format.is_segwit(),
+        }
+    }
 }
 
 pub fn qrc20_swap_id(time_lock: u32, secret_hash: &[u8]) -> Vec<u8> {

--- a/mm2src/coins/test_coin.rs
+++ b/mm2src/coins/test_coin.rs
@@ -64,8 +64,6 @@ impl MarketCoinOps for TestCoin {
 
     fn current_block(&self) -> Box<dyn Future<Item = u64, Error = String> + Send> { unimplemented!() }
 
-    fn address_from_pubkey_str(&self, pubkey: &str, addr_format: &str) -> Result<String, String> { unimplemented!() }
-
     fn display_priv_key(&self) -> String { unimplemented!() }
 
     fn min_tx_amount(&self) -> BigDecimal { unimplemented!() }

--- a/mm2src/coins/test_coin.rs
+++ b/mm2src/coins/test_coin.rs
@@ -64,7 +64,7 @@ impl MarketCoinOps for TestCoin {
 
     fn current_block(&self) -> Box<dyn Future<Item = u64, Error = String> + Send> { unimplemented!() }
 
-    fn address_from_pubkey_str(&self, pubkey: &str) -> Result<String, String> { unimplemented!() }
+    fn address_from_pubkey_str(&self, pubkey: &str, addr_format: &str) -> Result<String, String> { unimplemented!() }
 
     fn display_priv_key(&self) -> String { unimplemented!() }
 
@@ -269,4 +269,8 @@ impl MmCoin for TestCoin {
     fn swap_contract_address(&self) -> Option<BytesJson> { unimplemented!() }
 
     fn mature_confirmations(&self) -> Option<u32> { unimplemented!() }
+
+    fn coin_protocol_info(&self) -> Option<Vec<u8>> { None }
+
+    fn is_coin_protocol_supported(&self, _info: &Option<Vec<u8>>) -> bool { true }
 }

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -1997,7 +1997,12 @@ pub fn output_script(address: &Address) -> Script {
     }
 }
 
-pub fn address_by_conf_and_pubkey_str(coin: &str, conf: &Json, pubkey: &str) -> Result<String, String> {
+pub fn address_by_conf_and_pubkey_str(
+    coin: &str,
+    conf: &Json,
+    pubkey: &str,
+    addr_format: UtxoAddressFormat,
+) -> Result<String, String> {
     let null = Json::Null;
     let conf_builder = UtxoConfBuilder::new(&conf, &null, coin);
     let utxo_conf = try_s!(conf_builder.build());
@@ -2009,8 +2014,8 @@ pub fn address_by_conf_and_pubkey_str(coin: &str, conf: &Json, pubkey: &str) -> 
         t_addr_prefix: utxo_conf.pub_t_addr_prefix,
         hash,
         checksum_type: utxo_conf.checksum_type,
-        hrp: utxo_conf.bech32_hrp.clone(),
-        addr_format: utxo_conf.default_address_format,
+        hrp: utxo_conf.bech32_hrp,
+        addr_format,
     };
     address.display_address()
 }

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -565,10 +565,6 @@ impl MarketCoinOps for QtumCoin {
         utxo_common::current_block(&self.utxo_arc)
     }
 
-    fn address_from_pubkey_str(&self, pubkey: &str, addr_format: &str) -> Result<String, String> {
-        utxo_common::address_from_pubkey_str(self, pubkey, addr_format)
-    }
-
     fn display_priv_key(&self) -> String { utxo_common::display_priv_key(&self.utxo_arc) }
 
     fn min_tx_amount(&self) -> BigDecimal { utxo_common::min_tx_amount(self.as_ref()) }

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -5,7 +5,6 @@ use common::mm_metrics::MetricsArc;
 use common::mm_number::MmNumber;
 use ethereum_types::H160;
 use futures::{FutureExt, TryFutureExt};
-use keys::AddressFormat;
 use serialization::CoinVariant;
 
 pub const QTUM_STANDARD_DUST: u64 = 1000;
@@ -640,15 +639,10 @@ impl MmCoin for QtumCoin {
 
     fn mature_confirmations(&self) -> Option<u32> { Some(self.utxo_arc.conf.mature_confirmations) }
 
-    fn coin_protocol_info(&self) -> Option<Vec<u8>> {
-        Some(serde_json::to_vec(&self.utxo_arc.my_address.addr_format).unwrap())
-    }
+    fn coin_protocol_info(&self) -> Option<Vec<u8>> { utxo_common::coin_protocol_info(&self.utxo_arc) }
 
     fn is_coin_protocol_supported(&self, info: &Option<Vec<u8>>) -> bool {
-        match info {
-            Some(format) => json::from_slice::<AddressFormat>(format).is_ok(),
-            None => !&self.utxo_arc.my_address.addr_format.is_segwit(),
-        }
+        utxo_common::is_coin_protocol_supported(&self.utxo_arc, info)
     }
 }
 

--- a/mm2src/coins/utxo/slp.rs
+++ b/mm2src/coins/utxo/slp.rs
@@ -887,8 +887,6 @@ impl MarketCoinOps for SlpToken {
 
     fn current_block(&self) -> Box<dyn Future<Item = u64, Error = String> + Send> { self.platform_utxo.current_block() }
 
-    fn address_from_pubkey_str(&self, _pubkey: &str, _addr_format: &str) -> Result<String, String> { unimplemented!() }
-
     fn display_priv_key(&self) -> String { self.platform_utxo.display_priv_key() }
 
     fn min_tx_amount(&self) -> BigDecimal { big_decimal_from_sat_unsigned(1, self.decimals()) }

--- a/mm2src/coins/utxo/slp.rs
+++ b/mm2src/coins/utxo/slp.rs
@@ -887,7 +887,7 @@ impl MarketCoinOps for SlpToken {
 
     fn current_block(&self) -> Box<dyn Future<Item = u64, Error = String> + Send> { self.platform_utxo.current_block() }
 
-    fn address_from_pubkey_str(&self, _pubkey: &str) -> Result<String, String> { unimplemented!() }
+    fn address_from_pubkey_str(&self, _pubkey: &str, _addr_format: &str) -> Result<String, String> { unimplemented!() }
 
     fn display_priv_key(&self) -> String { self.platform_utxo.display_priv_key() }
 
@@ -1217,6 +1217,10 @@ impl MmCoin for SlpToken {
     fn swap_contract_address(&self) -> Option<BytesJson> { None }
 
     fn mature_confirmations(&self) -> Option<u32> { self.platform_utxo.mature_confirmations() }
+
+    fn coin_protocol_info(&self) -> Option<Vec<u8>> { unimplemented!() }
+
+    fn is_coin_protocol_supported(&self, _info: &Option<Vec<u8>>) -> bool { unimplemented!() }
 }
 
 #[cfg(test)]

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -2295,6 +2295,17 @@ pub fn set_requires_notarization(coin: &UtxoCoinFields, requires_nota: bool) {
         .store(requires_nota, AtomicOrderding::Relaxed);
 }
 
+pub fn coin_protocol_info(coin: &UtxoCoinFields) -> Option<Vec<u8>> {
+    Some(rmp_serde::to_vec(&coin.my_address.addr_format).unwrap())
+}
+
+pub fn is_coin_protocol_supported(coin: &UtxoCoinFields, info: &Option<Vec<u8>>) -> bool {
+    match info {
+        Some(format) => rmp_serde::from_read_ref::<_, UtxoAddressFormat>(format).is_ok(),
+        None => !coin.my_address.addr_format.is_segwit(),
+    }
+}
+
 #[allow(clippy::needless_lifetimes)]
 pub async fn ordered_mature_unspents<'a, T>(
     coin: &'a T,

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -1350,24 +1350,6 @@ pub fn current_block(coin: &UtxoCoinFields) -> Box<dyn Future<Item = u64, Error 
     Box::new(coin.rpc_client.get_block_count().map_err(|e| ERRL!("{}", e)))
 }
 
-pub fn address_from_pubkey_str<T>(coin: &T, pubkey: &str, addr_format: &str) -> Result<String, String>
-where
-    T: AsRef<UtxoCoinFields> + UtxoCommonOps,
-{
-    let pubkey_bytes = try_s!(hex::decode(pubkey));
-    let addr_format = json::from_str::<UtxoAddressFormat>(addr_format)
-        .unwrap_or_else(|_| coin.as_ref().my_address.addr_format.clone());
-    let addr = try_s!(address_from_raw_pubkey(
-        &pubkey_bytes,
-        coin.as_ref().conf.pub_addr_prefix,
-        coin.as_ref().conf.pub_t_addr_prefix,
-        coin.as_ref().conf.checksum_type,
-        coin.as_ref().conf.bech32_hrp.clone(),
-        addr_format
-    ));
-    addr.display_address()
-}
-
 pub fn display_priv_key(coin: &UtxoCoinFields) -> String { format!("{}", coin.key_pair.private()) }
 
 pub fn min_tx_amount(coin: &UtxoCoinFields) -> BigDecimal {

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -1350,18 +1350,20 @@ pub fn current_block(coin: &UtxoCoinFields) -> Box<dyn Future<Item = u64, Error 
     Box::new(coin.rpc_client.get_block_count().map_err(|e| ERRL!("{}", e)))
 }
 
-pub fn address_from_pubkey_str<T>(coin: &T, pubkey: &str) -> Result<String, String>
+pub fn address_from_pubkey_str<T>(coin: &T, pubkey: &str, addr_format: &str) -> Result<String, String>
 where
     T: AsRef<UtxoCoinFields> + UtxoCommonOps,
 {
     let pubkey_bytes = try_s!(hex::decode(pubkey));
+    let addr_format = json::from_str::<UtxoAddressFormat>(addr_format)
+        .unwrap_or_else(|_| coin.as_ref().my_address.addr_format.clone());
     let addr = try_s!(address_from_raw_pubkey(
         &pubkey_bytes,
         coin.as_ref().conf.pub_addr_prefix,
         coin.as_ref().conf.pub_t_addr_prefix,
         coin.as_ref().conf.checksum_type,
         coin.as_ref().conf.bech32_hrp.clone(),
-        coin.as_ref().my_address.addr_format.clone()
+        addr_format
     ));
     addr.display_address()
 }

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -4,7 +4,6 @@ use crate::{CanRefundHtlc, CoinBalance, NegotiateSwapContractAddrErr, SwapOps, T
 use common::mm_metrics::MetricsArc;
 use common::mm_number::MmNumber;
 use futures::{FutureExt, TryFutureExt};
-use keys::AddressFormat;
 use serialization::CoinVariant;
 
 #[derive(Clone, Debug)]
@@ -504,14 +503,9 @@ impl MmCoin for UtxoStandardCoin {
 
     fn mature_confirmations(&self) -> Option<u32> { Some(self.utxo_arc.conf.mature_confirmations) }
 
-    fn coin_protocol_info(&self) -> Option<Vec<u8>> {
-        Some(serde_json::to_vec(&self.utxo_arc.my_address.addr_format).unwrap())
-    }
+    fn coin_protocol_info(&self) -> Option<Vec<u8>> { utxo_common::coin_protocol_info(&self.utxo_arc) }
 
     fn is_coin_protocol_supported(&self, info: &Option<Vec<u8>>) -> bool {
-        match info {
-            Some(format) => json::from_slice::<AddressFormat>(format).is_ok(),
-            None => !&self.utxo_arc.my_address.addr_format.is_segwit(),
-        }
+        utxo_common::is_coin_protocol_supported(&self.utxo_arc, info)
     }
 }

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -430,10 +430,6 @@ impl MarketCoinOps for UtxoStandardCoin {
         utxo_common::current_block(&self.utxo_arc)
     }
 
-    fn address_from_pubkey_str(&self, pubkey: &str, addr_format: &str) -> Result<String, String> {
-        utxo_common::address_from_pubkey_str(self, pubkey, addr_format)
-    }
-
     fn display_priv_key(&self) -> String { utxo_common::display_priv_key(&self.utxo_arc) }
 
     fn min_tx_amount(&self) -> BigDecimal { utxo_common::min_tx_amount(self.as_ref()) }

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -1249,7 +1249,13 @@ fn test_cashaddresses_in_tx_details_by_hash() {
     });
     let req = json!({
          "method": "electrum",
-         "servers": [{"url":"blackie.c3-soft.com:60001"}, {"url":"bch0.kister.net:51001"}, {"url":"testnet.imaginary.cash:50001"}],
+         "servers": [
+             {"url":"electroncash.de:50003"},
+             {"url":"tbch.loping.net:60001"},
+             {"url":"blackie.c3-soft.com:60001"},
+             {"url":"bch0.kister.net:51001"},
+             {"url":"testnet.imaginary.cash:50001"}
+         ],
     });
 
     let ctx = MmCtxBuilder::new().into_mm_arc();
@@ -1289,7 +1295,13 @@ fn test_address_from_str_with_cashaddress_activated() {
     });
     let req = json!({
          "method": "electrum",
-         "servers": [{"url":"blackie.c3-soft.com:60001"}, {"url":"bch0.kister.net:51001"}, {"url":"testnet.imaginary.cash:50001"}],
+         "servers": [
+             {"url":"electroncash.de:50003"},
+             {"url":"tbch.loping.net:60001"},
+             {"url":"blackie.c3-soft.com:60001"},
+             {"url":"bch0.kister.net:51001"},
+             {"url":"testnet.imaginary.cash:50001"}
+         ],
     });
 
     let ctx = MmCtxBuilder::new().into_mm_arc();
@@ -1317,7 +1329,13 @@ fn test_address_from_str_with_legacy_address_activated() {
     });
     let req = json!({
          "method": "electrum",
-         "servers": [{"url":"blackie.c3-soft.com:60001"}, {"url":"bch0.kister.net:51001"}, {"url":"testnet.imaginary.cash:50001"}],
+         "servers": [
+             {"url":"electroncash.de:50003"},
+             {"url":"tbch.loping.net:60001"},
+             {"url":"blackie.c3-soft.com:60001"},
+             {"url":"bch0.kister.net:51001"},
+             {"url":"testnet.imaginary.cash:50001"}
+         ],
     });
 
     let ctx = MmCtxBuilder::new().into_mm_arc();
@@ -2798,6 +2816,8 @@ fn test_tx_details_kmd_rewards_claimed_by_other() {
 #[test]
 fn test_tx_details_bch_no_rewards() {
     let electrum = electrum_client_for_test(&[
+        "electroncash.de:50003",
+        "tbch.loping.net:60001",
         "blackie.c3-soft.com:60001",
         "bch0.kister.net:51001",
         "testnet.imaginary.cash:50001",

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -186,8 +186,6 @@ impl MarketCoinOps for ZCoin {
         utxo_common::current_block(&self.utxo_arc)
     }
 
-    fn address_from_pubkey_str(&self, _pubkey: &str, _addr_format: &str) -> Result<String, String> { todo!() }
-
     fn display_priv_key(&self) -> String {
         encode_extended_spending_key(
             z_mainnet_constants::HRP_SAPLING_EXTENDED_SPENDING_KEY,

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -511,15 +511,10 @@ impl MmCoin for ZCoin {
 
     fn mature_confirmations(&self) -> Option<u32> { Some(self.utxo_arc.conf.mature_confirmations) }
 
-    fn coin_protocol_info(&self) -> Option<Vec<u8>> {
-        Some(serde_json::to_vec(&self.utxo_arc.my_address.addr_format).unwrap())
-    }
+    fn coin_protocol_info(&self) -> Option<Vec<u8>> { utxo_common::coin_protocol_info(&self.utxo_arc) }
 
     fn is_coin_protocol_supported(&self, info: &Option<Vec<u8>>) -> bool {
-        match info {
-            Some(format) => json::from_slice::<AddressFormat>(format).is_ok(),
-            None => !&self.utxo_arc.my_address.addr_format.is_segwit(),
-        }
+        utxo_common::is_coin_protocol_supported(&self.utxo_arc, info)
     }
 }
 

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -186,7 +186,7 @@ impl MarketCoinOps for ZCoin {
         utxo_common::current_block(&self.utxo_arc)
     }
 
-    fn address_from_pubkey_str(&self, _pubkey: &str) -> Result<String, String> { todo!() }
+    fn address_from_pubkey_str(&self, _pubkey: &str, _addr_format: &str) -> Result<String, String> { todo!() }
 
     fn display_priv_key(&self) -> String {
         encode_extended_spending_key(
@@ -510,6 +510,17 @@ impl MmCoin for ZCoin {
     fn swap_contract_address(&self) -> Option<BytesJson> { utxo_common::swap_contract_address() }
 
     fn mature_confirmations(&self) -> Option<u32> { Some(self.utxo_arc.conf.mature_confirmations) }
+
+    fn coin_protocol_info(&self) -> Option<Vec<u8>> {
+        Some(serde_json::to_vec(&self.utxo_arc.my_address.addr_format).unwrap())
+    }
+
+    fn is_coin_protocol_supported(&self, info: &Option<Vec<u8>>) -> bool {
+        match info {
+            Some(format) => json::from_slice::<AddressFormat>(format).is_ok(),
+            None => !&self.utxo_arc.my_address.addr_format.is_segwit(),
+        }
+    }
 }
 
 #[async_trait]

--- a/mm2src/lp_ordermatch/best_orders.rs
+++ b/mm2src/lp_ordermatch/best_orders.rs
@@ -1,4 +1,5 @@
-use super::{OrderbookItemWithProof, OrdermatchContext, OrdermatchRequest};
+use super::{addr_format_from_protocol_info, OrderbookItemWithProof, OrdermatchContext, OrdermatchRequest,
+            OrdermatchRequestVersion};
 use crate::mm2::lp_network::{request_any_relay, P2PRequest};
 use coins::{address_by_coin_conf_and_pubkey_str, coin_conf, is_wallet_only_conf, is_wallet_only_ticker};
 use common::log;
@@ -24,7 +25,7 @@ struct BestOrdersRequest {
     volume: MmNumber,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 struct BestOrdersRes {
     orders: HashMap<String, Vec<OrderbookItemWithProof>>,
 }
@@ -34,6 +35,7 @@ pub async fn process_best_orders_p2p_request(
     coin: String,
     action: BestOrdersAction,
     required_volume: BigRational,
+    version: OrdermatchRequestVersion,
 ) -> Result<Option<Vec<u8>>, String> {
     let ordermatch_ctx = OrdermatchContext::from_ctx(&ctx).expect("ordermatch_ctx must exist at this point");
     let orderbook = ordermatch_ctx.orderbook.lock().await;
@@ -63,6 +65,13 @@ pub async fn process_best_orders_p2p_request(
         for ordered in orders {
             match orderbook.order_set.get(&ordered.uuid) {
                 Some(o) => {
+                    if version == OrdermatchRequestVersion::V1
+                        && (o.base_protocol_info.is_some() || o.base_protocol_info.is_some())
+                    {
+                        log::debug!("Order {} address format is not supported by receiver", o.uuid);
+                        continue;
+                    }
+
                     let min_volume = match action {
                         BestOrdersAction::Buy => o.min_volume.clone(),
                         BestOrdersAction::Sell => &o.min_volume * &o.price,
@@ -109,6 +118,7 @@ pub async fn best_orders_rpc(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>,
         coin: req.coin,
         action: req.action,
         volume: req.volume.into(),
+        version: OrdermatchRequestVersion::V2,
     };
 
     let best_orders_res =
@@ -131,7 +141,11 @@ pub async fn best_orders_rpc(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>,
             }
             for order_w_proof in orders_w_proofs {
                 let order = order_w_proof.order;
-                let address = match address_by_coin_conf_and_pubkey_str(&coin, &coin_conf, &order.pubkey) {
+                let addr_format = match req.action {
+                    BestOrdersAction::Buy => addr_format_from_protocol_info(&order.rel_protocol_info),
+                    BestOrdersAction::Sell => addr_format_from_protocol_info(&order.base_protocol_info),
+                };
+                let address = match address_by_coin_conf_and_pubkey_str(&coin, &coin_conf, &order.pubkey, addr_format) {
                     Ok(a) => a,
                     Err(e) => {
                         log::error!("Error {} getting coin {} address from pubkey {}", e, coin, order.pubkey);
@@ -139,8 +153,8 @@ pub async fn best_orders_rpc(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>,
                     },
                 };
                 let entry = match req.action {
-                    BestOrdersAction::Buy => order.as_rpc_entry_ask(address, false),
-                    BestOrdersAction::Sell => order.as_rpc_entry_bid(address, false),
+                    BestOrdersAction::Buy => order.as_rpc_best_orders_buy(address, false),
+                    BestOrdersAction::Sell => order.as_rpc_best_orders_sell(address, false),
                 };
                 response.entry(coin.clone()).or_insert_with(Vec::new).push(entry);
             }
@@ -151,4 +165,93 @@ pub async fn best_orders_rpc(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>,
     Response::builder()
         .body(json::to_vec(&res).expect("Serialization failed"))
         .map_err(|e| ERRL!("{}", e))
+}
+
+#[cfg(test)]
+mod best_orders_tests {
+    use common::new_uuid;
+    use uuid::Uuid;
+
+    use super::super::OrderbookItem;
+    use super::*;
+
+    #[test]
+    fn check_best_orders_res_deserialize_to_old() {
+        type TrieProof = Vec<Vec<u8>>;
+        #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+        struct OrderbookItemOld {
+            pubkey: String,
+            base: String,
+            rel: String,
+            price: BigRational,
+            max_volume: BigRational,
+            min_volume: BigRational,
+            uuid: Uuid,
+            created_at: u64,
+        }
+
+        #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+        struct OrderbookItemWithProofOld {
+            order: OrderbookItemOld,
+            last_message_payload: Vec<u8>,
+            proof: TrieProof,
+        }
+
+        #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+        struct BestOrdersResOld {
+            orders: HashMap<String, Vec<OrderbookItemWithProofOld>>,
+        }
+
+        let uuid = new_uuid();
+
+        let mut best_order_res_new_orders = HashMap::new();
+        best_order_res_new_orders.insert(String::from("RICK"), vec![OrderbookItemWithProof {
+            order: OrderbookItem {
+                pubkey: "03c6a78589e18b482aea046975e6d0acbdea7bf7dbf04d9d5bd67fda917815e3ed".into(),
+                base: "tBTC".into(),
+                rel: "RICK".into(),
+                price: BigRational::from_integer(1.into()),
+                max_volume: BigRational::from_integer(2.into()),
+                min_volume: BigRational::from_integer(1.into()),
+                uuid,
+                created_at: 1626959392,
+                base_protocol_info: None,
+                rel_protocol_info: None,
+            },
+            last_message_payload: vec![],
+            proof: vec![],
+        }]);
+        let best_order_res_new = BestOrdersRes {
+            orders: best_order_res_new_orders,
+        };
+
+        let mut best_order_res_old_orders = HashMap::new();
+        best_order_res_old_orders.insert(String::from("RICK"), vec![OrderbookItemWithProofOld {
+            order: OrderbookItemOld {
+                pubkey: "03c6a78589e18b482aea046975e6d0acbdea7bf7dbf04d9d5bd67fda917815e3ed".into(),
+                base: "tBTC".into(),
+                rel: "RICK".into(),
+                price: BigRational::from_integer(1.into()),
+                max_volume: BigRational::from_integer(2.into()),
+                min_volume: BigRational::from_integer(1.into()),
+                uuid,
+                created_at: 1626959392,
+            },
+            last_message_payload: vec![],
+            proof: vec![],
+        }]);
+        let best_order_res_old = BestOrdersResOld {
+            orders: best_order_res_old_orders,
+        };
+
+        // new format should be deserialized to old when protocol_infos are None
+        let serialized = rmp_serde::to_vec(&best_order_res_new).unwrap();
+        let deserialized: BestOrdersResOld = rmp_serde::from_read_ref(serialized.as_slice()).unwrap();
+        assert_eq!(best_order_res_old, deserialized);
+
+        // old format should be deserialized to new with protocol_infos as None
+        let serialized = rmp_serde::to_vec(&best_order_res_old).unwrap();
+        let deserialized: BestOrdersRes = rmp_serde::from_read_ref(serialized.as_slice()).unwrap();
+        assert_eq!(best_order_res_new, deserialized);
+    }
 }

--- a/mm2src/lp_ordermatch/new_protocol.rs
+++ b/mm2src/lp_ordermatch/new_protocol.rs
@@ -108,7 +108,7 @@ mod compact_uuid {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Deserialize, PartialEq, Serialize)]
 pub struct MakerOrderCreated {
     pub uuid: CompactUuid,
     pub base: String,
@@ -122,6 +122,12 @@ pub struct MakerOrderCreated {
     /// This is timestamp of message
     pub timestamp: u64,
     pub pair_trie_root: H64,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_protocol_info: Option<Vec<u8>>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rel_protocol_info: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -254,6 +260,12 @@ pub struct TakerRequest {
     pub uuid: CompactUuid,
     pub match_by: MatchBy,
     pub conf_settings: OrderConfirmationsSettings,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_protocol_info: Option<Vec<u8>>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rel_protocol_info: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -265,6 +277,12 @@ pub struct MakerReserved {
     pub taker_order_uuid: CompactUuid,
     pub maker_order_uuid: CompactUuid,
     pub conf_settings: OrderConfirmationsSettings,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_protocol_info: Option<Vec<u8>>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rel_protocol_info: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -282,6 +300,7 @@ pub struct MakerConnected {
 #[cfg(test)]
 mod new_protocol_tests {
     use common::new_uuid;
+    use serde_json::{self as json};
 
     use super::*;
 
@@ -362,5 +381,38 @@ mod new_protocol_tests {
         let deserialized: MakerOrderUpdated = rmp_serde::from_read_ref(serialized.as_slice()).unwrap();
 
         assert_eq!(deserialized, v2);
+    }
+
+    #[test]
+    fn check_maker_order_created_serde() {
+        let uuid = Uuid::parse_str("fe5144b8-cb21-4bb8-b235-97211023abd6").unwrap();
+        let compact_uuid = CompactUuid::from(uuid);
+        let conf_settings = OrderConfirmationsSettings {
+            base_confs: 5,
+            base_nota: true,
+            rel_confs: 5,
+            rel_nota: true,
+        };
+        // New format should be serialized to old format when protocol_info is None
+        let maker_order_created_new = MakerOrderCreated {
+            uuid: compact_uuid,
+            base: "BASE".into(),
+            rel: "REL".into(),
+            price: BigRational::from_integer(2.into()),
+            max_volume: BigRational::from_integer(3.into()),
+            min_volume: BigRational::from_integer(1.into()),
+            created_at: 1626639468,
+            conf_settings,
+            timestamp: 1626639468,
+            pair_trie_root: H64::default(),
+            base_protocol_info: None,
+            rel_protocol_info: None,
+        };
+
+        let old_format_str = r#"{"uuid":[254,81,68,184,203,33,75,184,178,53,151,33,16,35,171,214],"base":"BASE","rel":"REL","price":[[1,[2]],[1,[1]]],"max_volume":[[1,[3]],[1,[1]]],"min_volume":[[1,[1]],[1,[1]]],"created_at":1626639468,"conf_settings":{"base_confs":5,"base_nota":true,"rel_confs":5,"rel_nota":true},"timestamp":1626639468,"pair_trie_root":[0,0,0,0,0,0,0,0]}"#;
+
+        let new_format_str = json::to_string(&maker_order_created_new).unwrap();
+
+        assert_eq!(new_format_str, old_format_str);
     }
 }

--- a/mm2src/lp_ordermatch/orderbook_rpc.rs
+++ b/mm2src/lp_ordermatch/orderbook_rpc.rs
@@ -1,4 +1,4 @@
-use super::{subscribe_to_orderbook_topic, OrdermatchContext, RpcOrderbookEntry};
+use super::{addr_format_from_protocol_info, subscribe_to_orderbook_topic, OrdermatchContext, RpcOrderbookEntry};
 use coins::{address_by_coin_conf_and_pubkey_str, coin_conf, is_wallet_only_conf};
 use common::{mm_ctx::MmArc, mm_number::MmNumber, now_ms};
 use http::Response;
@@ -106,11 +106,12 @@ pub async fn orderbook_rpc(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, S
                     "Orderbook::unordered contains {:?} uuid that is not in Orderbook::order_set",
                     uuid
                 ))?;
-
+                let address_format = addr_format_from_protocol_info(&ask.base_protocol_info);
                 let address = try_s!(address_by_coin_conf_and_pubkey_str(
                     &req.base,
                     &base_coin_conf,
-                    &ask.pubkey
+                    &ask.pubkey,
+                    address_format,
                 ));
                 let is_mine = my_pubsecp == ask.pubkey;
                 orderbook_entries.push(ask.as_rpc_entry_ask(address, is_mine));
@@ -131,10 +132,12 @@ pub async fn orderbook_rpc(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, S
                     "Orderbook::unordered contains {:?} uuid that is not in Orderbook::order_set",
                     uuid
                 ))?;
+                let address_format = addr_format_from_protocol_info(&bid.base_protocol_info);
                 let address = try_s!(address_by_coin_conf_and_pubkey_str(
                     &req.rel,
                     &rel_coin_conf,
-                    &bid.pubkey
+                    &bid.pubkey,
+                    address_format,
                 ));
                 let is_mine = my_pubsecp == bid.pubkey;
                 orderbook_entries.push(bid.as_rpc_entry_bid(address, is_mine));

--- a/mm2src/mm2_tests.rs
+++ b/mm2src/mm2_tests.rs
@@ -7520,7 +7520,7 @@ fn test_best_orders_segwit() {
     let best_orders = response.result.get("tBTC").unwrap();
     assert_eq!(1, best_orders.len());
     assert_eq!(best_orders[0].coin, "tBTC");
-    // assert_eq!(best_orders[0].address, tbtc_segwit_address);
+    assert_eq!(best_orders[0].address, tbtc_segwit_address);
 
     let rc = block_on(mm_alice.rpc(json! ({
         "userpass": mm_alice.userpass,

--- a/mm2src/mm2_tests.rs
+++ b/mm2src/mm2_tests.rs
@@ -3979,7 +3979,13 @@ fn test_withdraw_cashaddresses() {
         "userpass": mm.userpass,
         "method": "electrum",
         "coin": "BCH",
-        "servers": [{"url":"blackie.c3-soft.com:60001"}, {"url":"bch0.kister.net:51001"}, {"url":"testnet.imaginary.cash:50001"}],
+        "servers": [
+            {"url":"electroncash.de:50003"},
+            {"url":"tbch.loping.net:60001"},
+            {"url":"blackie.c3-soft.com:60001"},
+            {"url":"bch0.kister.net:51001"},
+            {"url":"testnet.imaginary.cash:50001"}
+        ],
         "mm2": 1,
     })))
     .unwrap();
@@ -4099,7 +4105,13 @@ fn test_withdraw_cashaddresses() {
         "userpass": mm.userpass,
         "method": "electrum",
         "coin": "BCH",
-        "servers": [{"url":"blackie.c3-soft.com:60001"}, {"url":"bch0.kister.net:51001"}, {"url":"testnet.imaginary.cash:50001"}],
+        "servers": [
+            {"url":"electroncash.de:50003"},
+            {"url":"tbch.loping.net:60001"},
+            {"url":"blackie.c3-soft.com:60001"},
+            {"url":"bch0.kister.net:51001"},
+            {"url":"testnet.imaginary.cash:50001"}
+        ],
         "address_format":{"format":"standard"},
         "mm2": 1,
     })))
@@ -4189,7 +4201,13 @@ fn test_withdraw_to_different_cashaddress_network_should_fail() {
         "userpass": mm.userpass,
         "method": "electrum",
         "coin": "BCH",
-        "servers": [{"url":"blackie.c3-soft.com:60001"}, {"url":"bch0.kister.net:51001"}, {"url":"testnet.imaginary.cash:50001"}],
+        "servers": [
+            {"url":"electroncash.de:50003"},
+            {"url":"tbch.loping.net:60001"},
+            {"url":"blackie.c3-soft.com:60001"},
+            {"url":"bch0.kister.net:51001"},
+            {"url":"testnet.imaginary.cash:50001"}
+        ],
         "mm2": 1,
     })))
     .unwrap();
@@ -4248,13 +4266,20 @@ fn test_common_cashaddresses() {
 
     // Enable BCH electrum client with tx_history loop.
     // Enable RICK electrum client with tx_history loop.
-    let electrum = block_on(mm.rpc (json! ({
+    let electrum = block_on(mm.rpc(json! ({
         "userpass": mm.userpass,
         "method": "electrum",
         "coin": "BCH",
-        "servers": [{"url":"blackie.c3-soft.com:60001"}, {"url":"bch0.kister.net:51001"}, {"url":"testnet.imaginary.cash:50001"}],
+        "servers": [
+            {"url":"electroncash.de:50003"},
+            {"url":"tbch.loping.net:60001"},
+            {"url":"blackie.c3-soft.com:60001"},
+            {"url":"bch0.kister.net:51001"},
+            {"url":"testnet.imaginary.cash:50001"}
+        ],
         "mm2": 1,
-    }))).unwrap();
+    })))
+    .unwrap();
 
     assert_eq!(
         electrum.0,
@@ -4332,6 +4357,8 @@ fn test_convert_utxo_address() {
     log!({ "log path: {}", mm.log_path.display() });
 
     let _electrum = block_on(enable_electrum(&mm, "BCH", false, &[
+        "electroncash.de:50003",
+        "tbch.loping.net:60001",
         "blackie.c3-soft.com:60001",
         "bch0.kister.net:51001",
         "testnet.imaginary.cash:50001",

--- a/mm2src/mm2_tests.rs
+++ b/mm2src/mm2_tests.rs
@@ -7329,6 +7329,191 @@ fn test_best_orders_filter_response() {
     block_on(mm_alice.stop()).unwrap();
 }
 
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_best_orders_segwit() {
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
+
+    let bob_coins_config = json!([
+        {"coin":"RICK","asset":"RICK","rpcport":8923,"txversion":4,"overwintered":1,"protocol":{"type":"UTXO"}},
+        {"coin":"tBTC","name":"tbitcoin","fname":"tBitcoin","rpcport":18332,"pubtype":111,"p2shtype":196,"wiftype":239,"segwit":true,"bech32_hrp":"tb","txfee":0,"estimate_fee_mode":"ECONOMICAL","mm2":1,"required_confirmations":0,"protocol":{"type":"UTXO"}}
+    ]);
+
+    let alice_coins_config = json!([
+        {"coin":"RICK","asset":"RICK","rpcport":8923,"txversion":4,"overwintered":1,"protocol":{"type":"UTXO"}},
+        {"coin":"tBTC","name":"tbitcoin","fname":"tBitcoin","rpcport":18332,"pubtype":111,"p2shtype":196,"wiftype":239,"segwit":true,"bech32_hrp":"tb","txfee":0,"estimate_fee_mode":"ECONOMICAL","mm2":1,"required_confirmations":0,"protocol":{"type":"UTXO"}}
+    ]);
+
+    let mut mm_bob = MarketMakerIt::start(
+        json! ({
+            "gui": "nogui",
+            "netid": 9998,
+            "myipaddr": env::var ("BOB_TRADE_IP") .ok(),
+            "rpcip": env::var ("BOB_TRADE_IP") .ok(),
+            "canbind": env::var ("BOB_TRADE_PORT") .ok().map (|s| s.parse::<i64>().unwrap()),
+            "passphrase": bob_passphrase,
+            "coins": bob_coins_config,
+            "rpc_password": "pass",
+            "i_am_seed": true,
+        }),
+        "pass".into(),
+        local_start!("bob"),
+    )
+    .unwrap();
+    let (_bob_dump_log, _bob_dump_dashboard) = mm_bob.mm_dump();
+    log!({"Bob log path: {}", mm_bob.log_path.display()});
+
+    // Enable coins on Bob side. Print the replies in case we need the "address".
+    let electrum = block_on(mm_bob.rpc(json!({
+        "userpass": "pass",
+        "method": "electrum",
+        "coin": "tBTC",
+        "servers": [{"url":"electrum1.cipig.net:10068"},{"url":"electrum2.cipig.net:10068"},{"url":"electrum3.cipig.net:10068"}],
+        "address_format":{"format":"segwit"},
+        "mm2": 1,
+    }))).unwrap();
+    assert_eq!(
+        electrum.0,
+        StatusCode::OK,
+        "RPC «electrum» failed with {} {}",
+        electrum.0,
+        electrum.1
+    );
+    log!({ "enable tBTC: {:?}", electrum });
+    let enable_tbtc_res: Json = json::from_str(&electrum.1).unwrap();
+    let tbtc_segwit_address = enable_tbtc_res["address"].as_str().unwrap();
+
+    let electrum = block_on(mm_bob.rpc(json!({
+        "userpass": "pass",
+        "method": "electrum",
+        "coin": "RICK",
+        "servers": [{"url":"electrum1.cipig.net:10017"},{"url":"electrum2.cipig.net:10017"},{"url":"electrum3.cipig.net:10017"}],
+        "mm2": 1,
+    }))).unwrap();
+    assert_eq!(
+        electrum.0,
+        StatusCode::OK,
+        "RPC «electrum» failed with {} {}",
+        electrum.0,
+        electrum.1
+    );
+    log!({ "enable RICK: {:?}", electrum });
+    let enable_rick_res: Json = json::from_str(&electrum.1).unwrap();
+    let rick_address = enable_rick_res["address"].as_str().unwrap();
+
+    // issue sell request on Bob side by setting base/rel price
+    log!("Issue bob sell requests");
+
+    let bob_orders = [
+        // (base, rel, price, volume, min_volume)
+        ("tBTC", "RICK", "0.7", "0.0002", Some("0.00015")),
+        ("RICK", "tBTC", "0.7", "0.0002", Some("0.00015")),
+    ];
+    for (base, rel, price, volume, min_volume) in bob_orders.iter() {
+        let rc = block_on(mm_bob.rpc(json! ({
+            "userpass": mm_bob.userpass,
+            "method": "setprice",
+            "base": base,
+            "rel": rel,
+            "price": price,
+            "volume": volume,
+            "min_volume": min_volume.unwrap_or("0.00777"),
+            "cancel_previous": false,
+        })))
+        .unwrap();
+        assert!(rc.0.is_success(), "!setprice: {}", rc.1);
+    }
+
+    let mm_alice = MarketMakerIt::start(
+        json! ({
+            "gui": "nogui",
+            "netid": 9998,
+            "myipaddr": env::var ("ALICE_TRADE_IP") .ok(),
+            "rpcip": env::var ("ALICE_TRADE_IP") .ok(),
+            "passphrase": "alice passphrase",
+            "coins": alice_coins_config,
+            "seednodes": [fomat!((mm_bob.ip))],
+            "rpc_password": "pass",
+        }),
+        "pass".into(),
+        local_start!("alice"),
+    )
+    .unwrap();
+
+    let (_alice_dump_log, _alice_dump_dashboard) = mm_alice.mm_dump();
+    log!({ "Alice log path: {}", mm_alice.log_path.display() });
+
+    block_on(mm_bob.wait_for_log(22., |log| {
+        log.contains("DEBUG Handling IncludedTorelaysMesh message for peer")
+    }))
+    .unwrap();
+
+    // checking buy and sell best_orders against ("tBTC", "RICK", "0.7", "0.0002", Some("0.00015"))
+    let rc = block_on(mm_alice.rpc(json! ({
+        "userpass": mm_alice.userpass,
+        "method": "best_orders",
+        "coin": "tBTC",
+        "action": "buy",
+        "volume": "0.0002",
+    })))
+    .unwrap();
+    assert!(rc.0.is_success(), "!best_orders: {}", rc.1);
+    let response: BestOrdersResponse = json::from_str(&rc.1).unwrap();
+    let best_orders = response.result.get("RICK").unwrap();
+    assert_eq!(1, best_orders.len());
+    assert_eq!(best_orders[0].coin, "RICK");
+    assert_eq!(best_orders[0].address, rick_address);
+
+    let rc = block_on(mm_alice.rpc(json! ({
+        "userpass": mm_alice.userpass,
+        "method": "best_orders",
+        "coin": "RICK",
+        "action": "sell",
+        "volume": "0.0002",
+    })))
+    .unwrap();
+    assert!(rc.0.is_success(), "!best_orders: {}", rc.1);
+    let response: BestOrdersResponse = json::from_str(&rc.1).unwrap();
+    let best_orders = response.result.get("tBTC").unwrap();
+    assert_eq!(1, best_orders.len());
+    assert_eq!(best_orders[0].coin, "tBTC");
+    assert_eq!(best_orders[0].address, tbtc_segwit_address);
+
+    // checking buy and sell best_orders against ("RICK", "tBTC", "0.7", "0.0002", Some("0.00015"))
+    let rc = block_on(mm_alice.rpc(json! ({
+        "userpass": mm_alice.userpass,
+        "method": "best_orders",
+        "coin": "RICK",
+        "action": "buy",
+        "volume": "0.0002",
+    })))
+    .unwrap();
+    assert!(rc.0.is_success(), "!best_orders: {}", rc.1);
+    let response: BestOrdersResponse = json::from_str(&rc.1).unwrap();
+    let best_orders = response.result.get("tBTC").unwrap();
+    assert_eq!(1, best_orders.len());
+    assert_eq!(best_orders[0].coin, "tBTC");
+    // assert_eq!(best_orders[0].address, tbtc_segwit_address);
+
+    let rc = block_on(mm_alice.rpc(json! ({
+        "userpass": mm_alice.userpass,
+        "method": "best_orders",
+        "coin": "tBTC",
+        "action": "sell",
+        "volume": "0.0002",
+    })))
+    .unwrap();
+    assert!(rc.0.is_success(), "!best_orders: {}", rc.1);
+    let response: BestOrdersResponse = json::from_str(&rc.1).unwrap();
+    let best_orders = response.result.get("RICK").unwrap();
+    assert_eq!(1, best_orders.len());
+    assert_eq!(best_orders[0].coin, "RICK");
+    assert_eq!(best_orders[0].address, rick_address);
+
+    block_on(mm_bob.stop()).unwrap();
+    block_on(mm_alice.stop()).unwrap();
+}
+
 fn request_and_check_orderbook_depth(mm_alice: &MarketMakerIt) {
     let rc = block_on(mm_alice.rpc(json! ({
         "userpass": mm_alice.userpass,

--- a/mm2src/mm2_tests/structs.rs
+++ b/mm2src/mm2_tests/structs.rs
@@ -119,12 +119,6 @@ pub struct TakerRequest {
     dest_pub_key: H256Json,
     match_by: MatchBy,
     conf_settings: OrderConfirmationsSettings,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub base_protocol_info: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rel_protocol_info: Option<Vec<u8>>,
 }
 
 #[derive(Deserialize)]
@@ -142,12 +136,6 @@ pub struct MakerReserved {
     sender_pubkey: H256Json,
     dest_pub_key: H256Json,
     conf_settings: OrderConfirmationsSettings,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub base_protocol_info: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rel_protocol_info: Option<Vec<u8>>,
 }
 
 #[derive(Deserialize)]

--- a/mm2src/mm2_tests/structs.rs
+++ b/mm2src/mm2_tests/structs.rs
@@ -119,6 +119,12 @@ pub struct TakerRequest {
     dest_pub_key: H256Json,
     match_by: MatchBy,
     conf_settings: OrderConfirmationsSettings,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_protocol_info: Option<Vec<u8>>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rel_protocol_info: Option<Vec<u8>>,
 }
 
 #[derive(Deserialize)]
@@ -136,6 +142,12 @@ pub struct MakerReserved {
     sender_pubkey: H256Json,
     dest_pub_key: H256Json,
     conf_settings: OrderConfirmationsSettings,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_protocol_info: Option<Vec<u8>>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rel_protocol_info: Option<Vec<u8>>,
 }
 
 #[derive(Deserialize)]

--- a/mm2src/ordermatch_tests.rs
+++ b/mm2src/ordermatch_tests.rs
@@ -8,6 +8,7 @@ use common::{block_on,
              mm_ctx::{MmArc, MmCtx, MmCtxBuilder},
              privkey::key_pair_from_seed};
 use futures::{channel::mpsc, lock::Mutex as AsyncMutex, StreamExt};
+use keys::AddressFormat;
 use mm2_libp2p::atomicdex_behaviour::AdexBehaviourCmd;
 use mm2_libp2p::{decode_message, PeerId};
 use mocktopus::mocking::*;
@@ -1458,6 +1459,38 @@ fn make_random_orders(pubkey: String, _secret: &[u8; 32], base: String, rel: Str
     orders
 }
 
+fn make_random_orders_segwit(
+    pubkey: String,
+    _secret: &[u8; 32],
+    base: String,
+    rel: String,
+    n: usize,
+) -> Vec<OrderbookItem> {
+    let mut rng = rand::thread_rng();
+    let mut orders = Vec::with_capacity(n);
+    for _i in 0..n {
+        let numer: u64 = rng.gen_range(2000, 10000000);
+        let order = new_protocol::MakerOrderCreated {
+            uuid: Uuid::new_v4().into(),
+            base: base.clone(),
+            rel: rel.clone(),
+            price: BigRational::new(numer.into(), 1000000.into()),
+            max_volume: BigRational::from_integer(1.into()),
+            min_volume: BigRational::from_integer(0.into()),
+            conf_settings: OrderConfirmationsSettings::default(),
+            created_at: now_ms() / 1000,
+            timestamp: now_ms() / 1000,
+            pair_trie_root: H64::default(),
+            base_protocol_info: Some(rmp_serde::to_vec(&AddressFormat::Segwit).unwrap()),
+            rel_protocol_info: Some(rmp_serde::to_vec(&AddressFormat::Standard).unwrap()),
+        };
+
+        orders.push((order, pubkey.clone()).into());
+    }
+
+    orders
+}
+
 fn pubkey_and_secret_for_test(passphrase: &str) -> (String, [u8; 32]) {
     let key_pair = key_pair_from_seed(passphrase).unwrap();
     let pubkey = hex::encode(&**key_pair.public());
@@ -1525,6 +1558,76 @@ fn test_process_get_orderbook_request() {
         ctx.clone(),
         "RICK".into(),
         "MORTY".into(),
+        OrdermatchRequestVersion::V2,
+    ))
+    .unwrap()
+    .unwrap();
+
+    let orderbook = decode_message::<GetOrderbookRes>(&encoded).unwrap();
+    for (pubkey, item) in orderbook.pubkey_orders {
+        let expected = orders_by_pubkeys
+            .get(&pubkey)
+            .expect(&format!("!best_orders_by_pubkeys is expected to contain {:?}", pubkey));
+
+        let mut actual: Vec<OrderbookItem> = item.orders.iter().map(|(_uuid, order)| order.clone()).collect();
+        actual.sort_unstable_by(|x, y| x.uuid.cmp(&y.uuid));
+        log!([pubkey]"-"[actual.len()]);
+        assert_eq!(actual, *expected);
+    }
+}
+
+#[test]
+fn test_process_get_orderbook_request_with_old_nodes() {
+    const ORDERS_NUMBER: usize = 10;
+
+    let (ctx, _pubkey, _secret) = make_ctx_for_tests();
+    let (pubkey1, secret1) = pubkey_and_secret_for_test("passphrase-1");
+    let (pubkey2, secret2) = pubkey_and_secret_for_test("passphrase-2");
+    let (pubkey3, secret3) = pubkey_and_secret_for_test("passphrase-3");
+
+    let mut pubkey1_orders =
+        make_random_orders(pubkey1.clone(), &secret1, "RICK".into(), "MORTY".into(), ORDERS_NUMBER);
+    // orders that use segwit which should be removed by process_get_orderbook_request when orderbook is requested from old nodes
+    let mut pubkey2_orders =
+        make_random_orders_segwit(pubkey2.clone(), &secret2, "MORTY".into(), "RICK".into(), ORDERS_NUMBER);
+    let mut pubkey3_orders =
+        make_random_orders(pubkey3.clone(), &secret3, "RICK".into(), "MORTY".into(), ORDERS_NUMBER);
+    pubkey3_orders.extend_from_slice(&make_random_orders(
+        pubkey3.clone(),
+        &secret3,
+        "MORTY".into(),
+        "RICK".into(),
+        ORDERS_NUMBER,
+    ));
+
+    pubkey1_orders.sort_unstable_by(|x, y| x.uuid.cmp(&y.uuid));
+    pubkey2_orders.sort_unstable_by(|x, y| x.uuid.cmp(&y.uuid));
+    pubkey3_orders.sort_unstable_by(|x, y| x.uuid.cmp(&y.uuid));
+
+    // will be use for expected orders which should not have pubkey2_orders in them
+    let mut orders_by_pubkeys = HashMap::new();
+    orders_by_pubkeys.insert(pubkey1, pubkey1_orders);
+    orders_by_pubkeys.insert(pubkey3, pubkey3_orders);
+
+    let ordermatch_ctx = Arc::new(OrdermatchContext::default());
+    let ordermatch_ctx_clone = ordermatch_ctx.clone();
+    OrdermatchContext::from_ctx.mock_safe(move |_| MockResult::Return(Ok(ordermatch_ctx_clone.clone())));
+
+    let mut orderbook = block_on(ordermatch_ctx.orderbook.lock());
+
+    for order in orders_by_pubkeys.iter().map(|(_pubkey, orders)| orders).flatten() {
+        orderbook.insert_or_update_order_update_trie(order.clone());
+    }
+
+    // avoid dead lock on orderbook as process_get_orderbook_request also acquires it
+    drop(orderbook);
+
+    // using OrdermatchRequestVersion::V1 mimicking old nodes
+    let encoded = block_on(process_get_orderbook_request(
+        ctx.clone(),
+        "RICK".into(),
+        "MORTY".into(),
+        OrdermatchRequestVersion::V1,
     ))
     .unwrap()
     .unwrap();
@@ -1571,6 +1674,7 @@ fn test_process_get_orderbook_request_limit() {
         ctx.clone(),
         "RICK".into(),
         "MORTY".into(),
+        OrdermatchRequestVersion::V2,
     ))
     .err()
     .expect("Expected an error");
@@ -1616,6 +1720,7 @@ fn test_request_and_fill_orderbook() {
     let expected_request = P2PRequest::Ordermatch(OrdermatchRequest::GetOrderbook {
         base: "RICK".into(),
         rel: "MORTY".into(),
+        version: OrdermatchRequestVersion::V2,
     });
 
     let orders = expected_orders.clone();

--- a/mm2src/ordermatch_tests.rs
+++ b/mm2src/ordermatch_tests.rs
@@ -45,6 +45,8 @@ fn test_match_maker_order_and_taker_request() {
         action: TakerAction::Buy,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let actual = maker.match_with_request(&request);
@@ -78,6 +80,8 @@ fn test_match_maker_order_and_taker_request() {
         action: TakerAction::Buy,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let actual = maker.match_with_request(&request);
@@ -111,6 +115,8 @@ fn test_match_maker_order_and_taker_request() {
         action: TakerAction::Buy,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let actual = maker.match_with_request(&request);
@@ -144,6 +150,8 @@ fn test_match_maker_order_and_taker_request() {
         action: TakerAction::Sell,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let actual = maker.match_with_request(&request);
@@ -177,6 +185,8 @@ fn test_match_maker_order_and_taker_request() {
         action: TakerAction::Sell,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let actual = maker.match_with_request(&request);
@@ -210,6 +220,8 @@ fn test_match_maker_order_and_taker_request() {
         action: TakerAction::Sell,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let actual = maker.match_with_request(&request);
@@ -276,6 +288,8 @@ fn test_maker_order_available_amount() {
             action: TakerAction::Buy,
             match_by: MatchBy::Any,
             conf_settings: None,
+            base_protocol_info: None,
+            rel_protocol_info: None,
         },
         reserved: MakerReserved {
             base: "BASE".into(),
@@ -287,6 +301,8 @@ fn test_maker_order_available_amount() {
             maker_order_uuid: Uuid::new_v4(),
             taker_order_uuid: Uuid::new_v4(),
             conf_settings: None,
+            base_protocol_info: None,
+            rel_protocol_info: None,
         },
         connect: None,
         connected: None,
@@ -304,6 +320,8 @@ fn test_maker_order_available_amount() {
             action: TakerAction::Buy,
             match_by: MatchBy::Any,
             conf_settings: None,
+            base_protocol_info: None,
+            rel_protocol_info: None,
         },
         reserved: MakerReserved {
             base: "BASE".into(),
@@ -315,6 +333,8 @@ fn test_maker_order_available_amount() {
             maker_order_uuid: Uuid::new_v4(),
             taker_order_uuid: Uuid::new_v4(),
             conf_settings: None,
+            base_protocol_info: None,
+            rel_protocol_info: None,
         },
         connect: None,
         connected: None,
@@ -341,6 +361,8 @@ fn test_taker_match_reserved() {
         action: TakerAction::Buy,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let order = TakerOrder {
@@ -363,6 +385,8 @@ fn test_taker_match_reserved() {
         maker_order_uuid: Uuid::new_v4(),
         taker_order_uuid: uuid,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -378,6 +402,8 @@ fn test_taker_match_reserved() {
         action: TakerAction::Sell,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let order = TakerOrder {
@@ -400,6 +426,8 @@ fn test_taker_match_reserved() {
         maker_order_uuid: Uuid::new_v4(),
         taker_order_uuid: uuid,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -415,6 +443,8 @@ fn test_taker_match_reserved() {
         action: TakerAction::Sell,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let order = TakerOrder {
@@ -437,6 +467,8 @@ fn test_taker_match_reserved() {
         maker_order_uuid: Uuid::new_v4(),
         taker_order_uuid: uuid,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -452,6 +484,8 @@ fn test_taker_match_reserved() {
         action: TakerAction::Sell,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let order = TakerOrder {
@@ -474,6 +508,8 @@ fn test_taker_match_reserved() {
         maker_order_uuid: Uuid::new_v4(),
         taker_order_uuid: uuid,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -489,6 +525,8 @@ fn test_taker_match_reserved() {
         action: TakerAction::Buy,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let order = TakerOrder {
@@ -511,6 +549,8 @@ fn test_taker_match_reserved() {
         maker_order_uuid: Uuid::new_v4(),
         taker_order_uuid: uuid,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -526,6 +566,8 @@ fn test_taker_match_reserved() {
         action: TakerAction::Buy,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let order = TakerOrder {
@@ -548,6 +590,8 @@ fn test_taker_match_reserved() {
         maker_order_uuid: Uuid::new_v4(),
         taker_order_uuid: uuid,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -563,6 +607,8 @@ fn test_taker_match_reserved() {
         action: TakerAction::Buy,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let order = TakerOrder {
@@ -585,6 +631,8 @@ fn test_taker_match_reserved() {
         maker_order_uuid: Uuid::new_v4(),
         taker_order_uuid: uuid,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -600,6 +648,8 @@ fn test_taker_match_reserved() {
         action: TakerAction::Buy,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let order = TakerOrder {
@@ -622,6 +672,8 @@ fn test_taker_match_reserved() {
         maker_order_uuid: Uuid::new_v4(),
         taker_order_uuid: uuid,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -641,6 +693,8 @@ fn test_taker_match_reserved() {
             dest_pub_key: H256Json::default(),
             match_by: MatchBy::Any,
             conf_settings: None,
+            base_protocol_info: None,
+            rel_protocol_info: None,
         },
         matches: HashMap::new(),
         order_type: OrderType::GoodTillCancelled,
@@ -659,6 +713,8 @@ fn test_taker_match_reserved() {
         sender_pubkey: H256Json::default(),
         dest_pub_key: H256Json::default(),
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
@@ -677,6 +733,8 @@ fn test_taker_order_cancellable() {
         action: TakerAction::Buy,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let order = TakerOrder {
@@ -702,6 +760,8 @@ fn test_taker_order_cancellable() {
         action: TakerAction::Buy,
         match_by: MatchBy::Any,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let mut order = TakerOrder {
@@ -726,6 +786,8 @@ fn test_taker_order_cancellable() {
             maker_order_uuid: Uuid::new_v4(),
             taker_order_uuid: Uuid::new_v4(),
             conf_settings: None,
+            base_protocol_info: None,
+            rel_protocol_info: None,
         },
         connect: TakerConnect {
             sender_pubkey: H256Json::default(),
@@ -807,6 +869,8 @@ fn prepare_for_cancel_by(ctx: &MmArc) -> mpsc::Receiver<AdexBehaviourCmd> {
             sender_pubkey: H256Json::default(),
             match_by: MatchBy::Any,
             conf_settings: None,
+            base_protocol_info: None,
+            rel_protocol_info: None,
         },
         order_type: OrderType::GoodTillCancelled,
         min_volume: 0.into(),
@@ -901,6 +965,8 @@ fn test_taker_order_match_by() {
         action: TakerAction::Buy,
         match_by: MatchBy::Orders(not_matching_uuids),
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     let mut order = TakerOrder {
@@ -923,6 +989,8 @@ fn test_taker_order_match_by() {
         maker_order_uuid: Uuid::new_v4(),
         taker_order_uuid: uuid,
         conf_settings: None,
+        base_protocol_info: None,
+        rel_protocol_info: None,
     };
 
     assert_eq!(MatchReservedResult::NotMatched, order.match_reserved(&reserved));
@@ -1380,6 +1448,8 @@ fn make_random_orders(pubkey: String, _secret: &[u8; 32], base: String, rel: Str
             created_at: now_ms() / 1000,
             timestamp: now_ms() / 1000,
             pair_trie_root: H64::default(),
+            base_protocol_info: None,
+            rel_protocol_info: None,
         };
 
         orders.push((order, pubkey.clone()).into());


### PR DESCRIPTION
This PR prevents order matching between new nodes and older nodes for coins that segwit is enabled for in the newer nodes.