### PR TITLE
enhancements(eth): remove unused fields and support alias name

### DIFF
--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -3064,22 +3064,8 @@ fn signed_tx_from_web3_tx(transaction: Web3Transaction) -> Result<SignedEthTx, S
 
 #[derive(Deserialize, Debug)]
 struct GasStationData {
-    fast: f64,
-    speed: f64,
-    fastest: f64,
-    #[serde(rename = "avgWait")]
-    avg_wait: f64,
-    #[serde(rename = "fastWait")]
-    fast_wait: f64,
-    #[serde(rename = "blockNum")]
-    block_num: u64,
-    #[serde(rename = "safeLowWait")]
-    safe_low_wait: f64,
-    block_time: f64,
-    #[serde(rename = "fastestWait")]
-    fastest_wait: f64,
-    #[serde(rename = "safeLow")]
-    safe_low: f64,
+    // matic gas station average fees is named standard, using alias to support both format.
+    #[serde(alias = "average", alias = "standard")]
     average: f64,
 }
 


### PR DESCRIPTION
This pr can be tested through this GUI update: https://github.com/KomodoPlatform/atomicDEX-Desktop/pull/1303

@tonymorony this required a full test on ETH to be sure that nothing is broken, you can use ETHR for the testing.

`gas_station_url` for ETHR can be used for chargeless testing.

I will also sync this with mm2.1 after the merge of #1075 in order to match UTXO's coins.