### PR TITLE
Fix hanging pointers #1158

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_repr",
+ "shared_ref_counter",
  "tokio",
  "uuid",
  "wasm-bindgen",
@@ -4818,6 +4819,13 @@ dependencies = [
  "digest 0.8.1",
  "keccak",
  "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "shared_ref_counter"
+version = "0.1.0"
+dependencies = [
+ "log 0.4.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ default-run = "mm2"
 # Deprecated
 native = []
 zhtlc = ["coins/zhtlc"]
+track-ctx-pointer = ["common/track-ctx-pointer"]
 
 [[bin]]
 name = "mm2"

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -9,6 +9,9 @@ name = "common"
 path = "common.rs"
 doctest = false
 
+[features]
+track-ctx-pointer = ["shared_ref_counter/enable", "shared_ref_counter/log"]
+
 [dependencies]
 arrayref = "0.3"
 async-std = { version = "1.5", features = ["unstable"] }
@@ -52,6 +55,7 @@ serde_json = { version = "1.0", features = ["raw_value", "preserve_order"] }
 serde_repr = "0.1.6"
 ser_error = { path = "../derives/ser_error" }
 ser_error_derive = { path = "../derives/ser_error_derive" }
+shared_ref_counter = { path = "shared_ref_counter" }
 uuid = { version = "0.7", features = ["serde", "v4"] }
 wasm-timer = "0.2.4"
 winapi = "0.3"

--- a/mm2src/common/log.rs
+++ b/mm2src/common/log.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use std::thread;
 
-pub use log::{debug, error, info, trace, warn, LevelFilter};
+pub use log::{self as log_crate, debug, error, info, trace, warn, LevelFilter};
 
 #[cfg(target_arch = "wasm32")]
 #[path = "log/wasm_log.rs"]

--- a/mm2src/common/mm_ctx.rs
+++ b/mm2src/common/mm_ctx.rs
@@ -1,3 +1,5 @@
+#[cfg(any(not(target_arch = "wasm32"), feature = "track-ctx-pointer"))]
+use crate::executor::Timer;
 use crate::log::{self, LogState};
 use crate::mm_metrics::{MetricsArc, MetricsOps};
 use crate::{bits256, small_rng};
@@ -7,13 +9,14 @@ use primitives::hash::H160;
 use rand::Rng;
 use serde_bytes::ByteBuf;
 use serde_json::{self as json, Value as Json};
+use shared_ref_counter::{SharedRc, WeakRc};
 use std::any::Any;
 use std::collections::hash_map::{Entry, HashMap};
 use std::collections::HashSet;
 use std::fmt;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Mutex};
 
 cfg_wasm32! {
     use crate::wasm_rpc::WasmRpcSender;
@@ -21,7 +24,6 @@ cfg_wasm32! {
 }
 
 cfg_native! {
-    use crate::executor::Timer;
     use crate::mm_metrics::prometheus;
     use lightning_background_processor::BackgroundProcessor;
     use rusqlite::Connection;
@@ -206,20 +208,6 @@ impl MmCtx {
 
     pub fn p2p_in_memory_port(&self) -> Option<u64> { self.conf["p2p_in_memory_port"].as_u64() }
 
-    pub fn stop(&self) -> Result<(), String> {
-        try_s!(self.stop.pin(true));
-        let mut stop_listeners = self.stop_listeners.lock().expect("Can't lock stop_listeners");
-        // NB: It is important that we `drain` the `stop_listeners` rather than simply iterating over them
-        // because otherwise there might be reference counting instances remaining in a listener
-        // that would prevent the contexts from properly `Drop`ping.
-        for mut listener in stop_listeners.drain(..) {
-            if let Err(err) = listener() {
-                log! ({"MmCtx::stop] Listener error: {}", err})
-            }
-        }
-        Ok(())
-    }
-
     /// True if the MarketMaker instance needs to stop.
     pub fn is_stopping(&self) -> bool { self.stop.copy_or(false) }
 
@@ -285,6 +273,17 @@ impl Default for MmCtx {
     fn default() -> Self { Self::with_log_state(LogState::in_memory()) }
 }
 
+impl Drop for MmCtx {
+    fn drop(&mut self) {
+        let ffi_handle = self
+            .ffi_handle
+            .as_option()
+            .map(|handle| handle.to_string())
+            .unwrap_or_else(|| "UNKNOWN".to_owned());
+        log!("MmCtx ("(ffi_handle)") has been dropped")
+    }
+}
+
 // We don't want to send `MmCtx` across threads, it will only obstruct the normal use case
 // (and might result in undefined behaviour if there's a C struct or value in the context that is aliased from the various MM threads).
 // Only the `MmArc` is `Send`.
@@ -292,21 +291,26 @@ impl Default for MmCtx {
 // which will likely come useful during the gradual port.
 //not-implemented-on-stable// impl !Send for MmCtx {}
 
-pub struct MmArc(pub Arc<MmCtx>);
+pub struct MmArc(pub SharedRc<MmCtx>);
+
 // NB: Explicit `Send` and `Sync` marks here should become unnecessary later,
 // after we finish the initial port and replace the C values with the corresponding Rust alternatives.
 unsafe impl Send for MmArc {}
 unsafe impl Sync for MmArc {}
+
 impl Clone for MmArc {
+    #[track_caller]
     fn clone(&self) -> MmArc { MmArc(self.0.clone()) }
 }
+
 impl Deref for MmArc {
     type Target = MmCtx;
-    fn deref(&self) -> &MmCtx { &*self.0 }
+    fn deref(&self) -> &MmCtx { &self.0 }
 }
 
 #[derive(Clone, Default)]
-pub struct MmWeak(Weak<MmCtx>);
+pub struct MmWeak(WeakRc<MmCtx>);
+
 // Same as `MmArc`.
 unsafe impl Send for MmWeak {}
 unsafe impl Sync for MmWeak {}
@@ -355,6 +359,46 @@ struct NativeCtx {
 }
 
 impl MmArc {
+    pub fn stop(&self) -> Result<(), String> {
+        try_s!(self.stop.pin(true));
+        let mut stop_listeners = self.stop_listeners.lock().expect("Can't lock stop_listeners");
+        // NB: It is important that we `drain` the `stop_listeners` rather than simply iterating over them
+        // because otherwise there might be reference counting instances remaining in a listener
+        // that would prevent the contexts from properly `Drop`ping.
+        for mut listener in stop_listeners.drain(..) {
+            if let Err(err) = listener() {
+                log! ({"MmCtx::stop] Listener error: {}", err})
+            }
+        }
+
+        #[cfg(feature = "track-ctx-pointer")]
+        self.track_ctx_pointer();
+
+        Ok(())
+    }
+
+    #[cfg(feature = "track-ctx-pointer")]
+    fn track_ctx_pointer(&self) {
+        let ctx_weak = self.weak();
+        let fut = async move {
+            let level = log::log_crate::Level::Info;
+            loop {
+                Timer::sleep(5.).await;
+                match MmArc::from_weak(&ctx_weak) {
+                    Some(ctx) => ctx.log_existing_pointers(level),
+                    None => {
+                        log::info!("MmCtx was dropped. Stop the loop");
+                        break;
+                    },
+                }
+            }
+        };
+        crate::executor::spawn(fut);
+    }
+
+    #[cfg(feature = "track-ctx-pointer")]
+    pub fn log_existing_pointers(&self, level: log::log_crate::Level) { self.0.log_existing_pointers(level, "MmArc") }
+
     /// Unique context identifier, allowing us to more easily pass the context through the FFI boundaries.
     pub fn ffi_handle(&self) -> Result<u32, String> {
         let mut mm_ctx_ffi = try_s!(MM_CTX_FFI.lock());
@@ -386,6 +430,7 @@ impl MmArc {
 
     /// Tries getting access to the MM context.  
     /// Fails if an invalid MM context handler is passed (no such context or dropped context).
+    #[track_caller]
     pub fn from_ffi_handle(ffi_handle: u32) -> Result<MmArc, String> {
         if ffi_handle == 0 {
             return ERR!("MmArc] Zeroed ffi_handle");
@@ -400,10 +445,11 @@ impl MmArc {
         }
     }
 
-    /// Generates a weak link, to track the context without prolonging its life.
-    pub fn weak(&self) -> MmWeak { MmWeak(Arc::downgrade(&self.0)) }
+    /// Generates a weak pointer, to track the allocated data without prolonging its life.
+    pub fn weak(&self) -> MmWeak { MmWeak(SharedRc::downgrade(&self.0)) }
 
-    /// Tries to obtain the MM context from the weak link.
+    /// Tries to obtain the MM context from the weak pointer.
+    #[track_caller]
     pub fn from_weak(weak: &MmWeak) -> Option<MmArc> { weak.0.upgrade().map(MmArc) }
 
     /// Init metrics with dashboard.
@@ -535,6 +581,6 @@ impl MmCtxBuilder {
             ctx.db_namespace = self.db_namespace;
         }
 
-        MmArc(Arc::new(ctx))
+        MmArc(SharedRc::new(ctx))
     }
 }

--- a/mm2src/common/mm_ctx.rs
+++ b/mm2src/common/mm_ctx.rs
@@ -359,6 +359,8 @@ struct NativeCtx {
 }
 
 impl MmArc {
+    pub fn new(ctx: MmCtx) -> MmArc { MmArc(SharedRc::new(ctx)) }
+
     pub fn stop(&self) -> Result<(), String> {
         try_s!(self.stop.pin(true));
         let mut stop_listeners = self.stop_listeners.lock().expect("Can't lock stop_listeners");
@@ -581,6 +583,6 @@ impl MmCtxBuilder {
             ctx.db_namespace = self.db_namespace;
         }
 
-        MmArc(SharedRc::new(ctx))
+        MmArc::new(ctx)
     }
 }

--- a/mm2src/common/shared_ref_counter/Cargo.toml
+++ b/mm2src/common/shared_ref_counter/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "shared_ref_counter"
+version = "0.1.0"
+edition = "2018"
+
+[features]
+enable = []
+
+[dependencies]
+log = { version = "0.4.8", optional = true }

--- a/mm2src/common/shared_ref_counter/src/disable.rs
+++ b/mm2src/common/shared_ref_counter/src/disable.rs
@@ -1,0 +1,46 @@
+use std::ops::Deref;
+use std::panic::Location;
+use std::sync::{Arc, Weak};
+
+pub struct SharedRc<T>(Arc<T>);
+
+unsafe impl<T> Send for SharedRc<T> {}
+unsafe impl<T> Sync for SharedRc<T> {}
+
+impl<T> Deref for SharedRc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl<T> Clone for SharedRc<T> {
+    fn clone(&self) -> Self { SharedRc(self.0.clone()) }
+}
+
+impl<T> SharedRc<T> {
+    pub fn new(inner: T) -> Self { SharedRc(Arc::new(inner)) }
+
+    pub fn existing_pointers(&self) -> Vec<&'static Location<'static>> { Vec::new() }
+
+    /// Generates a weak pointer, to track the allocated data without prolonging its life.
+    pub fn downgrade(&self) -> WeakRc<T> { WeakRc(Arc::downgrade(&self.0)) }
+}
+
+pub struct WeakRc<T>(Weak<T>);
+
+unsafe impl<T> Send for WeakRc<T> {}
+unsafe impl<T> Sync for WeakRc<T> {}
+
+impl<T> Clone for WeakRc<T> {
+    fn clone(&self) -> Self { WeakRc(self.0.clone()) }
+}
+
+impl<T> Default for WeakRc<T> {
+    fn default() -> Self { WeakRc(Weak::default()) }
+}
+
+impl<T> WeakRc<T> {
+    pub fn upgrade(&self) -> Option<SharedRc<T>> { self.0.upgrade().map(SharedRc) }
+
+    pub fn strong_count(&self) -> usize { self.0.strong_count() }
+}

--- a/mm2src/common/shared_ref_counter/src/enable.rs
+++ b/mm2src/common/shared_ref_counter/src/enable.rs
@@ -1,0 +1,167 @@
+#[cfg(feature = "log")] use log::{log, Level};
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::panic::Location;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, RwLock, Weak};
+
+const LOCKING_ERROR: &str = "Error locking 'SharedRc::existing_pointers'";
+const UPGRADING_ERROR: &str = "Some counter fields are dropped unexpectedly though an inner pointer is still alive";
+
+pub struct SharedRc<T> {
+    inner: Arc<T>,
+    index: usize,
+    next_index: Arc<AtomicUsize>,
+    existing_pointers: Arc<RwLock<HashMap<usize, &'static Location<'static>>>>,
+}
+
+unsafe impl<T> Send for SharedRc<T> {}
+unsafe impl<T> Sync for SharedRc<T> {}
+
+impl<T> Deref for SharedRc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target { &self.inner }
+}
+
+impl<T> Drop for SharedRc<T> {
+    fn drop(&mut self) {
+        let mut existing_pointers = self.existing_pointers.write().expect(LOCKING_ERROR);
+        existing_pointers.remove(&self.index).unwrap();
+    }
+}
+
+impl<T> Clone for SharedRc<T> {
+    /// # Panic
+    ///
+    /// May panic if another task failed inside with the locked `SharedRc::existing_pointers` mutex.
+    /// This behavior is considered acceptable since the `enable` feature is expected to be used for **debug** purposes only.
+    #[track_caller]
+    fn clone(&self) -> Self {
+        let index = self.next_index.fetch_add(1, Ordering::Relaxed);
+
+        let mut existing_pointers = self.existing_pointers.write().expect(LOCKING_ERROR);
+        existing_pointers.insert(index, Location::caller());
+        drop(existing_pointers);
+
+        Self {
+            inner: self.inner.clone(),
+            index,
+            next_index: self.next_index.clone(),
+            existing_pointers: self.existing_pointers.clone(),
+        }
+    }
+}
+
+impl<T> SharedRc<T> {
+    #[track_caller]
+    pub fn new(inner: T) -> Self {
+        let index = 0;
+        let mut existing_pointers = HashMap::new();
+        existing_pointers.insert(index, Location::caller());
+
+        Self {
+            inner: Arc::new(inner),
+            index,
+            next_index: Arc::new(AtomicUsize::new(index + 1)),
+            existing_pointers: Arc::new(RwLock::new(existing_pointers)),
+        }
+    }
+
+    /// # Panic
+    ///
+    /// May panic if another task failed inside with the locked `SharedRc::existing_pointers` mutex.
+    /// This behavior is considered acceptable since the `enable` feature is expected to be used for **debug** purposes only.
+    #[cfg(feature = "log")]
+    pub fn log_existing_pointers(&self, level: Level, ident: &'static str) {
+        let existing_pointers = self.existing_pointers.read().expect(LOCKING_ERROR);
+        log!(level, "{} exists at:", ident);
+        for (_idx, location) in existing_pointers.iter() {
+            log!(level, "\t{}", stringify_location(*location));
+        }
+    }
+
+    /// # Panic
+    ///
+    /// May panic if another task failed inside with the locked `SharedRc::existing_pointers` mutex.
+    /// This behavior is considered acceptable since the `enable` feature is expected to be used for **debug** purposes only.
+    pub fn existing_pointers(&self) -> Vec<&'static Location<'static>> {
+        let existing_pointers = self.existing_pointers.read().expect(LOCKING_ERROR);
+        let locations: Vec<_> = existing_pointers.iter().map(|(_index, location)| *location).collect();
+        locations
+    }
+
+    /// Generates a weak pointer, to track the allocated data without prolonging its life.
+    pub fn downgrade(&self) -> WeakRc<T> {
+        WeakRc {
+            inner: Arc::downgrade(&self.inner),
+            next_index: Arc::downgrade(&self.next_index),
+            existing_pointers: Arc::downgrade(&self.existing_pointers),
+        }
+    }
+}
+
+pub struct WeakRc<T> {
+    inner: Weak<T>,
+    next_index: Weak<AtomicUsize>,
+    existing_pointers: Weak<RwLock<HashMap<usize, &'static Location<'static>>>>,
+}
+
+unsafe impl<T> Send for WeakRc<T> {}
+unsafe impl<T> Sync for WeakRc<T> {}
+
+impl<T> Clone for WeakRc<T> {
+    fn clone(&self) -> Self {
+        WeakRc {
+            inner: self.inner.clone(),
+            next_index: self.next_index.clone(),
+            existing_pointers: self.existing_pointers.clone(),
+        }
+    }
+}
+
+impl<T> Default for WeakRc<T> {
+    fn default() -> Self {
+        WeakRc {
+            inner: Weak::default(),
+            next_index: Weak::default(),
+            existing_pointers: Weak::default(),
+        }
+    }
+}
+
+impl<T> WeakRc<T> {
+    /// # Panic
+    ///
+    /// May panic if another task failed inside with the locked `SharedRc::existing_pointers` mutex.
+    /// This behavior is considered acceptable since the `enable` feature is expected to be used for **debug** purposes only.
+    #[track_caller]
+    pub fn upgrade(&self) -> Option<SharedRc<T>> {
+        let inner = match self.inner.upgrade() {
+            Some(ctx) => ctx,
+            None => return None,
+        };
+
+        let next_index = self.next_index.upgrade().expect(UPGRADING_ERROR);
+        let index = next_index.fetch_add(1, Ordering::Relaxed);
+
+        let existing_pointers = self.existing_pointers.upgrade().expect(UPGRADING_ERROR);
+        let mut existing_pointers_lock = existing_pointers.write().expect(LOCKING_ERROR);
+        existing_pointers_lock.insert(index, Location::caller());
+        drop(existing_pointers_lock);
+
+        Some(SharedRc {
+            inner,
+            index,
+            next_index,
+            existing_pointers,
+        })
+    }
+
+    pub fn strong_count(&self) -> usize { self.inner.strong_count() }
+}
+
+#[cfg(feature = "log")]
+fn stringify_location(location: &'static Location<'static>) -> String {
+    format!("{}:{}", location.file(), location.line())
+}

--- a/mm2src/common/shared_ref_counter/src/lib.rs
+++ b/mm2src/common/shared_ref_counter/src/lib.rs
@@ -1,0 +1,30 @@
+//! `SharedRc` is a thread-safe reference-counting pointer based on `Arc` that stands for 'Atomically
+//! Reference Counted'.
+//! The main difference from `Arc` is that `SharedRc` allows developers to debug hanging pointers
+//! by collecting the location where all `SharedRc` pointers to the same allocation still exist.
+//!
+//! # Optimization
+//!
+//! `shared-ref-counter` works exactly the same as `Arc` if the `enable` feature is not activated.
+//! It means that `SharedRc` doesn't collect any extra data without `enable` feature.
+//!
+//! # Enable
+//!
+//! Add the `enable` feature to the `Cargo.toml` to enable collecting the location of `SharedRc` pointers:
+//! ```toml
+//! shared_ref_counter = { version = "0.1", features = "enable" }
+//! ```
+//!
+//! Please note `enable` feature should be used for **debug** purposes only.
+//!
+//! # Panic
+//!
+//! Some operations over `SharedRc` may lead to a panic if the `enable` features is activated.
+//! This behavior is considered acceptable since the `enable` feature is expected to be used for **debug** purposes only.
+
+#[cfg(not(feature = "enable"))] mod disable;
+#[cfg(feature = "enable")] mod enable;
+
+#[cfg(not(feature = "enable"))]
+pub use disable::{SharedRc, WeakRc};
+#[cfg(feature = "enable")] pub use enable::{SharedRc, WeakRc};

--- a/mm2src/lp_native_dex.rs
+++ b/mm2src/lp_native_dex.rs
@@ -288,7 +288,7 @@ pub async fn lp_init(ctx: MmArc) -> Result<(), String> {
 
     spawn(broadcast_maker_orders_keep_alive_loop(ctx.clone()));
 
-    spawn(clean_memory_loop(ctx.clone()));
+    spawn(clean_memory_loop(ctx.weak()));
 
     let ctx_id = try_s!(ctx.ffi_handle());
 

--- a/mm2src/ordermatch_tests.rs
+++ b/mm2src/ordermatch_tests.rs
@@ -1575,7 +1575,7 @@ fn test_choose_taker_confs_settings_sell_action() {
 }
 
 fn make_ctx_for_tests() -> (MmArc, String, [u8; 32]) {
-    let ctx = MmArc(Arc::new(MmCtx::default()));
+    let ctx = MmArc::new(MmCtx::default());
     ctx.init_metrics().unwrap();
     ctx.secp256k1_key_pair
         .pin(key_pair_from_seed("passphrase").unwrap())


### PR DESCRIPTION
* Add `SharedRc` and `WeakRc` that can be used to debug hanging pointers
* Move `MmCtx::stop` to `MmArc::stop`
* Replace `Arc<MmCtx>` with `SharedRc<MmCtx>`

To run mm2 with pointer tracker, run
```
cargo build --feature track-ctx-pointer
```

We also can add a test that checks if all `MmArc` pointers are released in 30s.