### PR TITLE
Slurp refactoring #914

### DIFF
--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -24,7 +24,8 @@ use common::custom_futures::TimedAsyncMutex;
 use common::executor::Timer;
 use common::mm_ctx::{MmArc, MmWeak};
 use common::mm_error::prelude::*;
-use common::{now_ms, slurp_url, small_rng, DEX_FEE_ADDR_RAW_PUBKEY};
+use common::transport::{slurp_url, SlurpError};
+use common::{now_ms, small_rng, DEX_FEE_ADDR_RAW_PUBKEY};
 use derive_more::Display;
 use ethabi::{Contract, Token};
 use ethcore_transaction::{Action, Transaction as UnSignedEthTx, UnverifiedTransaction};
@@ -109,14 +110,31 @@ pub type GasStationResult = Result<GasStationData, MmError<GasStationReqErr>>;
 
 #[derive(Debug, Display)]
 pub enum GasStationReqErr {
-    #[display(fmt = "Transport: {}", _0)]
-    Transport(String),
+    #[display(fmt = "Transport '{}' error: {}", uri, error)]
+    Transport {
+        uri: String,
+        error: String,
+    },
     #[display(fmt = "Invalid response: {}", _0)]
     InvalidResponse(String),
+    Internal(String),
 }
 
 impl From<serde_json::Error> for GasStationReqErr {
     fn from(e: serde_json::Error) -> Self { GasStationReqErr::InvalidResponse(e.to_string()) }
+}
+
+impl From<SlurpError> for GasStationReqErr {
+    fn from(e: SlurpError) -> Self {
+        let error = e.to_string();
+        match e {
+            SlurpError::ErrorDeserializing { .. } => GasStationReqErr::InvalidResponse(error),
+            SlurpError::Transport { uri, .. } | SlurpError::Timeout { uri, .. } => {
+                GasStationReqErr::Transport { uri, error }
+            },
+            SlurpError::Internal(_) | SlurpError::InvalidRequest(_) => GasStationReqErr::Internal(error),
+        }
+    }
 }
 
 #[derive(Debug, Display)]
@@ -132,8 +150,9 @@ pub enum Web3RpcError {
 impl From<GasStationReqErr> for Web3RpcError {
     fn from(err: GasStationReqErr) -> Self {
         match err {
-            GasStationReqErr::Transport(err) => Web3RpcError::Transport(err),
+            GasStationReqErr::Transport { .. } => Web3RpcError::Transport(err.to_string()),
             GasStationReqErr::InvalidResponse(err) => Web3RpcError::InvalidResponse(err),
+            GasStationReqErr::Internal(err) => Web3RpcError::Internal(err),
         }
     }
 }
@@ -292,10 +311,13 @@ pub enum EthAddressFormat {
 
 #[cfg_attr(test, mockable)]
 async fn make_gas_station_request(url: &str) -> GasStationResult {
-    let resp = slurp_url(url).await.map_to_mm(GasStationReqErr::Transport)?;
+    let resp = slurp_url(url).await?;
     if resp.0 != StatusCode::OK {
         let error = format!("Gas price request failed with status code {}", resp.0);
-        return MmError::err(GasStationReqErr::Transport(error));
+        return MmError::err(GasStationReqErr::Transport {
+            uri: url.to_owned(),
+            error,
+        });
     }
     let result: GasStationData = json::from_slice(&resp.2)?;
     Ok(result)

--- a/mm2src/coins/eth/web3_transport.rs
+++ b/mm2src/coins/eth/web3_transport.rs
@@ -17,9 +17,9 @@ const REQUEST_TIMEOUT_S: f64 = 60.;
 /// Parse bytes RPC response into `Result`.
 /// Implementation copied from Web3 HTTP transport
 #[cfg(not(target_arch = "wasm32"))]
-fn single_response<T: Deref<Target = [u8]>>(response: T) -> Result<Json, Error> {
-    let response =
-        serde_json::from_slice(&*response).map_err(|e| Error::from(ErrorKind::InvalidResponse(format!("{}", e))))?;
+fn single_response<T: Deref<Target = [u8]>>(response: T, rpc_url: &str) -> Result<Json, Error> {
+    let response = serde_json::from_slice(&*response)
+        .map_err(|e| Error::from(ErrorKind::InvalidResponse(format!("{}: {}", rpc_url, e))))?;
 
     match response {
         Response::Single(output) => to_result_from_output(output),
@@ -158,7 +158,7 @@ async fn send_request(
             continue;
         }
 
-        return single_response(body);
+        return single_response(body, &uri.to_string());
     }
     Err(ErrorKind::Transport(fomat!(
         "request " [request] " failed: "

--- a/mm2src/coins/utxo/rpc_clients.rs
+++ b/mm2src/coins/utxo/rpc_clients.rs
@@ -538,7 +538,7 @@ impl JsonRpcClient for NativeClientImpl {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn transport(&self, request: JsonRpcRequest) -> JsonRpcResponseFut {
-        use common::wio::slurp_req;
+        use common::transport::slurp_req;
 
         let request_body = try_fus!(json::to_string(&request));
         // measure now only body length, because the `hyper` crate doesn't allow to get total HTTP packet length
@@ -2052,7 +2052,7 @@ async fn connect_loop(
         static ref CONN_IDX: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
     }
 
-    use common::wasm_ws::ws_transport;
+    use common::transport::wasm_ws::ws_transport;
 
     let mut delay: u64 = 0;
     loop {

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -102,20 +102,25 @@ pub mod privkey;
 pub mod seri;
 #[path = "patterns/state_machine.rs"] pub mod state_machine;
 pub mod time_cache;
+#[path = "transport/transport.rs"] pub mod transport;
 
-#[cfg(target_arch = "wasm32")] pub mod executor;
+#[cfg(not(target_arch = "wasm32"))]
+#[path = "executor/native_executor.rs"]
+pub mod executor;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[path = "wio.rs"]
+pub mod wio;
+
+#[cfg(target_arch = "wasm32")]
+#[path = "executor/wasm_executor.rs"]
+pub mod executor;
+
 #[cfg(target_arch = "wasm32")]
 #[path = "indexed_db/indexed_db.rs"]
 pub mod indexed_db;
 
-#[cfg(target_arch = "wasm32")]
-#[path = "transport/wasm_http.rs"]
-pub mod wasm_http;
-
 #[cfg(target_arch = "wasm32")] pub mod wasm_rpc;
-#[cfg(target_arch = "wasm32")]
-#[path = "transport/wasm_ws.rs"]
-pub mod wasm_ws;
 
 use backtrace::SymbolName;
 use bigdecimal::BigDecimal;
@@ -126,7 +131,7 @@ use futures01::{future, task::Task, Future};
 use gstuff::binprint;
 use hex::FromHex;
 use http::header::{HeaderValue, CONTENT_TYPE};
-use http::{HeaderMap, Response, StatusCode};
+use http::{Response, StatusCode};
 use parking_lot::{Mutex as PaMutex, MutexGuard as PaMutexGuard};
 use rand::{rngs::SmallRng, SeedableRng};
 use serde::{de, ser};
@@ -163,7 +168,6 @@ cfg_native! {
 
     #[cfg(not(windows))]
     use findshlibs::{IterationControl, Segment, SharedLibrary, TargetSharedLibrary};
-    use http::Request;
     use libc::{free, malloc};
     use std::env;
     use std::path::PathBuf;
@@ -604,8 +608,6 @@ pub fn is_a_test_drill() -> bool {
     true
 }
 
-pub type SlurpRes = Result<(StatusCode, HeaderMap, Vec<u8>), String>;
-
 /// RPC response, returned by the RPC handlers.  
 /// NB: By default the future is executed on the shared asynchronous reactor (`CORE`),
 /// the handler is responsible for spawning the future on another reactor if it doesn't fit the `CORE` well.
@@ -636,216 +638,6 @@ struct HostedHttpResponse {
 // we're splitting the code in place with conditional compilation.
 // wio stands for "web I/O" or "wasm I/O",
 // it contains the parts which aren't directly available with WASM.
-
-#[cfg(not(target_arch = "wasm32"))]
-pub mod wio {
-    use crate::SlurpRes;
-    use futures::compat::Future01CompatExt;
-    use futures::executor::ThreadPool;
-    use futures01::sync::oneshot::{self, Receiver};
-    use futures01::{Async, Future, Poll};
-    use futures_cpupool::CpuPool;
-    use gstuff::{duration_to_float, now_float};
-    use http::{HeaderMap, Request, StatusCode};
-    use hyper::client::HttpConnector;
-    use hyper::{Body, Client};
-    use hyper_rustls::HttpsConnector;
-    use std::fmt;
-    use std::sync::Mutex;
-    use std::thread::JoinHandle;
-    use std::time::Duration;
-    use tokio::runtime::Runtime;
-
-    fn start_core_thread() -> Mm2Runtime { Mm2Runtime(Runtime::new().unwrap()) }
-
-    pub struct Mm2Runtime(pub Runtime);
-
-    lazy_static! {
-        /// Shared asynchronous reactor.
-        pub static ref CORE: Mm2Runtime = start_core_thread();
-        /// Shared CPU pool to run intensive/sleeping requests on a separate thread.
-        ///
-        /// Deprecated, prefer the futures 0.3 `POOL` instead.
-        pub static ref CPUPOOL: CpuPool = CpuPool::new(8);
-        /// Shared CPU pool to run intensive/sleeping requests on s separate thread.
-        pub static ref POOL: Mutex<ThreadPool> = Mutex::new(ThreadPool::builder()
-            .pool_size(8)
-            .name_prefix("POOL")
-            .create().expect("!ThreadPool"));
-    }
-
-    impl<Fut: std::future::Future<Output = ()> + Send + 'static> hyper::rt::Executor<Fut> for &Mm2Runtime {
-        fn execute(&self, fut: Fut) { self.0.spawn(fut); }
-    }
-
-    /// With a shared reactor drives the future `f` to completion.
-    ///
-    /// NB: This function is only useful if you need to get the results of the execution.
-    /// If the results are not necessary then a future can be scheduled directly on the reactor:
-    ///
-    ///     CORE.spawn (|_| f);
-    pub fn drive<F, R, E>(f: F) -> Receiver<Result<R, E>>
-    where
-        F: Future<Item = R, Error = E> + Send + 'static,
-        R: Send + 'static,
-        E: Send + 'static,
-    {
-        let (sx, rx) = oneshot::channel();
-        CORE.0.spawn(
-            f.then(move |fr: Result<R, E>| -> Result<(), ()> {
-                let _ = sx.send(fr);
-                Ok(())
-            })
-            .compat(),
-        );
-        rx
-    }
-
-    pub fn drive03<F, O>(f: F) -> futures::channel::oneshot::Receiver<O>
-    where
-        F: std::future::Future<Output = O> + Send + 'static,
-        O: Send + 'static,
-    {
-        let (sx, rx) = futures::channel::oneshot::channel();
-        CORE.0.spawn(async move {
-            let res = f.await;
-            if sx.send(res).is_err() {
-                log!("drive03 receiver is dropped");
-            };
-        });
-        rx
-    }
-
-    /// With a shared reactor drives the future `f` to completion.
-    ///
-    /// Similar to `fn drive`, but returns a stringified error,
-    /// allowing us to collapse the `Receiver` and return the `R` directly.
-    pub fn drive_s<F, R, E>(f: F) -> impl Future<Item = R, Error = String>
-    where
-        F: Future<Item = R, Error = E> + Send + 'static,
-        R: Send + 'static,
-        E: fmt::Display + Send + 'static,
-    {
-        drive(f).then(move |r| -> Result<R, String> {
-            let r = try_s!(r); // Peel the `Receiver`.
-            let r = try_s!(r); // `E` to `String`.
-            Ok(r)
-        })
-    }
-
-    /// Finishes with the "timeout" error if the underlying future isn't ready withing the given timeframe.
-    ///
-    /// NB: Tokio timers (in `tokio::timer`) only seem to work under the Tokio runtime,
-    /// which is unfortunate as we want the different futures executed on the different reactors
-    /// depending on how much they're I/O-bound, CPU-bound or blocking.
-    /// Unlike the Tokio timers this `Timeout` implementation works with any reactor.
-    /// Another option to consider is https://github.com/alexcrichton/futures-timer.
-    /// P.S. The older `0.1` version of the `tokio::timer` might work NP, it works in other parts of our code.
-    ///      The new version, on the other hand, requires the Tokio runtime (https://tokio.rs/blog/2018-03-timers/).
-    /// P.S. We could try using the `futures-timer` crate instead, but note that it is currently under-maintained,
-    ///      https://github.com/rustasync/futures-timer/issues/9#issuecomment-400802515.
-    pub struct Timeout<R> {
-        fut: Box<dyn Future<Item = R, Error = String>>,
-        started: f64,
-        timeout: f64,
-        monitor: Option<JoinHandle<()>>,
-    }
-    impl<R> Future for Timeout<R> {
-        type Item = R;
-        type Error = String;
-        fn poll(&mut self) -> Poll<R, String> {
-            match self.fut.poll() {
-                Err(err) => Err(err),
-                Ok(Async::Ready(r)) => Ok(Async::Ready(r)),
-                Ok(Async::NotReady) => {
-                    let now = now_float();
-                    if now >= self.started + self.timeout {
-                        Err(format!("timeout ({:.1} > {:.1})", now - self.started, self.timeout))
-                    } else {
-                        // Start waking up this future until it has a chance to timeout.
-                        // For now it's just a basic separate thread. Will probably optimize later.
-                        if self.monitor.is_none() {
-                            let task = futures01::task::current();
-                            let deadline = self.started + self.timeout;
-                            self.monitor = Some(
-                                std::thread::Builder::new()
-                                    .name("timeout monitor".into())
-                                    .spawn(move || loop {
-                                        std::thread::sleep(Duration::from_secs(1));
-                                        task.notify();
-                                        if now_float() > deadline + 2. {
-                                            break;
-                                        }
-                                    })
-                                    .unwrap(),
-                            );
-                        }
-                        Ok(Async::NotReady)
-                    }
-                },
-            }
-        }
-    }
-    impl<R> Timeout<R> {
-        pub fn new(fut: Box<dyn Future<Item = R, Error = String>>, timeout: Duration) -> Timeout<R> {
-            Timeout {
-                fut,
-                started: now_float(),
-                timeout: duration_to_float(timeout),
-                monitor: None,
-            }
-        }
-    }
-
-    unsafe impl<R> Send for Timeout<R> {}
-
-    /// Initialize the crate.
-    pub fn init() {
-        // Pre-allocate the stack trace buffer in order to avoid allocating it from a signal handler.
-        super::black_box(&*super::trace_buf());
-        super::black_box(&*super::trace_name_buf());
-    }
-
-    lazy_static! {
-        /// NB: With a shared client there is a possibility that keep-alive connections will be reused.
-        pub static ref HYPER: Client<HttpsConnector<HttpConnector>> = {
-            // Please note there was a problem on iOS if [`HttpsConnector::with_native_roots`] is used instead.
-            let https = HttpsConnector::with_webpki_roots();
-            Client::builder()
-                .executor(&*CORE)
-                // Hyper had a lot of Keep-Alive bugs over the years and I suspect
-                // that with the shared client we might be getting errno 10054
-                // due to a closed Keep-Alive connection mismanagement.
-                // (To solve this problem Hyper should proactively close the Keep-Alive
-                // connections after a configurable amount of time has passed since
-                // their creation, thus saving us from trying to use the connections
-                // closed on the other side. I wonder if we can implement this strategy
-                // ourselves with a custom connector or something).
-                // Performance of Keep-Alive in the Hyper client is questionable as well,
-                // should measure it on a case-by-case basis when we need it.
-                .pool_max_idle_per_host(0)
-                .build(https)
-        };
-    }
-
-    /// Executes a Hyper request, returning the response status, headers and body.
-    pub async fn slurp_req(request: Request<Vec<u8>>) -> SlurpRes {
-        let (head, body) = request.into_parts();
-        let request = Request::from_parts(head, Body::from(body));
-
-        let request_f = HYPER.request(request);
-        let response = try_s!(try_s!(drive03(request_f).await));
-        let status = response.status();
-        let headers = response.headers().clone();
-        let body = response.into_body();
-        let output = try_s!(hyper::body::to_bytes(body).await);
-        Ok((status, headers, output.to_vec()))
-    }
-
-    pub async fn slurp_reqʹ(request: Request<Vec<u8>>) -> Result<(StatusCode, HeaderMap, Vec<u8>), String> {
-        slurp_req(request).await
-    }
-}
 
 pub mod lazy {
     #[cfg(test)] use super::block_on;
@@ -1015,137 +807,6 @@ pub mod lazy {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-pub mod executor {
-    use futures::task::Context;
-    use futures::task::Poll as Poll03;
-    use futures::Future as Future03;
-    use gstuff::now_float;
-    use std::pin::Pin;
-    use std::thread;
-    use std::time::Duration;
-
-    pub fn spawn(future: impl Future03<Output = ()> + Send + 'static) { crate::wio::CORE.0.spawn(future); }
-
-    pub fn spawn_boxed(future: Box<dyn Future03<Output = ()> + Send + Unpin + 'static>) { spawn(future); }
-
-    /// Schedule the given `future` to be executed shortly after the given `utc` time is reached.
-    pub fn spawn_after(utc: f64, future: impl Future03<Output = ()> + Send + 'static) {
-        use crossbeam::channel;
-        use gstuff::Constructible;
-        use std::collections::BTreeMap;
-        use std::sync::Once;
-
-        type SheduleChannelItem = (f64, Pin<Box<dyn Future03<Output = ()> + Send + 'static>>);
-        static START: Once = Once::new();
-        static SCHEDULE: Constructible<channel::Sender<SheduleChannelItem>> = Constructible::new();
-        START.call_once(|| {
-            thread::Builder::new()
-                .name("spawn_after".into())
-                .spawn(move || {
-                    let (tx, rx) = channel::bounded(0);
-                    SCHEDULE.pin(tx).expect("spawn_after] Can't pin the channel");
-                    type Task = Pin<Box<dyn Future03<Output = ()> + Send + 'static>>;
-                    let mut tasks: BTreeMap<Duration, Vec<Task>> = BTreeMap::new();
-                    let mut ready = Vec::with_capacity(4);
-                    loop {
-                        let now = Duration::from_secs_f64(now_float());
-                        let mut next_stop = Duration::from_secs_f64(0.1);
-                        for (utc, _) in tasks.iter() {
-                            if *utc <= now {
-                                ready.push(*utc)
-                            } else {
-                                next_stop = *utc - now;
-                                break;
-                            }
-                        }
-                        for utc in ready.drain(..) {
-                            let v = match tasks.remove(&utc) {
-                                Some(v) => v,
-                                None => continue,
-                            };
-                            //log! ("spawn_after] spawning " (v.len()) " tasks at " [utc]);
-                            for f in v {
-                                spawn(f)
-                            }
-                        }
-                        let (utc, f) = match rx.recv_timeout(next_stop) {
-                            Ok(t) => t,
-                            Err(channel::RecvTimeoutError::Disconnected) => break,
-                            Err(channel::RecvTimeoutError::Timeout) => continue,
-                        };
-                        tasks
-                            .entry(Duration::from_secs_f64(utc))
-                            .or_insert_with(Vec::new)
-                            .push(f)
-                    }
-                })
-                .expect("Can't spawn a spawn_after thread");
-        });
-        loop {
-            match SCHEDULE.as_option() {
-                None => {
-                    thread::yield_now();
-                    continue;
-                },
-                Some(tx) => {
-                    tx.send((utc, Box::pin(future))).expect("Can't reach spawn_after");
-                    break;
-                },
-            }
-        }
-    }
-
-    /// A future that completes at a given time.  
-    pub struct Timer {
-        till_utc: f64,
-    }
-
-    impl Timer {
-        pub fn till(till_utc: f64) -> Timer { Timer { till_utc } }
-        pub fn sleep(seconds: f64) -> Timer {
-            Timer {
-                till_utc: now_float() + seconds,
-            }
-        }
-        pub fn sleep_ms(ms: u32) -> Timer {
-            let seconds = gstuff::duration_to_float(Duration::from_millis(ms as u64));
-            Timer {
-                till_utc: now_float() + seconds,
-            }
-        }
-        pub fn till_utc(&self) -> f64 { self.till_utc }
-    }
-
-    impl Future03 for Timer {
-        type Output = ();
-        fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll03<Self::Output> {
-            let delta = self.till_utc - now_float();
-            if delta <= 0. {
-                return Poll03::Ready(());
-            }
-            // NB: We should get a new `Waker` on every `poll` in case the future migrates between executors.
-            // cf. https://rust-lang.github.io/async-book/02_execution/03_wakeups.html
-            let waker = cx.waker().clone();
-            spawn_after(self.till_utc, async move { waker.wake() });
-            Poll03::Pending
-        }
-    }
-
-    #[test]
-    fn test_timer() {
-        let started = now_float();
-        let ti = Timer::sleep(0.2);
-        let delta = now_float() - started;
-        assert!(delta < 0.04, "{}", delta);
-        super::block_on(ti);
-        let delta = now_float() - started;
-        println!("time delta is {}", delta);
-        assert!(delta > 0.2);
-        assert!(delta < 0.4)
-    }
-}
-
 /// Returns a JSON error HyRes on a failure.
 #[macro_export]
 macro_rules! try_h {
@@ -1155,55 +816,6 @@ macro_rules! try_h {
             Err(err) => return $crate::rpc_err_response(500, &ERRL!("{}", err)),
         }
     };
-}
-
-/// Executes a GET request, returning the response status, headers and body.
-#[cfg(not(target_arch = "wasm32"))]
-pub async fn slurp_url(url: &str) -> SlurpRes {
-    wio::slurp_req(try_s!(Request::builder().uri(url).body(Vec::new()))).await
-}
-
-/// Executes a GET request, returning the response status, headers and body.
-/// Please note the return header map is empty, because `wasm_bindgen` doesn't provide the way to extract all headers.
-#[cfg(target_arch = "wasm32")]
-pub async fn slurp_url(url: &str) -> SlurpRes {
-    wasm_http::FetchRequest::get(url)
-        .request_str()
-        .await
-        .map(|(status_code, response)| (status_code, HeaderMap::new(), response.into_bytes()))
-}
-
-#[test]
-fn test_slurp_req() {
-    let (status, headers, body) = block_on(slurp_url("https://httpbin.org/get")).unwrap();
-    assert!(status.is_success(), "{:?} {:?} {:?}", status, headers, body);
-}
-
-/// Fetch URL by HTTPS and parse JSON response
-pub async fn fetch_json<T>(url: &str) -> Result<T, String>
-where
-    T: serde::de::DeserializeOwned + Send + 'static,
-{
-    let result = try_s!(slurp_url(url).await);
-    let result = try_s!(serde_json::from_slice(&result.2));
-    Ok(result)
-}
-
-/// Send POST JSON HTTPS request and parse response
-#[cfg(not(target_arch = "wasm32"))]
-pub async fn post_json<T>(url: &str, json: String) -> Result<T, String>
-where
-    T: serde::de::DeserializeOwned + Send + 'static,
-{
-    let request = try_s!(Request::builder()
-        .method("POST")
-        .uri(url)
-        .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
-        .body(json.into()));
-
-    let result = try_s!(wio::slurp_req(request).await);
-    let result = try_s!(serde_json::from_slice(&result.2));
-    Ok(result)
 }
 
 /// Wraps a JSON string into the `HyRes` RPC response future.

--- a/mm2src/common/executor/native_executor.rs
+++ b/mm2src/common/executor/native_executor.rs
@@ -1,0 +1,127 @@
+use futures::task::Context;
+use futures::task::Poll as Poll03;
+use futures::Future as Future03;
+use gstuff::now_float;
+use std::pin::Pin;
+use std::thread;
+use std::time::Duration;
+
+pub fn spawn(future: impl Future03<Output = ()> + Send + 'static) { crate::wio::CORE.0.spawn(future); }
+
+pub fn spawn_boxed(future: Box<dyn Future03<Output = ()> + Send + Unpin + 'static>) { spawn(future); }
+
+/// Schedule the given `future` to be executed shortly after the given `utc` time is reached.
+pub fn spawn_after(utc: f64, future: impl Future03<Output = ()> + Send + 'static) {
+    use crossbeam::channel;
+    use gstuff::Constructible;
+    use std::collections::BTreeMap;
+    use std::sync::Once;
+
+    type SheduleChannelItem = (f64, Pin<Box<dyn Future03<Output = ()> + Send + 'static>>);
+    static START: Once = Once::new();
+    static SCHEDULE: Constructible<channel::Sender<SheduleChannelItem>> = Constructible::new();
+    START.call_once(|| {
+        thread::Builder::new()
+            .name("spawn_after".into())
+            .spawn(move || {
+                let (tx, rx) = channel::bounded(0);
+                SCHEDULE.pin(tx).expect("spawn_after] Can't pin the channel");
+                type Task = Pin<Box<dyn Future03<Output = ()> + Send + 'static>>;
+                let mut tasks: BTreeMap<Duration, Vec<Task>> = BTreeMap::new();
+                let mut ready = Vec::with_capacity(4);
+                loop {
+                    let now = Duration::from_secs_f64(now_float());
+                    let mut next_stop = Duration::from_secs_f64(0.1);
+                    for (utc, _) in tasks.iter() {
+                        if *utc <= now {
+                            ready.push(*utc)
+                        } else {
+                            next_stop = *utc - now;
+                            break;
+                        }
+                    }
+                    for utc in ready.drain(..) {
+                        let v = match tasks.remove(&utc) {
+                            Some(v) => v,
+                            None => continue,
+                        };
+                        //log! ("spawn_after] spawning " (v.len()) " tasks at " [utc]);
+                        for f in v {
+                            spawn(f)
+                        }
+                    }
+                    let (utc, f) = match rx.recv_timeout(next_stop) {
+                        Ok(t) => t,
+                        Err(channel::RecvTimeoutError::Disconnected) => break,
+                        Err(channel::RecvTimeoutError::Timeout) => continue,
+                    };
+                    tasks
+                        .entry(Duration::from_secs_f64(utc))
+                        .or_insert_with(Vec::new)
+                        .push(f)
+                }
+            })
+            .expect("Can't spawn a spawn_after thread");
+    });
+    loop {
+        match SCHEDULE.as_option() {
+            None => {
+                thread::yield_now();
+                continue;
+            },
+            Some(tx) => {
+                tx.send((utc, Box::pin(future))).expect("Can't reach spawn_after");
+                break;
+            },
+        }
+    }
+}
+
+/// A future that completes at a given time.  
+pub struct Timer {
+    till_utc: f64,
+}
+
+impl Timer {
+    pub fn till(till_utc: f64) -> Timer { Timer { till_utc } }
+    pub fn sleep(seconds: f64) -> Timer {
+        Timer {
+            till_utc: now_float() + seconds,
+        }
+    }
+    pub fn sleep_ms(ms: u32) -> Timer {
+        let seconds = gstuff::duration_to_float(Duration::from_millis(ms as u64));
+        Timer {
+            till_utc: now_float() + seconds,
+        }
+    }
+    pub fn till_utc(&self) -> f64 { self.till_utc }
+}
+
+impl Future03 for Timer {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll03<Self::Output> {
+        let delta = self.till_utc - now_float();
+        if delta <= 0. {
+            return Poll03::Ready(());
+        }
+        // NB: We should get a new `Waker` on every `poll` in case the future migrates between executors.
+        // cf. https://rust-lang.github.io/async-book/02_execution/03_wakeups.html
+        let waker = cx.waker().clone();
+        spawn_after(self.till_utc, async move { waker.wake() });
+        Poll03::Pending
+    }
+}
+
+#[test]
+fn test_timer() {
+    let started = now_float();
+    let ti = Timer::sleep(0.2);
+    let delta = now_float() - started;
+    assert!(delta < 0.04, "{}", delta);
+    super::block_on(ti);
+    let delta = now_float() - started;
+    println!("time delta is {}", delta);
+    assert!(delta > 0.2);
+    assert!(delta < 0.4)
+}

--- a/mm2src/common/executor/wasm_executor.rs
+++ b/mm2src/common/executor/wasm_executor.rs
@@ -1,0 +1,113 @@
+use crate::now_float;
+use futures::task::{Context, Poll};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::Waker;
+use std::time::Duration;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    /// https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout
+    fn setTimeout(closure: &Closure<dyn FnMut()>, delay_ms: u32) -> i32;
+
+    /// https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearTimeout
+    fn clearTimeout(id: i32);
+}
+
+pub fn spawn(future: impl Future<Output = ()> + Send + 'static) { spawn_local(future) }
+
+pub fn spawn_boxed(future: Box<dyn Future<Output = ()> + Send + Unpin + 'static>) { spawn_local(future) }
+
+pub fn spawn_local(future: impl Future<Output = ()> + 'static) { wasm_bindgen_futures::spawn_local(future) }
+
+/// The timer uses [`setTimeout`] and [`clearTimeout`] for scheduling.
+/// See the [example](https://rustwasm.github.io/docs/wasm-bindgen/reference/passing-rust-closures-to-js.html#heap-allocated-closures).
+///
+/// According to the [blogpost](https://rustwasm.github.io/2018/10/24/multithreading-rust-and-wasm.html),
+/// very few types in [`wasm_bindgen`] are `Send` and `Sync`, and [`wasm_bindgen::closure::Closure`] is not an exception.
+/// Although wasm is currently single-threaded, we can implement the `Send` trait for the `Timer`,
+/// but it won't be safe when wasm becomes multi-threaded.
+#[must_use = "futures do nothing unless polled"]
+pub struct Timer {
+    timeout_id: i32,
+    _closure: Closure<dyn FnMut()>,
+    state: Arc<Mutex<TimerState>>,
+}
+
+unsafe impl Send for Timer {}
+
+impl Timer {
+    pub fn till(till_utc: f64) -> Timer {
+        let secs = till_utc - now_float();
+        Timer::sleep(secs)
+    }
+
+    pub fn sleep(secs: f64) -> Timer {
+        let dur = Duration::from_secs_f64(secs);
+        let delay_ms = gstuff::duration_to_ms(dur) as u32;
+        Timer::sleep_ms(delay_ms)
+    }
+
+    pub fn sleep_ms(delay_ms: u32) -> Timer {
+        fn on_timeout(state: &Arc<Mutex<TimerState>>) {
+            let mut state = match state.lock() {
+                Ok(s) => s,
+                Err(e) => {
+                    log::error!("!on_timeout: {}", e);
+                    return;
+                },
+            };
+            state.completed = true;
+            if let Some(waker) = state.waker.take() {
+                waker.wake();
+            }
+        }
+
+        let state = Arc::new(Mutex::new(TimerState::default()));
+        let state_c = state.clone();
+        // we should hold the closure until the callback function is called
+        let closure = Closure::new(move || on_timeout(&state_c));
+
+        let timeout_id = setTimeout(&closure, delay_ms);
+        Timer {
+            timeout_id,
+            _closure: closure,
+            state,
+        }
+    }
+}
+
+/// When the `Timer` is destroyed, cancel its `setTimeout` timer.
+impl Drop for Timer {
+    fn drop(&mut self) { clearTimeout(self.timeout_id) }
+}
+
+impl Future for Timer {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let mut state = match self.state.lock() {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("!Timer::poll: {}", e);
+                // if the mutex is poisoned, this error will appear every poll iteration
+                return Poll::Ready(());
+            },
+        };
+        if state.completed {
+            return Poll::Ready(());
+        }
+
+        // NB: We should get a new `Waker` on every `poll` in case the future migrates between executors.
+        // cf. https://rust-lang.github.io/async-book/02_execution/03_wakeups.html
+        state.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+#[derive(Default)]
+struct TimerState {
+    completed: bool,
+    waker: Option<Waker>,
+}

--- a/mm2src/common/for_tests.rs
+++ b/mm2src/common/for_tests.rs
@@ -24,7 +24,8 @@ cfg_native! {
     use crate::block_on;
     use crate::log::dashboard_path;
     use crate::fs::slurp;
-    use crate::wio::{slurp_req, POOL};
+    use crate::transport::slurp_req;
+    use crate::wio::POOL;
     use chrono::{Local, TimeZone};
     use bytes::Bytes;
     use futures::channel::oneshot;

--- a/mm2src/common/grpc_web.rs
+++ b/mm2src/common/grpc_web.rs
@@ -2,19 +2,21 @@
 /// Implementation was taken from https://github.com/hyperium/tonic/blob/ddab65ede90f503360b7adb0d7afe6d5b7bb8b02/examples/src/grpc-web/client.rs
 /// with minor refactoring
 use crate::mm_error::prelude::*;
+use crate::transport::SlurpError;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use prost::DecodeError;
 
 cfg_native! {
-    use crate::wio::slurp_req;
+    use crate::transport::slurp_req;
     use http::header::{ACCEPT, CONTENT_TYPE};
 }
 
 cfg_wasm32! {
-    use crate::wasm_http::FetchRequest;
+    use crate::transport::wasm_http::FetchRequest;
 }
 
 // one byte for the compression flag plus four bytes for the length
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 const GRPC_HEADER_SIZE: usize = 5;
 
 #[derive(Debug)]
@@ -26,6 +28,7 @@ impl From<prost::EncodeError> for EncodeBodyError {
     fn from(err: prost::EncodeError) -> Self { EncodeBodyError::Encode(err) }
 }
 
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 fn encode_body<T>(msg: &T) -> Result<Vec<u8>, MmError<EncodeBodyError>>
 where
     T: prost::Message,
@@ -65,6 +68,7 @@ impl From<prost::DecodeError> for DecodeBodyError {
     fn from(err: DecodeError) -> Self { DecodeBodyError::DecodeError(err) }
 }
 
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 fn decode_body<T>(mut body: Bytes) -> Result<T, MmError<DecodeBodyError>>
 where
     T: Default + prost::Message,
@@ -87,22 +91,37 @@ where
 
 #[derive(Debug)]
 pub enum PostGrpcWebErr {
-    Http(http::Error),
-    Request(String),
-    EncodeBody(EncodeBodyError),
-    DecodeBody(DecodeBodyError),
+    InvalidRequest(String),
+    EncodeBody(String),
+    DecodeBody(String),
+    Transport { uri: String, error: String },
+    Internal(String),
 }
 
 impl From<EncodeBodyError> for PostGrpcWebErr {
-    fn from(err: EncodeBodyError) -> Self { PostGrpcWebErr::EncodeBody(err) }
+    fn from(err: EncodeBodyError) -> Self { PostGrpcWebErr::EncodeBody(format!("{:?}", err)) }
 }
 
 impl From<DecodeBodyError> for PostGrpcWebErr {
-    fn from(err: DecodeBodyError) -> Self { PostGrpcWebErr::DecodeBody(err) }
+    fn from(err: DecodeBodyError) -> Self { PostGrpcWebErr::DecodeBody(format!("{:?}", err)) }
 }
 
+/// `http::Error` can appear on an HTTP request [`http::Builder::build`] building.
 impl From<http::Error> for PostGrpcWebErr {
-    fn from(err: http::Error) -> Self { PostGrpcWebErr::Http(err) }
+    fn from(err: http::Error) -> Self { PostGrpcWebErr::InvalidRequest(err.to_string()) }
+}
+
+impl From<SlurpError> for PostGrpcWebErr {
+    fn from(e: SlurpError) -> Self {
+        let error = e.to_string();
+        match e {
+            SlurpError::ErrorDeserializing { .. } => PostGrpcWebErr::DecodeBody(error),
+            SlurpError::Transport { uri, .. } | SlurpError::Timeout { uri, .. } => {
+                PostGrpcWebErr::Transport { uri, error }
+            },
+            SlurpError::Internal(_) | SlurpError::InvalidRequest(_) => PostGrpcWebErr::Internal(error),
+        }
+    }
 }
 
 /// Send POST gRPC WEB HTTPS request and parse response
@@ -120,7 +139,7 @@ where
         .header(ACCEPT, "application/grpc-web")
         .body(encode_body(req)?)?;
 
-    let response = slurp_req(request).await.map_to_mm(PostGrpcWebErr::Request)?;
+    let response = slurp_req(request).await?;
 
     let reply = decode_body(response.2.into())?;
 
@@ -128,11 +147,11 @@ where
 }
 
 #[cfg(target_arch = "wasm32")]
-pub async fn post_grpc_web<Req, Res>(url: &str, req: &Req) -> Result<Res, MmError<PostGrpcWebErr>>
+pub async fn post_grpc_web<Req, Res>(url: &str, _req: &Req) -> Result<Res, MmError<PostGrpcWebErr>>
 where
     Req: prost::Message + Send + 'static,
     Res: prost::Message + Default + Send + 'static,
 {
-    let mut request = FetchRequest::post(url);
+    let _request = FetchRequest::post(url);
     unimplemented!()
 }

--- a/mm2src/common/ip_addr.rs
+++ b/mm2src/common/ip_addr.rs
@@ -1,5 +1,5 @@
-use super::mm_ctx::MmArc;
-use super::slurp_url;
+use crate::mm_ctx::MmArc;
+use crate::transport::slurp_url;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use std::fs;

--- a/mm2src/common/transport/native_http.rs
+++ b/mm2src/common/transport/native_http.rs
@@ -1,0 +1,65 @@
+use crate::mm_error::prelude::*;
+use crate::transport::{SlurpError, SlurpResult};
+use crate::wio::{drive03, HYPER};
+use futures::channel::oneshot::Canceled;
+use http::Request;
+use hyper::Body;
+
+impl From<Canceled> for SlurpError {
+    fn from(_: Canceled) -> Self { SlurpError::Internal("Spawned Slurp future has been canceled".to_owned()) }
+}
+
+impl SlurpError {
+    fn from_hyper_error(e: hyper::Error, uri: String) -> SlurpError {
+        let error = e.to_string();
+        if e.is_parse() || e.is_parse_status() || e.is_parse_too_large() {
+            SlurpError::ErrorDeserializing { uri, error }
+        } else if e.is_user() {
+            SlurpError::InvalidRequest(error)
+        } else if e.is_timeout() {
+            SlurpError::Timeout { uri, error }
+        } else {
+            SlurpError::Transport { uri, error }
+        }
+    }
+}
+
+/// Executes a Hyper request, returning the response status, headers and body.
+pub async fn slurp_req(request: Request<Vec<u8>>) -> SlurpResult {
+    let uri = request.uri().to_string();
+    let (head, body) = request.into_parts();
+    let request = Request::from_parts(head, Body::from(body));
+
+    let request_f = HYPER.request(request);
+    let response = drive03(request_f)
+        .await?
+        .map_to_mm(|e| SlurpError::from_hyper_error(e, uri.clone()))?;
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = response.into_body();
+    let output = hyper::body::to_bytes(body)
+        .await
+        .map_to_mm(|e| SlurpError::from_hyper_error(e, uri.clone()))?;
+    Ok((status, headers, output.to_vec()))
+}
+
+/// Executes a GET request, returning the response status, headers and body.
+pub async fn slurp_url(url: &str) -> SlurpResult {
+    let req = Request::builder()
+        .uri(url)
+        .body(Vec::new())
+        .map_to_mm(|e| SlurpError::InvalidRequest(e.to_string()))?;
+    slurp_req(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_on;
+
+    #[test]
+    fn test_slurp_req() {
+        let (status, headers, body) = block_on(slurp_url("https://httpbin.org/get")).unwrap();
+        assert!(status.is_success(), "{:?} {:?} {:?}", status, headers, body);
+    }
+}

--- a/mm2src/common/transport/transport.rs
+++ b/mm2src/common/transport/transport.rs
@@ -1,0 +1,28 @@
+use crate::mm_error::prelude::*;
+use derive_more::Display;
+use http::{HeaderMap, StatusCode};
+
+#[cfg(not(target_arch = "wasm32"))] pub mod native_http;
+#[cfg(target_arch = "wasm32")] pub mod wasm_http;
+#[cfg(target_arch = "wasm32")] pub mod wasm_ws;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use native_http::{slurp_req, slurp_url};
+
+#[cfg(target_arch = "wasm32")] pub use wasm_http::slurp_url;
+
+pub type SlurpResult = Result<(StatusCode, HeaderMap, Vec<u8>), MmError<SlurpError>>;
+
+#[derive(Debug, Display)]
+pub enum SlurpError {
+    #[display(fmt = "Error deserializing '{}' response: {}", uri, error)]
+    ErrorDeserializing { uri: String, error: String },
+    #[display(fmt = "Invalid request: {}", _0)]
+    InvalidRequest(String),
+    #[display(fmt = "Request '{}' timeout: {}", uri, error)]
+    Timeout { uri: String, error: String },
+    #[display(fmt = "Transport '{}' error: {}", uri, error)]
+    Transport { uri: String, error: String },
+    #[display(fmt = "Internal error: {}", _0)]
+    Internal(String),
+}

--- a/mm2src/common/transport/wasm_http.rs
+++ b/mm2src/common/transport/wasm_http.rs
@@ -22,6 +22,17 @@ pub async fn slurp_url(url: &str) -> SlurpResult {
         .map(|(status_code, response)| (status_code, HeaderMap::new(), response.into_bytes()))
 }
 
+/// Executes a POST request, returning the response status, headers and body.
+/// Please note the return header map is empty, because `wasm_bindgen` doesn't provide the way to extract all headers.
+pub async fn slurp_post_json(url: &str, body: String) -> SlurpResult {
+    FetchRequest::post(url)
+        .header("Content-Type", "application/json")
+        .body_utf8(body)
+        .request_str()
+        .await
+        .map(|(status_code, response)| (status_code, HeaderMap::new(), response.into_bytes()))
+}
+
 pub struct FetchRequest {
     uri: String,
     method: FetchMethod,

--- a/mm2src/common/transport/wasm_http.rs
+++ b/mm2src/common/transport/wasm_http.rs
@@ -1,8 +1,9 @@
 use crate::executor::spawn_local;
-use crate::log::warn;
+use crate::mm_error::prelude::*;
 use crate::stringify_js_error;
+use crate::transport::{SlurpError, SlurpResult};
 use futures::channel::oneshot;
-use http::StatusCode;
+use http::{HeaderMap, StatusCode};
 use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -10,12 +11,15 @@ use wasm_bindgen_futures::JsFuture;
 use web_sys::{Request, RequestInit, RequestMode, Response as JsResponse};
 
 /// The result containing either a pair of (HTTP status code, body) or a stringified error.
-pub type FetchResult<T> = Result<(StatusCode, T), String>;
+pub type FetchResult<T> = Result<(StatusCode, T), MmError<SlurpError>>;
 
-macro_rules! js_err {
-    ($($arg:tt)*) => {
-        Err(JsValue::from_str(&ERRL!($($arg)*)))
-    };
+/// Executes a GET request, returning the response status, headers and body.
+/// Please note the return header map is empty, because `wasm_bindgen` doesn't provide the way to extract all headers.
+pub async fn slurp_url(url: &str) -> SlurpResult {
+    FetchRequest::get(url)
+        .request_str()
+        .await
+        .map(|(status_code, response)| (status_code, HeaderMap::new(), response.into_bytes()))
 }
 
 pub struct FetchRequest {
@@ -69,25 +73,22 @@ impl FetchRequest {
         Self::spawn_fetch_str(self, tx);
         match rx.await {
             Ok(res) => res,
-            Err(_e) => ERR!("Spawned future has been canceled"),
+            Err(_e) => MmError::err(SlurpError::Internal("Spawned future has been canceled".to_owned())),
         }
     }
 
     fn spawn_fetch_str(request: Self, tx: oneshot::Sender<FetchResult<String>>) {
         let fut = async move {
-            let result = Self::fetch_str(request)
-                .await
-                .map_err(|e| ERRL!("{}", stringify_js_error(&e)));
-            if let Err(_res) = tx.send(result) {
-                warn!("spawn_fetch_str] the channel already closed");
-            }
+            let result = Self::fetch_str(request).await;
+            tx.send(result).ok();
         };
         spawn_local(fut);
     }
 
     /// The private non-Send method that is called in a spawned future.
-    async fn fetch_str(request: Self) -> Result<(StatusCode, String), JsValue> {
+    async fn fetch_str(request: Self) -> FetchResult<String> {
         let window = web_sys::window().expect("!window");
+        let uri = request.uri;
 
         let mut req_init = RequestInit::new();
         req_init.method(request.method.as_str());
@@ -97,41 +98,59 @@ impl FetchRequest {
             req_init.mode(mode);
         }
 
-        let js_request = Request::new_with_str_and_init(&request.uri, &req_init)?;
+        let js_request = Request::new_with_str_and_init(&uri, &req_init)
+            .map_to_mm(|e| SlurpError::Internal(stringify_js_error(&e)))?;
         for (hkey, hval) in request.headers {
-            js_request.headers().set(&hkey, &hval)?;
+            js_request
+                .headers()
+                .set(&hkey, &hval)
+                .map_to_mm(|e| SlurpError::Internal(stringify_js_error(&e)))?;
         }
 
         let request_promise = window.fetch_with_request(&js_request);
 
         let future = JsFuture::from(request_promise);
-        let resp_value = future.await?;
+        let resp_value = future.await.map_to_mm(|e| SlurpError::Transport {
+            uri: uri.clone(),
+            error: stringify_js_error(&e),
+        })?;
         let js_response: JsResponse = match resp_value.dyn_into() {
             Ok(res) => res,
-            Err(origin_val) => return js_err!("Error casting {:?} to 'JsResponse'", origin_val),
+            Err(origin_val) => {
+                let error = format!("Error casting {:?} to 'JsResponse'", origin_val);
+                return MmError::err(SlurpError::Internal(error));
+            },
         };
 
         let resp_txt_fut = match js_response.text() {
             Ok(txt) => txt,
             Err(e) => {
-                return js_err!(
-                    "Expected text, found {:?}: {}",
-                    js_response,
-                    crate::stringify_js_error(&e)
-                )
+                let error = format!("Expected text, found {:?}: {}", js_response, stringify_js_error(&e));
+                return MmError::err(SlurpError::ErrorDeserializing { uri, error });
             },
         };
-        let resp_txt = JsFuture::from(resp_txt_fut).await?;
+        let resp_txt = JsFuture::from(resp_txt_fut)
+            .await
+            .map_to_mm(|e| SlurpError::Transport {
+                uri: uri.clone(),
+                error: stringify_js_error(&e),
+            })?;
 
         let resp_str = match resp_txt.as_string() {
             Some(string) => string,
-            None => return js_err!("Expected a UTF-8 string JSON, found {:?}", resp_txt),
+            None => {
+                let error = format!("Expected a UTF-8 string JSON, found {:?}", resp_txt);
+                return MmError::err(SlurpError::ErrorDeserializing { uri, error });
+            },
         };
 
         let status_code = js_response.status();
         let status_code = match StatusCode::from_u16(status_code) {
             Ok(code) => code,
-            Err(e) => return js_err!("Unexpected HTTP status code, found {}: {}", status_code, e),
+            Err(e) => {
+                let error = format!("Unexpected HTTP status code, found {}: {}", status_code, e);
+                return MmError::err(SlurpError::ErrorDeserializing { uri, error });
+            },
         };
         Ok((status_code, resp_str))
     }

--- a/mm2src/common/wio.rs
+++ b/mm2src/common/wio.rs
@@ -1,0 +1,188 @@
+//! `wio` stands for "web I/O", it contains the parts which aren't directly available with WASM.
+
+use futures::compat::Future01CompatExt;
+use futures::executor::ThreadPool;
+use futures01::sync::oneshot::{self, Receiver};
+use futures01::{Async, Future, Poll};
+use futures_cpupool::CpuPool;
+use gstuff::{duration_to_float, now_float};
+use hyper::client::HttpConnector;
+use hyper::Client;
+use hyper_rustls::HttpsConnector;
+use std::fmt;
+use std::sync::Mutex;
+use std::thread::JoinHandle;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+
+fn start_core_thread() -> Mm2Runtime { Mm2Runtime(Runtime::new().unwrap()) }
+
+pub struct Mm2Runtime(pub Runtime);
+
+lazy_static! {
+    /// Shared asynchronous reactor.
+    pub static ref CORE: Mm2Runtime = start_core_thread();
+    /// Shared CPU pool to run intensive/sleeping requests on a separate thread.
+    ///
+    /// Deprecated, prefer the futures 0.3 `POOL` instead.
+    pub static ref CPUPOOL: CpuPool = CpuPool::new(8);
+    /// Shared CPU pool to run intensive/sleeping requests on s separate thread.
+    pub static ref POOL: Mutex<ThreadPool> = Mutex::new(ThreadPool::builder()
+        .pool_size(8)
+        .name_prefix("POOL")
+        .create().expect("!ThreadPool"));
+}
+
+impl<Fut: std::future::Future<Output = ()> + Send + 'static> hyper::rt::Executor<Fut> for &Mm2Runtime {
+    fn execute(&self, fut: Fut) { self.0.spawn(fut); }
+}
+
+/// With a shared reactor drives the future `f` to completion.
+///
+/// NB: This function is only useful if you need to get the results of the execution.
+/// If the results are not necessary then a future can be scheduled directly on the reactor:
+///
+///     CORE.spawn (|_| f);
+pub fn drive<F, R, E>(f: F) -> Receiver<Result<R, E>>
+where
+    F: Future<Item = R, Error = E> + Send + 'static,
+    R: Send + 'static,
+    E: Send + 'static,
+{
+    let (sx, rx) = oneshot::channel();
+    CORE.0.spawn(
+        f.then(move |fr: Result<R, E>| -> Result<(), ()> {
+            let _ = sx.send(fr);
+            Ok(())
+        })
+        .compat(),
+    );
+    rx
+}
+
+pub fn drive03<F, O>(f: F) -> futures::channel::oneshot::Receiver<O>
+where
+    F: std::future::Future<Output = O> + Send + 'static,
+    O: Send + 'static,
+{
+    let (sx, rx) = futures::channel::oneshot::channel();
+    CORE.0.spawn(async move {
+        let res = f.await;
+        if sx.send(res).is_err() {
+            log!("drive03 receiver is dropped");
+        };
+    });
+    rx
+}
+
+/// With a shared reactor drives the future `f` to completion.
+///
+/// Similar to `fn drive`, but returns a stringified error,
+/// allowing us to collapse the `Receiver` and return the `R` directly.
+pub fn drive_s<F, R, E>(f: F) -> impl Future<Item = R, Error = String>
+where
+    F: Future<Item = R, Error = E> + Send + 'static,
+    R: Send + 'static,
+    E: fmt::Display + Send + 'static,
+{
+    drive(f).then(move |r| -> Result<R, String> {
+        let r = try_s!(r); // Peel the `Receiver`.
+        let r = try_s!(r); // `E` to `String`.
+        Ok(r)
+    })
+}
+
+/// Finishes with the "timeout" error if the underlying future isn't ready withing the given timeframe.
+///
+/// NB: Tokio timers (in `tokio::timer`) only seem to work under the Tokio runtime,
+/// which is unfortunate as we want the different futures executed on the different reactors
+/// depending on how much they're I/O-bound, CPU-bound or blocking.
+/// Unlike the Tokio timers this `Timeout` implementation works with any reactor.
+/// Another option to consider is https://github.com/alexcrichton/futures-timer.
+/// P.S. The older `0.1` version of the `tokio::timer` might work NP, it works in other parts of our code.
+///      The new version, on the other hand, requires the Tokio runtime (https://tokio.rs/blog/2018-03-timers/).
+/// P.S. We could try using the `futures-timer` crate instead, but note that it is currently under-maintained,
+///      https://github.com/rustasync/futures-timer/issues/9#issuecomment-400802515.
+pub struct Timeout<R> {
+    fut: Box<dyn Future<Item = R, Error = String>>,
+    started: f64,
+    timeout: f64,
+    monitor: Option<JoinHandle<()>>,
+}
+impl<R> Future for Timeout<R> {
+    type Item = R;
+    type Error = String;
+    fn poll(&mut self) -> Poll<R, String> {
+        match self.fut.poll() {
+            Err(err) => Err(err),
+            Ok(Async::Ready(r)) => Ok(Async::Ready(r)),
+            Ok(Async::NotReady) => {
+                let now = now_float();
+                if now >= self.started + self.timeout {
+                    Err(format!("timeout ({:.1} > {:.1})", now - self.started, self.timeout))
+                } else {
+                    // Start waking up this future until it has a chance to timeout.
+                    // For now it's just a basic separate thread. Will probably optimize later.
+                    if self.monitor.is_none() {
+                        let task = futures01::task::current();
+                        let deadline = self.started + self.timeout;
+                        self.monitor = Some(
+                            std::thread::Builder::new()
+                                .name("timeout monitor".into())
+                                .spawn(move || loop {
+                                    std::thread::sleep(Duration::from_secs(1));
+                                    task.notify();
+                                    if now_float() > deadline + 2. {
+                                        break;
+                                    }
+                                })
+                                .unwrap(),
+                        );
+                    }
+                    Ok(Async::NotReady)
+                }
+            },
+        }
+    }
+}
+impl<R> Timeout<R> {
+    pub fn new(fut: Box<dyn Future<Item = R, Error = String>>, timeout: Duration) -> Timeout<R> {
+        Timeout {
+            fut,
+            started: now_float(),
+            timeout: duration_to_float(timeout),
+            monitor: None,
+        }
+    }
+}
+
+unsafe impl<R> Send for Timeout<R> {}
+
+/// Initialize the crate.
+pub fn init() {
+    // Pre-allocate the stack trace buffer in order to avoid allocating it from a signal handler.
+    super::black_box(&*super::trace_buf());
+    super::black_box(&*super::trace_name_buf());
+}
+
+lazy_static! {
+    /// NB: With a shared client there is a possibility that keep-alive connections will be reused.
+    pub static ref HYPER: Client<HttpsConnector<HttpConnector>> = {
+        // Please note there was a problem on iOS if [`HttpsConnector::with_native_roots`] is used instead.
+        let https = HttpsConnector::with_webpki_roots();
+        Client::builder()
+            .executor(&*CORE)
+            // Hyper had a lot of Keep-Alive bugs over the years and I suspect
+            // that with the shared client we might be getting errno 10054
+            // due to a closed Keep-Alive connection mismanagement.
+            // (To solve this problem Hyper should proactively close the Keep-Alive
+            // connections after a configurable amount of time has passed since
+            // their creation, thus saving us from trying to use the connections
+            // closed on the other side. I wonder if we can implement this strategy
+            // ourselves with a custom connector or something).
+            // Performance of Keep-Alive in the Hyper client is questionable as well,
+            // should measure it on a case-by-case basis when we need it.
+            .pool_max_idle_per_host(0)
+            .build(https)
+    };
+}

--- a/mm2src/lp_ordermatch/simple_market_maker.rs
+++ b/mm2src/lp_ordermatch/simple_market_maker.rs
@@ -14,7 +14,8 @@ use common::{executor::{spawn, Timer},
              mm_ctx::MmArc,
              mm_error::MmError,
              mm_number::MmNumber,
-             slurp_url, HttpStatusCode, PagingOptions};
+             transport::{slurp_url, SlurpError},
+             HttpStatusCode, PagingOptions};
 use derive_more::Display;
 use futures::compat::Future01CompatExt;
 use http::StatusCode;
@@ -161,6 +162,7 @@ pub enum StartSimpleMakerBotError {
 pub enum PriceServiceRequestError {
     HttpProcessError(String),
     ParsingAnswerError(String),
+    Internal(String),
 }
 
 impl From<serde_json::Error> for PriceServiceRequestError {
@@ -173,6 +175,19 @@ impl From<std::string::String> for PriceServiceRequestError {
 
 impl From<std::str::Utf8Error> for PriceServiceRequestError {
     fn from(error: Utf8Error) -> Self { PriceServiceRequestError::HttpProcessError(error.to_string()) }
+}
+
+impl From<SlurpError> for PriceServiceRequestError {
+    fn from(e: SlurpError) -> Self {
+        let error = e.to_string();
+        match e {
+            SlurpError::ErrorDeserializing { .. } => PriceServiceRequestError::ParsingAnswerError(error),
+            SlurpError::Transport { .. } | SlurpError::Timeout { .. } => {
+                PriceServiceRequestError::HttpProcessError(error)
+            },
+            SlurpError::Internal(_) | SlurpError::InvalidRequest(_) => PriceServiceRequestError::Internal(error),
+        }
+    }
 }
 
 impl HttpStatusCode for StartSimpleMakerBotError {


### PR DESCRIPTION
* Add SlurpError
* Refactor slurp_req, slurp_url so they return SlurpResult
* Replace slurp functions into native/wasm common::transport
* Replace native executor mod into native_executor.rs
* Rename executor.rs into wasm_executor.rs
* Replace wio mod from common.rs into wio.rs