### PR TITLE
Add signature_version to coin configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4597,6 +4597,7 @@ dependencies = [
  "keys",
  "log 0.4.11",
  "primitives",
+ "serde",
  "serialization",
 ]
 

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -1109,11 +1109,12 @@ impl<'a> UtxoConfBuilder<'a> {
     }
 
     fn signature_version(&self) -> SignatureVersion {
-        if self.ticker == "BCH" || self.fork_id() != 0 {
+        let default_signature_version = if self.ticker == "BCH" || self.fork_id() != 0 {
             SignatureVersion::ForkId
         } else {
             SignatureVersion::Base
-        }
+        };
+        json::from_value(self.conf["signature_version"].clone()).unwrap_or(default_signature_version)
     }
 
     fn fork_id(&self) -> u32 {

--- a/mm2src/mm2_bitcoin/script/Cargo.toml
+++ b/mm2src/mm2_bitcoin/script/Cargo.toml
@@ -8,6 +8,7 @@ bitcrypto = { path = "../crypto" }
 chain = { path = "../chain" }
 keys = { path = "../keys" }
 primitives = { path = "../primitives" }
+serde = "1.0"
 serialization = { path = "../serialization" }
 log = "0.4"
 blake2b_simd = "0.5"

--- a/mm2src/mm2_bitcoin/script/src/lib.rs
+++ b/mm2src/mm2_bitcoin/script/src/lib.rs
@@ -4,6 +4,7 @@ extern crate chain;
 extern crate keys;
 extern crate log;
 extern crate primitives;
+extern crate serde;
 extern crate serialization as ser;
 
 mod builder;

--- a/mm2src/mm2_bitcoin/script/src/sign.rs
+++ b/mm2src/mm2_bitcoin/script/src/sign.rs
@@ -8,6 +8,7 @@ use crypto::{dhash256, sha256};
 use hash::{H256, H512};
 use keys::KeyPair;
 use ser::Stream;
+use serde::Deserialize;
 use {Builder, Script};
 
 const ZCASH_PREVOUTS_HASH_PERSONALIZATION: &[u8] = b"ZcashPrevoutHash";
@@ -18,10 +19,13 @@ const ZCASH_SHIELDED_SPENDS_HASH_PERSONALIZATION: &[u8] = b"ZcashSSpendsHash";
 const ZCASH_SHIELDED_OUTPUTS_HASH_PERSONALIZATION: &[u8] = b"ZcashSOutputHash";
 const ZCASH_SIG_HASH_PERSONALIZATION: &[u8] = b"ZcashSigHash";
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, Deserialize)]
 pub enum SignatureVersion {
+    #[serde(rename = "base")]
     Base,
+    #[serde(rename = "witness_v0")]
     WitnessV0,
+    #[serde(rename = "fork_id")]
     ForkId,
 }
 


### PR DESCRIPTION
as found by @cipig [LCC](https://github.com/KomodoPlatform/coins/blob/c8c728ba21c6f8ac78cbd67bab3ee89d3d33643c/coins#L1988) withdraws are not working after this [PR](https://github.com/KomodoPlatform/atomicDEX-API/pull/1040), as a fix a new field `"signature_version": "base"` should be added to [LCC](https://github.com/KomodoPlatform/coins/blob/c8c728ba21c6f8ac78cbd67bab3ee89d3d33643c/coins#L1988) config. for any coin that needs a default `signature_version`, this field can be used with the parameters `base`, `witness_v0` or `fork_id`. @cipig can you please test if this is working now after adding this new field to your [LCC](https://github.com/KomodoPlatform/coins/blob/c8c728ba21c6f8ac78cbd67bab3ee89d3d33643c/coins#L1988) config? 