### PR TITLE
update_maker_order memory leak fix

### DIFF
--- a/mm2src/lp_ordermatch.rs
+++ b/mm2src/lp_ordermatch.rs
@@ -2211,6 +2211,7 @@ impl Orderbook {
         }
 
         if prev_root != H64::default() {
+            // log::info!("UUID: {}, prev_root {:?} new_root {:?}.",order.uuid, prev_root, *pair_root);
             let history = pair_history_mut(&mut pubkey_state.order_pairs_trie_state_history, &alb_ordered);
             history.insert_new_diff(prev_root, TrieDiff {
                 delta: vec![(order.uuid, Some(order.clone()))],
@@ -3976,9 +3977,9 @@ pub async fn update_maker_order(ctx: MmArc, req: Json) -> Result<Response<Vec<u8
                 return ERR!("Order {} is being matched now, can't update", req.uuid);
             }
 
-            let new_change = HistoricalOrder::build(&update_msg, order);
+            // let new_change = HistoricalOrder::build(&update_msg, order);
             order.apply_updated(&update_msg);
-            order.changes_history.get_or_insert(Vec::new()).push(new_change);
+            // order.changes_history.get_or_insert(Vec::new()).push(new_change);
             save_maker_order_on_update(ctx.clone(), order).await;
             update_msg.with_new_max_volume((new_volume - reserved_amount).into());
             (MakerOrderForRpc::from(&*order), order.base.as_str(), order.rel.as_str())
@@ -4393,37 +4394,37 @@ struct HistoricalOrder {
     conf_settings: Option<OrderConfirmationsSettings>,
 }
 
-impl HistoricalOrder {
-    fn build(new_order: &new_protocol::MakerOrderUpdated, old_order: &MakerOrder) -> HistoricalOrder {
-        HistoricalOrder {
-            max_base_vol: if new_order.new_max_volume().is_some() {
-                Some(old_order.max_base_vol.clone())
-            } else {
-                None
-            },
-            min_base_vol: if new_order.new_min_volume().is_some() {
-                Some(old_order.min_base_vol.clone())
-            } else {
-                None
-            },
-            price: if new_order.new_price().is_some() {
-                Some(old_order.price.clone())
-            } else {
-                None
-            },
-            updated_at: old_order.updated_at,
-            conf_settings: if let Some(settings) = new_order.new_conf_settings() {
-                if Some(settings) == old_order.conf_settings {
-                    None
-                } else {
-                    old_order.conf_settings
-                }
-            } else {
-                None
-            },
-        }
-    }
-}
+// impl HistoricalOrder {
+//     fn build(new_order: &new_protocol::MakerOrderUpdated, old_order: &MakerOrder) -> HistoricalOrder {
+//         HistoricalOrder {
+//             max_base_vol: if new_order.new_max_volume().is_some() {
+//                 Some(old_order.max_base_vol.clone())
+//             } else {
+//                 None
+//             },
+//             min_base_vol: if new_order.new_min_volume().is_some() {
+//                 Some(old_order.min_base_vol.clone())
+//             } else {
+//                 None
+//             },
+//             price: if new_order.new_price().is_some() {
+//                 Some(old_order.price.clone())
+//             } else {
+//                 None
+//             },
+//             updated_at: old_order.updated_at,
+//             conf_settings: if let Some(settings) = new_order.new_conf_settings() {
+//                 if Some(settings) == old_order.conf_settings {
+//                     None
+//                 } else {
+//                     old_order.conf_settings
+//                 }
+//             } else {
+//                 None
+//             },
+//         }
+//     }
+// }
 
 pub async fn orders_kick_start(ctx: &MmArc) -> Result<HashSet<String>, String> {
     let mut coins = HashSet::new();

--- a/mm2src/lp_ordermatch/my_orders_storage.rs
+++ b/mm2src/lp_ordermatch/my_orders_storage.rs
@@ -128,7 +128,7 @@ pub fn delete_my_maker_order(ctx: MmArc, order: MakerOrder, reason: MakerOrderCa
         let save_in_history = order_to_save.save_in_history;
 
         let storage = MyOrdersStorage::new(ctx);
-        if order_to_save.created_at != order_to_save.updated_at.unwrap_or(order_to_save.created_at) {
+        if order_to_save.was_updated() {
             if let Ok(order_from_file) = storage.load_active_maker_order(order_to_save.uuid).await {
                 order_to_save = order_from_file;
             }

--- a/mm2src/lp_ordermatch/my_orders_storage.rs
+++ b/mm2src/lp_ordermatch/my_orders_storage.rs
@@ -1,5 +1,5 @@
-use crate::mm2::lp_ordermatch::{MakerOrder, MakerOrderCancellationReason, MyOrdersFilter, Order,
-                                RecentOrdersSelectResult, TakerOrder, TakerOrderCancellationReason};
+use super::{HistoricalOrder, MakerOrder, MakerOrderCancellationReason, MyOrdersFilter, Order,
+            RecentOrdersSelectResult, TakerOrder, TakerOrderCancellationReason};
 use async_trait::async_trait;
 use common::log::LogOnError;
 use common::mm_ctx::MmArc;
@@ -65,12 +65,17 @@ pub async fn save_my_new_taker_order(ctx: MmArc, order: &TakerOrder) {
     }
 }
 
-pub async fn save_maker_order_on_update(ctx: MmArc, order: &MakerOrder) {
+pub async fn save_maker_order_on_update(ctx: MmArc, order: &mut MakerOrder, new_change: HistoricalOrder) {
     let storage = MyOrdersStorage::new(ctx);
+    if let Ok(old_order) = storage.load_active_maker_order(order.uuid).await {
+        order.changes_history = old_order.changes_history;
+        order.changes_history.get_or_insert(Vec::new()).push(new_change);
+    }
     storage
         .update_active_maker_order(order)
         .await
         .error_log_with_msg("!update_active_maker_order");
+    order.changes_history = None;
 
     if order.save_in_history {
         storage
@@ -118,10 +123,16 @@ pub fn delete_my_taker_order(ctx: MmArc, order: TakerOrder, reason: TakerOrderCa
 #[cfg_attr(test, mockable)]
 pub fn delete_my_maker_order(ctx: MmArc, order: MakerOrder, reason: MakerOrderCancellationReason) -> BoxFut<(), ()> {
     let fut = async move {
-        let uuid = order.uuid;
-        let save_in_history = order.save_in_history;
+        let mut order_to_save = order;
+        let uuid = order_to_save.uuid;
+        let save_in_history = order_to_save.save_in_history;
 
         let storage = MyOrdersStorage::new(ctx);
+        if order_to_save.created_at != order_to_save.updated_at.unwrap_or(order_to_save.created_at) {
+            if let Ok(order_from_file) = storage.load_active_maker_order(order_to_save.uuid).await {
+                order_to_save = order_from_file;
+            }
+        }
         storage
             .delete_active_maker_order(uuid)
             .await
@@ -129,7 +140,7 @@ pub fn delete_my_maker_order(ctx: MmArc, order: MakerOrder, reason: MakerOrderCa
 
         if save_in_history {
             storage
-                .save_order_in_history(&Order::Maker(order.clone()))
+                .save_order_in_history(&Order::Maker(order_to_save.clone()))
                 .await
                 .error_log_with_msg("!save_order_in_history");
             storage
@@ -145,6 +156,8 @@ pub fn delete_my_maker_order(ctx: MmArc, order: MakerOrder, reason: MakerOrderCa
 #[async_trait]
 pub trait MyActiveOrders {
     async fn load_active_maker_orders(&self) -> MyOrdersResult<Vec<MakerOrder>>;
+
+    async fn load_active_maker_order(&self, uuid: Uuid) -> MyOrdersResult<MakerOrder>;
 
     async fn load_active_taker_orders(&self) -> MyOrdersResult<Vec<TakerOrder>>;
 
@@ -240,6 +253,13 @@ mod native_impl {
         async fn load_active_maker_orders(&self) -> MyOrdersResult<Vec<MakerOrder>> {
             let dir_path = my_maker_orders_dir(&self.ctx);
             Ok(read_dir_json(&dir_path).await?)
+        }
+
+        async fn load_active_maker_order(&self, uuid: Uuid) -> MyOrdersResult<MakerOrder> {
+            let path = my_maker_order_file_path(&self.ctx, &uuid);
+            read_json(&path)
+                .await?
+                .or_mm_err(|| MyOrdersError::NoSuchOrder { uuid })
         }
 
         async fn load_active_taker_orders(&self) -> MyOrdersResult<Vec<TakerOrder>> {
@@ -401,6 +421,18 @@ mod wasm_impl {
                 .into_iter()
                 .map(|(_item_id, MyActiveMakerOrdersTable { order_payload, .. })| order_payload)
                 .collect())
+        }
+
+        async fn load_active_maker_order(&self, uuid: Uuid) -> MyOrdersResult<MakerOrder> {
+            let db = self.ctx.ordermatch_db().await?;
+            let transaction = db.transaction().await?;
+            let table = transaction.table::<MyActiveMakerOrdersTable>().await?;
+
+            table
+                .get_item_by_unique_index("uuid", uuid)
+                .await?
+                .map(|(_item_id, MyActiveMakerOrdersTable { order_payload, .. })| order_payload)
+                .or_mm_err(|| MyOrdersError::NoSuchOrder { uuid })
         }
 
         async fn load_active_taker_orders(&self) -> MyOrdersResult<Vec<TakerOrder>> {

--- a/mm2src/ordermatch_tests.rs
+++ b/mm2src/ordermatch_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::mm2::lp_network::P2PContext;
-use crate::mm2::lp_ordermatch::new_protocol::PubkeyKeepAlive;
+use crate::mm2::lp_ordermatch::new_protocol::{MakerOrderUpdated, PubkeyKeepAlive};
 use coins::{MmCoin, TestCoin};
 use common::rusqlite::Connection;
 use common::{block_on,
@@ -1083,6 +1083,30 @@ fn test_taker_order_match_by() {
     matching_pubkeys.insert(H256Json::default());
     order.request.match_by = MatchBy::Pubkeys(matching_pubkeys);
     assert_eq!(MatchReservedResult::Matched, order.match_reserved(&reserved));
+}
+
+#[test]
+fn test_maker_order_was_updated() {
+    let created_at = now_ms();
+    let mut maker_order = MakerOrder {
+        base: "BASE".into(),
+        rel: "REL".into(),
+        created_at,
+        updated_at: Some(created_at),
+        max_base_vol: 10.into(),
+        min_base_vol: 0.into(),
+        price: 1.into(),
+        matches: HashMap::new(),
+        started_swaps: Vec::new(),
+        uuid: Uuid::new_v4(),
+        conf_settings: None,
+        changes_history: None,
+        save_in_history: false,
+    };
+    let mut update_msg = MakerOrderUpdated::new(maker_order.uuid);
+    update_msg.with_new_price(BigRational::from_integer(2.into()));
+    maker_order.apply_updated(&update_msg);
+    assert!(maker_order.was_updated());
 }
 
 #[test]

--- a/mm2src/ordermatch_tests.rs
+++ b/mm2src/ordermatch_tests.rs
@@ -1105,6 +1105,9 @@ fn test_maker_order_was_updated() {
     };
     let mut update_msg = MakerOrderUpdated::new(maker_order.uuid);
     update_msg.with_new_price(BigRational::from_integer(2.into()));
+
+    std::thread::sleep(Duration::from_secs(1));
+
     maker_order.apply_updated(&update_msg);
     assert!(maker_order.was_updated());
 }


### PR DESCRIPTION
fixes https://github.com/KomodoPlatform/atomicDEX-API/issues/941#issuecomment-918023912
@Milerius if this doesn't fix the memory leak then you can lower `TRIE_ORDER_HISTORY_TIMEOUT `https://github.com/KomodoPlatform/atomicDEX-API/blob/3402e6defc08092d3bf602da71bae81d37984d29/mm2src/lp_ordermatch.rs#L107 to less than 30 seconds maybe 15 or something to test if it's from `insert_new_diff` https://github.com/KomodoPlatform/atomicDEX-API/blob/3402e6defc08092d3bf602da71bae81d37984d29/mm2src/lp_ordermatch.rs#L2215
as it can be the other reason for the memory leak.