### PR TITLE
Fix recreating Taker swap data

### DIFF
--- a/mm2src/lp_swap/recreate_swap_data.rs
+++ b/mm2src/lp_swap/recreate_swap_data.rs
@@ -433,7 +433,7 @@ fn convert_maker_to_taker_events(
                 return events;
             },
             MakerSwapEvent::TakerPaymentSpent(tx_ident) => {
-                let secret = match maker_coin.extract_secret(&secret_hash.0, &tx_ident.tx_hash) {
+                let secret = match maker_coin.extract_secret(&secret_hash.0, &tx_ident.tx_hex) {
                     Ok(secret) => H256Json::from(secret.as_slice()),
                     Err(e) => {
                         push_event!(TakerSwapEvent::TakerPaymentWaitForSpendFailed(ERRL!("{}", e).into()));


### PR DESCRIPTION
I found an error while trying to generate Taker swap data of the `8f285eec-7cae-4d9e-bada-0dfe181e6baa` swap.