### PR TITLE
feat(utxo_fees): replace fixed fee with fee per kb

### DIFF
--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -600,11 +600,19 @@ impl TradePreimageError {
             GenerateTxError::OutputValueLessThanDust { value, dust } => {
                 if is_upper_bound {
                     // If the preimage value is [`TradePreimageValue::UpperBound`], then we had to pass the account balance as the output value.
-                    let required = big_decimal_from_sat_unsigned(dust, decimals);
-                    TradePreimageError::NotSufficientBalance {
-                        coin,
-                        available: big_decimal_from_sat_unsigned(value, decimals),
-                        required,
+                    if value == 0 {
+                        let required = big_decimal_from_sat_unsigned(dust, decimals);
+                        TradePreimageError::NotSufficientBalance {
+                            coin,
+                            available: big_decimal_from_sat_unsigned(value, decimals),
+                            required,
+                        }
+                    } else {
+                        let error = format!(
+                            "Output value {} (equal to the account balance) less than dust {}. Probably, dust is not set or outdated",
+                            value, dust
+                        );
+                        TradePreimageError::InternalError(error)
                     }
                 } else {
                     let amount = big_decimal_from_sat_unsigned(value, decimals);

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -600,11 +600,12 @@ impl TradePreimageError {
             GenerateTxError::OutputValueLessThanDust { value, dust } => {
                 if is_upper_bound {
                     // If the preimage value is [`TradePreimageValue::UpperBound`], then we had to pass the account balance as the output value.
-                    let error = format!(
-                        "Output value {} (equal to the account balance) less than dust {}. Probably, dust is not set or outdated",
-                        value, dust
-                    );
-                    TradePreimageError::InternalError(error)
+                    let required = big_decimal_from_sat_unsigned(dust, decimals);
+                    TradePreimageError::NotSufficientBalance {
+                        coin,
+                        available: big_decimal_from_sat_unsigned(value, decimals),
+                        required,
+                    }
                 } else {
                     let amount = big_decimal_from_sat_unsigned(value, decimals);
                     let threshold = big_decimal_from_sat_unsigned(dust, decimals);

--- a/mm2src/coins/qrc20.rs
+++ b/mm2src/coins/qrc20.rs
@@ -352,9 +352,7 @@ impl Qrc20Coin {
     /// or should be sum of gas fee of all contract calls.
     pub async fn get_qrc20_tx_fee(&self, gas_fee: u64) -> Result<u64, String> {
         match try_s!(self.get_tx_fee().await) {
-            ActualTxFee::Fixed(amount) | ActualTxFee::Dynamic(amount) | ActualTxFee::FixedPerKb(amount) => {
-                Ok(amount + gas_fee)
-            },
+            ActualTxFee::Dynamic(amount) | ActualTxFee::FixedPerKb(amount) => Ok(amount + gas_fee),
         }
     }
 

--- a/mm2src/coins/qrc20/qrc20_tests.rs
+++ b/mm2src/coins/qrc20/qrc20_tests.rs
@@ -602,7 +602,7 @@ fn test_get_trade_fee() {
     ];
     let (_ctx, coin) = qrc20_coin_for_test(&priv_key, None);
     // check if the coin's tx fee is expected
-    check_tx_fee(&coin, ActualTxFee::Fixed(EXPECTED_TX_FEE as u64));
+    check_tx_fee(&coin, ActualTxFee::FixedPerKb(EXPECTED_TX_FEE as u64));
 
     let actual_trade_fee = coin.get_trade_fee().wait().unwrap();
     let expected_trade_fee_amount = big_decimal_from_sat(
@@ -629,7 +629,7 @@ fn test_sender_trade_preimage_zero_allowance() {
     ];
     let (_ctx, coin) = qrc20_coin_for_test(&priv_key, None);
     // check if the coin's tx fee is expected
-    check_tx_fee(&coin, ActualTxFee::Fixed(EXPECTED_TX_FEE as u64));
+    check_tx_fee(&coin, ActualTxFee::FixedPerKb(EXPECTED_TX_FEE as u64));
 
     let allowance = block_on(coin.allowance(coin.swap_contract_address)).expect("!allowance");
     assert_eq!(allowance, 0.into());
@@ -666,7 +666,7 @@ fn test_sender_trade_preimage_with_allowance() {
     ];
     let (_ctx, coin) = qrc20_coin_for_test(&priv_key, None);
     // check if the coin's tx fee is expected
-    check_tx_fee(&coin, ActualTxFee::Fixed(EXPECTED_TX_FEE as u64));
+    check_tx_fee(&coin, ActualTxFee::FixedPerKb(EXPECTED_TX_FEE as u64));
 
     let allowance = block_on(coin.allowance(coin.swap_contract_address)).expect("!allowance");
     assert_eq!(allowance, 300_000_000.into());
@@ -715,7 +715,7 @@ fn test_receiver_trade_preimage() {
     ];
     let (_ctx, coin) = qrc20_coin_for_test(&priv_key, None);
     // check if the coin's tx fee is expected
-    check_tx_fee(&coin, ActualTxFee::Fixed(EXPECTED_TX_FEE as u64));
+    check_tx_fee(&coin, ActualTxFee::FixedPerKb(EXPECTED_TX_FEE as u64));
 
     let actual = coin
         .get_receiver_trade_fee(FeeApproxStage::WithoutApprox)
@@ -742,7 +742,7 @@ fn test_taker_fee_tx_fee() {
     ];
     let (_ctx, coin) = qrc20_coin_for_test(&priv_key, None);
     // check if the coin's tx fee is expected
-    check_tx_fee(&coin, ActualTxFee::Fixed(EXPECTED_TX_FEE as u64));
+    check_tx_fee(&coin, ActualTxFee::FixedPerKb(EXPECTED_TX_FEE as u64));
     let expected_balance = CoinBalance {
         spendable: BigDecimal::from(5),
         unspendable: BigDecimal::from(0),

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -1309,12 +1309,6 @@ pub trait UtxoCoinBuilder {
     }
 
     async fn tx_fee(&self, rpc_client: &UtxoRpcClientEnum) -> Result<TxFee, String> {
-        const ONE_DOGE: u64 = 100000000;
-
-        if self.ticker() == "DOGE" {
-            return Ok(TxFee::FixedPerKb(ONE_DOGE));
-        }
-
         let tx_fee = match self.conf()["txfee"].as_u64() {
             None => TxFee::FixedPerKb(1000),
             Some(0) => {

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -198,18 +198,15 @@ pub struct AdditionalTxData {
 /// The fee set from coins config
 #[derive(Debug)]
 pub enum TxFee {
-    /// Tell the coin that it has fixed tx fee not depending on transaction size
-    Fixed(u64),
     /// Tell the coin that it should request the fee from daemon RPC and calculate it relying on tx size
     Dynamic(EstimateFeeMethod),
+    /// Tell the coin that it has fixed tx fee per kb.
     FixedPerKb(u64),
 }
 
 /// The actual "runtime" fee that is received from RPC in case of dynamic calculation
 #[derive(Debug, PartialEq)]
 pub enum ActualTxFee {
-    /// fixed tx fee not depending on transaction size
-    Fixed(u64),
     /// fee amount per Kbyte received from coin RPC
     Dynamic(u64),
     /// Use specified amount per each 1 kb of transaction and also per each output less than amount.
@@ -1319,7 +1316,7 @@ pub trait UtxoCoinBuilder {
         }
 
         let tx_fee = match self.conf()["txfee"].as_u64() {
-            None => TxFee::Fixed(1000),
+            None => TxFee::FixedPerKb(1000),
             Some(0) => {
                 let fee_method = match &rpc_client {
                     UtxoRpcClientEnum::Electrum(_) => EstimateFeeMethod::Standard,
@@ -1327,7 +1324,7 @@ pub trait UtxoCoinBuilder {
                 };
                 TxFee::Dynamic(fee_method)
             },
-            Some(fee) => TxFee::Fixed(fee),
+            Some(fee) => TxFee::FixedPerKb(fee),
         };
         Ok(tx_fee)
     }

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -1429,7 +1429,11 @@ where
     };
     let outputs = vec![TransactionOutput { value, script_pubkey }];
     let fee = match req.fee {
-        Some(WithdrawFee::UtxoPerKbyte { amount }) | Some(WithdrawFee::UtxoFixed { amount }) => {
+        Some(WithdrawFee::UtxoFixed { amount }) => {
+            let fixed = sat_from_big_decimal(&amount, decimals)?;
+            Some(ActualTxFee::FixedPerKb(fixed))
+        },
+        Some(WithdrawFee::UtxoPerKbyte { amount }) => {
             let dynamic = sat_from_big_decimal(&amount, decimals)?;
             Some(ActualTxFee::Dynamic(dynamic))
         },

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -145,7 +145,6 @@ struct UtxoMergeParams {
 pub async fn get_tx_fee(coin: &UtxoCoinFields) -> Result<ActualTxFee, JsonRpcError> {
     let conf = &coin.conf;
     match &coin.tx_fee {
-        TxFee::Fixed(fee) => Ok(ActualTxFee::Fixed(*fee)),
         TxFee::Dynamic(method) => {
             let fee = coin
                 .rpc_client
@@ -165,7 +164,6 @@ where
 {
     let coin_fee = coin.get_tx_fee().await?;
     let mut fee = match coin_fee {
-        ActualTxFee::Fixed(fee) => fee,
         // atomic swap payment spend transaction is slightly more than 300 bytes in average as of now
         ActualTxFee::Dynamic(fee_per_kb) => (fee_per_kb * SWAP_TX_SPEND_SIZE) / KILO_BYTE,
         // return satoshis here as swap spend transaction size is always less than 1 kb
@@ -399,7 +397,6 @@ where
             witness: Vec::new(),
         });
         tx_fee = match &coin_tx_fee {
-            ActualTxFee::Fixed(f) => *f,
             ActualTxFee::Dynamic(f) => {
                 let transaction = UtxoTx::from(tx.clone());
                 let v_size = tx_size_in_v_bytes(&coin.as_ref().my_address.addr_format, &transaction);
@@ -1432,11 +1429,7 @@ where
     };
     let outputs = vec![TransactionOutput { value, script_pubkey }];
     let fee = match req.fee {
-        Some(WithdrawFee::UtxoFixed { amount }) => {
-            let fixed = sat_from_big_decimal(&amount, decimals)?;
-            Some(ActualTxFee::Fixed(fixed))
-        },
-        Some(WithdrawFee::UtxoPerKbyte { amount }) => {
+        Some(WithdrawFee::UtxoPerKbyte { amount }) | Some(WithdrawFee::UtxoFixed { amount }) => {
             let dynamic = sat_from_big_decimal(&amount, decimals)?;
             Some(ActualTxFee::Dynamic(dynamic))
         },
@@ -2130,7 +2123,6 @@ where
     let fut = async move {
         let fee = try_s!(coin.get_tx_fee().await);
         let amount = match fee {
-            ActualTxFee::Fixed(f) => f,
             ActualTxFee::Dynamic(f) => f,
             ActualTxFee::FixedPerKb(f) => f,
         };
@@ -2172,10 +2164,6 @@ where
     let is_amount_upper_bound = matches!(fee_policy, FeePolicy::DeductFromOutput(_));
 
     match tx_fee {
-        ActualTxFee::Fixed(fee_amount) => {
-            let amount = big_decimal_from_sat(fee_amount as i64, decimals);
-            Ok(amount)
-        },
         // if it's a dynamic fee, we should generate a swap transaction to get an actual trade fee
         ActualTxFee::Dynamic(fee) => {
             // take into account that the dynamic tx fee may increase during the swap

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -2526,8 +2526,7 @@ fn firo_lelantus_tx_details() {
 
 #[test]
 fn test_generate_tx_doge_fee() {
-    // A tx below 1kb is always 1 doge fee yes.
-    // But keep in mind that every output below 1 doge will incur and extra 1 doge dust fee
+    // A tx below 1kb is always 0,01 doge fee per kb.
     let config = json!({
         "coin": "DOGE",
         "name": "dogecoin",
@@ -2536,9 +2535,8 @@ fn test_generate_tx_doge_fee() {
         "pubtype": 30,
         "p2shtype": 22,
         "wiftype": 158,
-        "txfee": 0,
+        "txfee": 1000000,
         "force_min_relay_fee": true,
-        "dust": 100000000,
         "mm2": 1,
         "required_confirmations": 2,
         "avg_blocktime": 1,
@@ -2567,7 +2565,7 @@ fn test_generate_tx_doge_fee() {
     }];
     let policy = FeePolicy::SendExact;
     let (_, data) = block_on(generate_transaction(&doge, unspents, outputs, policy, None, None)).unwrap();
-    let expected_fee = 100000000;
+    let expected_fee = 1000000;
     assert_eq!(expected_fee, data.fee_amount);
 
     let unspents = vec![UnspentInfo {
@@ -2585,7 +2583,7 @@ fn test_generate_tx_doge_fee() {
     ];
     let policy = FeePolicy::SendExact;
     let (_, data) = block_on(generate_transaction(&doge, unspents, outputs, policy, None, None)).unwrap();
-    let expected_fee = 200000000;
+    let expected_fee = 2000000;
     assert_eq!(expected_fee, data.fee_amount);
 
     let unspents = vec![UnspentInfo {
@@ -2603,7 +2601,7 @@ fn test_generate_tx_doge_fee() {
     ];
     let policy = FeePolicy::SendExact;
     let (_, data) = block_on(generate_transaction(&doge, unspents, outputs, policy, None, None)).unwrap();
-    let expected_fee = 300000000;
+    let expected_fee = 3000000;
     assert_eq!(expected_fee, data.fee_amount);
 }
 

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -494,7 +494,7 @@ fn test_withdraw_impl_set_fixed_fee() {
     };
     let expected = Some(
         UtxoFeeDetails {
-            amount: "0.0245".parse().unwrap(),
+            amount: "0.1".parse().unwrap(),
         }
         .into(),
     );

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -114,7 +114,7 @@ fn utxo_coin_fields_for_test(
         },
         decimals: 8,
         dust_amount: UTXO_DUST_AMOUNT,
-        tx_fee: TxFee::Fixed(1000),
+        tx_fee: TxFee::FixedPerKb(1000),
         rpc_client,
         key_pair,
         my_address,

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -494,7 +494,7 @@ fn test_withdraw_impl_set_fixed_fee() {
     };
     let expected = Some(
         UtxoFeeDetails {
-            amount: "0.1".parse().unwrap(),
+            amount: "0.0245".parse().unwrap(),
         }
         .into(),
     );

--- a/mm2src/docker_tests.rs
+++ b/mm2src/docker_tests.rs
@@ -2007,8 +2007,9 @@ mod docker_tests {
         assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
         let available = MmNumber::from("7.7701").to_decimal();
         // `required = volume + fee_to_send_taker_payment + dex_fee + fee_to_send_dex_fee`,
-        // where `volume = 7.77`, `fee_to_send_taker_payment = fee_to_send_dex_fee = 0.00001`, `dex_fee = 0.0001`.
-        // Please note `dex_fee = 7.77 / 7770` < `min_dex_fee = 0.0001`, so `dex_fee = min_dex_fee = 0.0001`
+        // where `volume = 7.77`, `fee_to_send_taker_payment = fee_to_send_dex_fee = 0.00001`, `dex_fee = 0.01`.
+        // Please note `dex_fee = 7.77 / 777` with dex_fee = 0.01
+        // required = 7.77 + 0.01 (dex_fee) + (0.0001 * 2) = 7.78002
         let required = MmNumber::from("7.78002");
         expect_not_sufficient_balance(&rc.1, available, required.to_decimal(), Some(BigDecimal::from(0)));
     }

--- a/mm2src/docker_tests.rs
+++ b/mm2src/docker_tests.rs
@@ -1883,19 +1883,30 @@ mod docker_tests {
     #[test]
     fn test_trade_preimage_not_sufficient_balance() {
         #[track_caller]
-        fn expect_not_sufficient_balance(res: &str, available: BigDecimal, required: BigDecimal) {
+        fn expect_not_sufficient_balance(
+            res: &str,
+            available: BigDecimal,
+            required: BigDecimal,
+            locked_by_swaps: Option<BigDecimal>,
+        ) {
             let actual: RpcErrorResponse<trade_preimage_error::NotSufficientBalance> = json::from_str(res).unwrap();
             assert_eq!(actual.error_type, "NotSufficientBalance");
             let expected = trade_preimage_error::NotSufficientBalance {
                 coin: "MYCOIN".to_owned(),
                 available,
                 required,
-                locked_by_swaps: Some(BigDecimal::from(0)),
+                locked_by_swaps,
             };
             assert_eq!(actual.error_data, Some(expected));
         }
 
         let priv_key = SecretKey::new(&mut rand6::thread_rng());
+        let fill_balance_functor = |amount: BigDecimal| {
+            //let low_balance = MmNumber::from("0.000015").to_decimal()
+            let (_ctx, mycoin) = utxo_coin_from_privkey("MYCOIN", priv_key.as_ref());
+            let my_address = mycoin.my_address().expect("!my_address");
+            fill_address(&mycoin, &my_address, amount, 30);
+        };
 
         let coins = json!([
             {"coin":"MYCOIN","asset":"MYCOIN","txversion":4,"overwintered":1,"txfee":1000,"protocol":{"type":"UTXO"}},
@@ -1920,6 +1931,7 @@ mod docker_tests {
         log!([block_on(enable_native(&mm, "MYCOIN1", &[]))]);
         log!([block_on(enable_native(&mm, "MYCOIN", &[]))]);
 
+        fill_balance_functor(MmNumber::from("0.000015").to_decimal());
         // Try sell the max amount with the zero balance.
         let rc = block_on(mm.rpc(json!({
             "userpass": mm.userpass,
@@ -1935,10 +1947,10 @@ mod docker_tests {
         })))
         .unwrap();
         assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
-        let available = BigDecimal::from(0);
+        let available = MmNumber::from("0.000015").to_decimal();
         // Required at least 0.00002 MYCOIN to pay the transaction_fee(0.00001) and to send a value not less than dust(0.00001).
         let required = MmNumber::from("0.00002").to_decimal();
-        expect_not_sufficient_balance(&rc.1, available, required);
+        expect_not_sufficient_balance(&rc.1, available, required, None);
 
         let rc = block_on(mm.rpc(json!({
             "userpass": mm.userpass,
@@ -1955,40 +1967,9 @@ mod docker_tests {
         .unwrap();
         assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
         // Required 0.00001 MYCOIN to pay the transaction fee and the specified 0.1 volume.
-        let available = BigDecimal::from(0);
+        let available = MmNumber::from("0.000015").to_decimal();
         let required = MmNumber::from("0.10001").to_decimal();
-        expect_not_sufficient_balance(&rc.1, available, required);
-
-        let rc = block_on(mm.rpc(json!({
-            "userpass": mm.userpass,
-            "mmrpc": "2.0",
-            "method": "trade_preimage",
-            "params": {
-                "base": "MYCOIN",
-                "rel": "MYCOIN1",
-                "swap_method": "sell",
-                "price": 1,
-                "volume": 0.01,
-            },
-        })))
-        .unwrap();
-        assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
-        let available = BigDecimal::from(0);
-        // `required = volume + fee_to_send_taker_payment + dex_fee + fee_to_send_dex_fee`,
-        // where `volume = 0.01`, `fee_to_send_taker_payment = fee_to_send_dex_fee = 0.00001`, `dex_fee = 0.0001`.
-        // Please note `dex_fee = 0.01 / 7770` < `min_dex_fee = 0.0001`, so `dex_fee = min_dex_fee = 0.0001`
-        let required = MmNumber::from("0.01") + MmNumber::from("0.00012");
-        expect_not_sufficient_balance(&rc.1, available, required.to_decimal());
-
-        // The max available value = balance (0.000015) - transaction_fee (0.00001) = 0.000005 that is less than dust (0.00001).
-        // In this case we have to receive the `NotSufficientBalance` error.
-        //
-        // vvv Fill the MYCOIN balance vvv
-
-        let low_balance = MmNumber::from("0.000015").to_decimal();
-        let (_ctx, mycoin) = utxo_coin_from_privkey("MYCOIN", priv_key.as_ref());
-        let my_address = mycoin.my_address().expect("!my_address");
-        fill_address(&mycoin, &my_address, low_balance.clone(), 30);
+        expect_not_sufficient_balance(&rc.1, available, required, None);
 
         let rc = block_on(mm.rpc(json!({
             "userpass": mm.userpass,
@@ -2005,10 +1986,38 @@ mod docker_tests {
         .unwrap();
         assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
         // balance(0.000015)
-        let available = low_balance;
+        let available = MmNumber::from("0.000015").to_decimal();
         // balance(0.000015) + transaction_fee(0.00001)
         let required = MmNumber::from("0.00002").to_decimal();
-        expect_not_sufficient_balance(&rc.1, available, required);
+        expect_not_sufficient_balance(&rc.1, available, required, None);
+
+        fill_balance_functor(MmNumber::from("0.099995").to_decimal());
+        let rc = block_on(mm.rpc(json!({
+            "userpass": mm.userpass,
+            "mmrpc": "2.0",
+            "method": "trade_preimage",
+            "params": {
+                "base": "MYCOIN",
+                "rel": "MYCOIN1",
+                "swap_method": "sell",
+                "price": 1,
+                "volume": 0.1,
+            },
+        })))
+        .unwrap();
+        assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
+        let available = MmNumber::from("0.10001").to_decimal();
+        // `required = volume + fee_to_send_taker_payment + dex_fee + fee_to_send_dex_fee`,
+        // where `volume = 0.1`, `fee_to_send_taker_payment = fee_to_send_dex_fee = 0.00001`, `dex_fee = 0.0001`.
+        // Please note `dex_fee = 0.01 / 7770` < `min_dex_fee = 0.0001`, so `dex_fee = min_dex_fee = 0.0001`
+        // 0.10001 / 7770 -> 0.1001487001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287001
+        // .00001287129987129987129987129987129987129987129987 + fee_to_send_dex_fee + fee_to_send_taker_payment
+        // = 0.0001487001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287001
+        // + 0.1 = 0.1001487001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287001
+        let required = MmNumber::from(
+            "0.1001487001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287001",
+        );
+        expect_not_sufficient_balance(&rc.1, available, required.to_decimal(), Some(BigDecimal::from(0)));
     }
 
     /// This test ensures that `trade_preimage` will not succeed on input that will fail on `buy/sell/setprice`.

--- a/mm2src/docker_tests.rs
+++ b/mm2src/docker_tests.rs
@@ -1990,7 +1990,7 @@ mod docker_tests {
         let required = MmNumber::from("0.00002").to_decimal();
         expect_not_sufficient_balance(&rc.1, available, required, None);
 
-        fill_balance_functor(MmNumber::from("0.099995").to_decimal());
+        fill_balance_functor(MmNumber::from("7.770085").to_decimal());
         let rc = block_on(mm.rpc(json!({
             "userpass": mm.userpass,
             "mmrpc": "2.0",
@@ -2000,22 +2000,16 @@ mod docker_tests {
                 "rel": "MYCOIN1",
                 "swap_method": "sell",
                 "price": 1,
-                "volume": 0.1,
+                "volume": 7.77,
             },
         })))
         .unwrap();
         assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
-        let available = MmNumber::from("0.10001").to_decimal();
+        let available = MmNumber::from("7.7701").to_decimal();
         // `required = volume + fee_to_send_taker_payment + dex_fee + fee_to_send_dex_fee`,
-        // where `volume = 0.1`, `fee_to_send_taker_payment = fee_to_send_dex_fee = 0.00001`, `dex_fee = 0.0001`.
-        // Please note `dex_fee = 0.01 / 7770` < `min_dex_fee = 0.0001`, so `dex_fee = min_dex_fee = 0.0001`
-        // 0.10001 / 7770 -> 0.1001487001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287001
-        // .00001287129987129987129987129987129987129987129987 + fee_to_send_dex_fee + fee_to_send_taker_payment
-        // = 0.0001487001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287001
-        // + 0.1 = 0.1001487001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287001
-        let required = MmNumber::from(
-            "0.1001487001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287001",
-        );
+        // where `volume = 7.77`, `fee_to_send_taker_payment = fee_to_send_dex_fee = 0.00001`, `dex_fee = 0.0001`.
+        // Please note `dex_fee = 7.77 / 7770` < `min_dex_fee = 0.0001`, so `dex_fee = min_dex_fee = 0.0001`
+        let required = MmNumber::from("7.78002");
         expect_not_sufficient_balance(&rc.1, available, required.to_decimal(), Some(BigDecimal::from(0)));
     }
 

--- a/mm2src/docker_tests.rs
+++ b/mm2src/docker_tests.rs
@@ -1902,7 +1902,6 @@ mod docker_tests {
 
         let priv_key = SecretKey::new(&mut rand6::thread_rng());
         let fill_balance_functor = |amount: BigDecimal| {
-            //let low_balance = MmNumber::from("0.000015").to_decimal()
             let (_ctx, mycoin) = utxo_coin_from_privkey("MYCOIN", priv_key.as_ref());
             let my_address = mycoin.my_address().expect("!my_address");
             fill_address(&mycoin, &my_address, amount, 30);


### PR DESCRIPTION
close #901 

Before opening the pr I did the following checks:

- Run `utxo_tests` test suite
- Run `qrc20_tests` test suite
- Using grep to verify occurrences of `Fixed(` into mm2src folder

ps: If the code specific code related to DOGE need to be removed, coins configuration need to also be updated, please let me know the value per KB that would suits DOGE transaction (txfee) before I can remove the DOGE specific code!