### PR TITLE
Add check_utxo_maturity to electrum/enable RPC call

### DIFF
--- a/mm2src/coins/lightning.rs
+++ b/mm2src/coins/lightning.rs
@@ -442,7 +442,7 @@ pub async fn open_channel(ctx: MmArc, req: OpenChannelRequest) -> OpenChannelRes
     let platform_coin = ln_coin.platform_coin().clone();
     let decimals = platform_coin.as_ref().decimals;
     let my_address = platform_coin.as_ref().derivation_method.iguana_or_err()?;
-    let (unspents, _) = platform_coin.ordered_mature_unspents(my_address).await?;
+    let (unspents, _) = platform_coin.list_unspent_ordered(my_address).await?;
     let (value, fee_policy) = match req.amount {
         ChannelOpenAmount::Max => (
             unspents.iter().fold(0, |sum, unspent| sum + unspent.value),

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -121,7 +121,7 @@ use qrc20::Qrc20ActivationParams;
 use qrc20::{qrc20_coin_from_conf_and_params, Qrc20Coin, Qrc20FeeDetails};
 use qtum::{Qrc20AddressError, ScriptHashTypeNotSupported};
 use utxo::bch::{bch_coin_from_conf_and_params, BchActivationRequest, BchCoin};
-use utxo::qtum::{self, qtum_coin_from_with_priv_key, QtumCoin};
+use utxo::qtum::{self, qtum_coin_with_priv_key, QtumCoin};
 use utxo::qtum::{QtumDelegationOps, QtumDelegationRequest, QtumStakingInfosDetails};
 use utxo::rpc_clients::UtxoRpcError;
 use utxo::slp::SlpToken;
@@ -1896,7 +1896,7 @@ pub async fn lp_coininit(ctx: &MmArc, ticker: &str, req: &Json) -> Result<MmCoin
         },
         CoinProtocol::QTUM => {
             let params = try_s!(UtxoActivationParams::from_legacy_req(req));
-            try_s!(qtum_coin_from_with_priv_key(ctx, ticker, &coins_en, &params, &secret).await).into()
+            try_s!(qtum_coin_with_priv_key(ctx, ticker, &coins_en, &params, &secret).await).into()
         },
         CoinProtocol::ETH | CoinProtocol::ERC20 { .. } => {
             try_s!(eth_coin_from_conf_and_request(ctx, ticker, &coins_en, req, &secret, protocol).await).into()

--- a/mm2src/coins/qrc20/qrc20_tests.rs
+++ b/mm2src/coins/qrc20/qrc20_tests.rs
@@ -54,7 +54,7 @@ fn check_tx_fee(coin: &Qrc20Coin, expected_tx_fee: ActualTxFee) {
 
 #[test]
 fn test_withdraw_impl_fee_details() {
-    Qrc20Coin::ordered_mature_unspents.mock_safe(|coin, _| {
+    Qrc20Coin::list_mature_unspent_ordered.mock_safe(|coin, _| {
         let cache = block_on(coin.as_ref().recently_spent_outpoints.lock());
         let unspents = vec![UnspentInfo {
             outpoint: OutPoint {

--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -754,11 +754,18 @@ impl UtxoCommonOps for BchCoin {
         .await
     }
 
-    async fn ordered_mature_unspents<'a>(
+    async fn list_all_unspent_ordered<'a>(
         &'a self,
         address: &Address,
     ) -> UtxoRpcResult<(Vec<UnspentInfo>, AsyncMutexGuard<'a, RecentlySpentOutPoints>)> {
-        self.list_unspent_ordered(address).await
+        utxo_common::list_all_unspent_ordered(self, address).await
+    }
+
+    async fn list_mature_unspent_ordered<'a>(
+        &'a self,
+        address: &Address,
+    ) -> UtxoRpcResult<(Vec<UnspentInfo>, AsyncMutexGuard<'a, RecentlySpentOutPoints>)> {
+        utxo_common::list_all_unspent_ordered(self, address).await
     }
 
     fn get_verbose_transaction_from_cache_or_rpc(&self, txid: H256Json) -> UtxoRpcFut<VerboseTransactionFrom> {

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -277,7 +277,7 @@ impl<'a> UtxoCoinBuilderCommonOps for QtumCoinWithIguanaPrivKeyBuilder<'a> {
     fn check_utxo_maturity(&self) -> bool {
         self.activation_params()
             .check_utxo_maturity
-            .unwrap_or(QTUM_CHECK_UTXO_MATURITY)
+            .unwrap_or(true)
     }
 }
 

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -274,11 +274,7 @@ impl<'a> UtxoCoinBuilderCommonOps for QtumCoinWithIguanaPrivKeyBuilder<'a> {
 
     fn ticker(&self) -> &str { self.ticker }
 
-    fn check_utxo_maturity(&self) -> bool {
-        self.activation_params()
-            .check_utxo_maturity
-            .unwrap_or(true)
-    }
+    fn check_utxo_maturity(&self) -> bool { self.activation_params().check_utxo_maturity.unwrap_or(true) }
 }
 
 impl<'a> UtxoFieldsWithIguanaPrivKeyBuilder for QtumCoinWithIguanaPrivKeyBuilder<'a> {}

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -3,10 +3,12 @@ use crate::coin_balance::{common_impl, AddressBalanceOps, CheckHDAccountBalanceP
                           HDAccountBalanceParams, HDAccountBalanceResponse, HDAccountBalanceRpcError,
                           HDAddressBalance, HDWalletBalance, HDWalletBalanceOps, HDWalletBalanceRpcOps};
 use crate::init_withdraw::{InitWithdrawCoin, WithdrawTaskHandle};
-use crate::utxo::utxo_builder::{UtxoArcWithIguanaPrivKeyBuilder, UtxoCoinWithIguanaPrivKeyBuilder};
+use crate::utxo::utxo_builder::{MergeUtxoArcOps, UtxoCoinBuildError, UtxoCoinBuildHwOps, UtxoCoinBuilder,
+                                UtxoCoinBuilderCommonOps, UtxoCoinWithIguanaPrivKeyBuilder,
+                                UtxoFieldsWithHardwareWalletBuilder, UtxoFieldsWithIguanaPrivKeyBuilder};
 use crate::{eth, AddressDerivingError, Bip44Chain, CanRefundHtlc, CoinBalance, CoinWithDerivationMethod,
-            DelegationError, DelegationFut, InvalidBip44ChainError, NegotiateSwapContractAddrErr, StakingInfosFut,
-            SwapOps, TradePreimageValue, ValidateAddressResult, WithdrawFut};
+            DelegationError, DelegationFut, InvalidBip44ChainError, NegotiateSwapContractAddrErr, PrivKeyBuildPolicy,
+            StakingInfosFut, SwapOps, TradePreimageValue, ValidateAddressResult, WithdrawFut};
 use common::mm_metrics::MetricsArc;
 use common::mm_number::MmNumber;
 use crypto::trezor::utxo::TrezorUtxoCoin;
@@ -15,8 +17,6 @@ use futures::{FutureExt, TryFutureExt};
 use keys::AddressHashEnum;
 use serialization::CoinVariant;
 use utxo_signer::UtxoSignerOps;
-
-pub const QTUM_STANDARD_DUST: u64 = 1000;
 
 #[derive(Debug, Display)]
 pub enum Qrc20AddressError {
@@ -70,19 +70,6 @@ pub trait QtumDelegationOps {
 
 #[async_trait]
 pub trait QtumBasedCoin: AsRef<UtxoCoinFields> + UtxoCommonOps + MarketCoinOps {
-    async fn qtum_address_balance(&self, address: Address) -> BalanceResult<CoinBalance> {
-        let balance = self
-            .as_ref()
-            .rpc_client
-            .display_balance(address, self.as_ref().decimals)
-            .compat()
-            .await?;
-
-        let unspendable = utxo_common::my_unspendable_balance(self, &balance).await?;
-        let spendable = &balance - &unspendable;
-        Ok(CoinBalance { spendable, unspendable })
-    }
-
     fn convert_to_address(&self, from: &str, to_address_format: Json) -> Result<String, String> {
         let to_address_format: QtumAddressFormat =
             json::from_value(to_address_format).map_err(|e| ERRL!("Error on parse Qtum address format {:?}", e))?;
@@ -184,6 +171,156 @@ pub trait QtumBasedCoin: AsRef<UtxoCoinFields> + UtxoCommonOps + MarketCoinOps {
     }
 }
 
+pub struct QtumCoinBuilder<'a, HwOps>
+where
+    HwOps: UtxoCoinBuildHwOps + Send + Sync,
+{
+    ctx: &'a MmArc,
+    ticker: &'a str,
+    conf: &'a Json,
+    activation_params: &'a UtxoActivationParams,
+    priv_key_policy: PrivKeyBuildPolicy<'a>,
+    hw_ops: HwOps,
+}
+
+#[async_trait]
+impl<'a, HwOps> UtxoCoinBuilderCommonOps for QtumCoinBuilder<'a, HwOps>
+where
+    HwOps: UtxoCoinBuildHwOps + Send + Sync,
+{
+    fn ctx(&self) -> &MmArc { self.ctx }
+
+    fn conf(&self) -> &Json { self.conf }
+
+    fn activation_params(&self) -> &UtxoActivationParams { self.activation_params }
+
+    fn ticker(&self) -> &str { self.ticker }
+
+    fn check_utxo_maturity(&self) -> bool { self.activation_params().check_utxo_maturity.unwrap_or(true) }
+}
+
+impl<'a, HwOps> UtxoFieldsWithIguanaPrivKeyBuilder for QtumCoinBuilder<'a, HwOps> where
+    HwOps: UtxoCoinBuildHwOps + Send + Sync
+{
+}
+
+impl<'a, HwOps> UtxoFieldsWithHardwareWalletBuilder<HwOps> for QtumCoinBuilder<'a, HwOps> where
+    HwOps: UtxoCoinBuildHwOps + Send + Sync
+{
+}
+
+#[async_trait]
+impl<'a, HwOps> UtxoCoinBuilder<HwOps> for QtumCoinBuilder<'a, HwOps>
+where
+    HwOps: UtxoCoinBuildHwOps + Send + Sync,
+{
+    type ResultCoin = QtumCoin;
+    type Error = UtxoCoinBuildError;
+
+    fn priv_key_policy(&self) -> PrivKeyBuildPolicy<'_> { self.priv_key_policy.clone() }
+
+    fn hw_ops(&self) -> &HwOps { &self.hw_ops }
+
+    async fn build(self) -> MmResult<Self::ResultCoin, Self::Error> {
+        let utxo = self.build_utxo_fields().await?;
+        let utxo_arc = UtxoArc::new(utxo);
+        let utxo_weak = utxo_arc.downgrade();
+        let result_coin = QtumCoin::from(utxo_arc);
+
+        self.spawn_merge_utxo_loop_if_required(utxo_weak, QtumCoin::from);
+        Ok(result_coin)
+    }
+}
+
+impl<'a, HwOps> MergeUtxoArcOps<QtumCoin> for QtumCoinBuilder<'a, HwOps> where HwOps: UtxoCoinBuildHwOps + Send + Sync {}
+
+impl<'a, HwOps> QtumCoinBuilder<'a, HwOps>
+where
+    HwOps: UtxoCoinBuildHwOps + Send + Sync,
+{
+    pub fn new(
+        ctx: &'a MmArc,
+        ticker: &'a str,
+        conf: &'a Json,
+        activation_params: &'a UtxoActivationParams,
+        priv_key_policy: PrivKeyBuildPolicy<'a>,
+        hw_ops: HwOps,
+    ) -> Self {
+        QtumCoinBuilder {
+            ctx,
+            ticker,
+            conf,
+            activation_params,
+            priv_key_policy,
+            hw_ops,
+        }
+    }
+}
+
+pub struct QtumCoinWithIguanaPrivKeyBuilder<'a> {
+    ctx: &'a MmArc,
+    ticker: &'a str,
+    conf: &'a Json,
+    activation_params: &'a UtxoActivationParams,
+    priv_key: &'a [u8],
+}
+
+impl<'a> UtxoCoinBuilderCommonOps for QtumCoinWithIguanaPrivKeyBuilder<'a> {
+    fn ctx(&self) -> &MmArc { self.ctx }
+
+    fn conf(&self) -> &Json { self.conf }
+
+    fn activation_params(&self) -> &UtxoActivationParams { self.activation_params }
+
+    fn ticker(&self) -> &str { self.ticker }
+
+    fn check_utxo_maturity(&self) -> bool {
+        self.activation_params()
+            .check_utxo_maturity
+            .unwrap_or(QTUM_CHECK_UTXO_MATURITY)
+    }
+}
+
+impl<'a> UtxoFieldsWithIguanaPrivKeyBuilder for QtumCoinWithIguanaPrivKeyBuilder<'a> {}
+
+impl<'a> MergeUtxoArcOps<QtumCoin> for QtumCoinWithIguanaPrivKeyBuilder<'a> {}
+
+#[async_trait]
+impl<'a> UtxoCoinWithIguanaPrivKeyBuilder for QtumCoinWithIguanaPrivKeyBuilder<'a> {
+    type ResultCoin = QtumCoin;
+    type Error = UtxoCoinBuildError;
+
+    fn priv_key(&self) -> &[u8] { self.priv_key }
+
+    async fn build(self) -> MmResult<Self::ResultCoin, Self::Error> {
+        let utxo = self.build_utxo_fields_with_iguana_priv_key(self.priv_key()).await?;
+        let utxo_arc = UtxoArc::new(utxo);
+        let utxo_weak = utxo_arc.downgrade();
+        let result_coin = QtumCoin::from(utxo_arc);
+
+        self.spawn_merge_utxo_loop_if_required(utxo_weak, QtumCoin::from);
+        Ok(result_coin)
+    }
+}
+
+impl<'a> QtumCoinWithIguanaPrivKeyBuilder<'a> {
+    pub fn new(
+        ctx: &'a MmArc,
+        ticker: &'a str,
+        conf: &'a Json,
+        activation_params: &'a UtxoActivationParams,
+        priv_key: &'a [u8],
+    ) -> Self {
+        QtumCoinWithIguanaPrivKeyBuilder {
+            ctx,
+            ticker,
+            conf,
+            activation_params,
+            priv_key,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct QtumCoin {
     utxo_arc: UtxoArc,
@@ -201,7 +338,7 @@ impl From<QtumCoin> for UtxoArc {
     fn from(coin: QtumCoin) -> Self { coin.utxo_arc }
 }
 
-pub async fn qtum_coin_from_with_priv_key(
+pub async fn qtum_coin_with_priv_key(
     ctx: &MmArc,
     ticker: &str,
     conf: &Json,
@@ -209,7 +346,7 @@ pub async fn qtum_coin_from_with_priv_key(
     priv_key: &[u8],
 ) -> Result<QtumCoin, String> {
     let coin = try_s!(
-        UtxoArcWithIguanaPrivKeyBuilder::new(ctx, ticker, conf, activation_params, priv_key, QtumCoin::from)
+        QtumCoinWithIguanaPrivKeyBuilder::new(ctx, ticker, conf, activation_params, priv_key)
             .build()
             .await
     );
@@ -322,11 +459,18 @@ impl UtxoCommonOps for QtumCoin {
         .await
     }
 
-    async fn ordered_mature_unspents<'a>(
+    async fn list_all_unspent_ordered<'a>(
         &'a self,
         address: &Address,
     ) -> UtxoRpcResult<(Vec<UnspentInfo>, AsyncMutexGuard<'a, RecentlySpentOutPoints>)> {
-        utxo_common::ordered_mature_unspents(self, address).await
+        utxo_common::list_all_unspent_ordered(self, address).await
+    }
+
+    async fn list_mature_unspent_ordered<'a>(
+        &'a self,
+        address: &Address,
+    ) -> UtxoRpcResult<(Vec<UnspentInfo>, AsyncMutexGuard<'a, RecentlySpentOutPoints>)> {
+        utxo_common::list_mature_unspent_ordered(self, address).await
     }
 
     fn get_verbose_transaction_from_cache_or_rpc(&self, txid: H256Json) -> UtxoRpcFut<VerboseTransactionFrom> {
@@ -343,7 +487,7 @@ impl UtxoCommonOps for QtumCoin {
         &'a self,
         address: &Address,
     ) -> UtxoRpcResult<(Vec<UnspentInfo>, AsyncMutexGuard<'a, RecentlySpentOutPoints>)> {
-        utxo_common::ordered_mature_unspents(self, address).await
+        utxo_common::list_unspent_ordered(self, address).await
     }
 
     async fn preimage_trade_fee_required_to_send_outputs(
@@ -605,14 +749,7 @@ impl MarketCoinOps for QtumCoin {
 
     fn my_address(&self) -> Result<String, String> { utxo_common::my_address(self) }
 
-    fn my_balance(&self) -> BalanceFut<CoinBalance> {
-        let selfi = self.clone();
-        let fut = async move {
-            let my_address = selfi.as_ref().derivation_method.iguana_or_err()?.clone();
-            selfi.qtum_address_balance(my_address).await
-        };
-        Box::new(fut.boxed().compat())
-    }
+    fn my_balance(&self) -> BalanceFut<CoinBalance> { utxo_common::my_balance(self.clone()) }
 
     fn base_coin_balance(&self) -> BalanceFut<BigDecimal> { utxo_common::base_coin_balance(self) }
 
@@ -775,7 +912,7 @@ impl AddressBalanceOps for QtumCoin {
     type Address = Address;
 
     async fn address_balance(&self, address: &Self::Address) -> BalanceResult<CoinBalance> {
-        self.qtum_address_balance(address.clone()).await
+        utxo_common::address_balance(self, address).await
     }
 }
 

--- a/mm2src/coins/utxo/qtum_delegation.rs
+++ b/mm2src/coins/utxo/qtum_delegation.rs
@@ -205,7 +205,7 @@ impl QtumCoin {
         let my_address = coin.derivation_method.iguana_or_err()?;
 
         let staker = self.am_i_currently_staking().await?;
-        let (unspents, _) = utxo_common::list_unspent_ordered(self, my_address).await?;
+        let (unspents, _) = self.list_unspent_ordered(my_address).await?;
         let lower_bound = QTUM_LOWER_BOUND_DELEGATION_AMOUNT.into();
         let mut amount = BigDecimal::zero();
         if staker.is_some() {
@@ -274,7 +274,7 @@ impl QtumCoin {
         let key_pair = utxo.priv_key_policy.key_pair_or_err()?;
         let my_address = utxo.derivation_method.iguana_or_err()?;
 
-        let (unspents, _) = self.ordered_mature_unspents(my_address).await?;
+        let (unspents, _) = self.list_unspent_ordered(my_address).await?;
         let mut gas_fee = 0;
         let mut outputs = Vec::with_capacity(contract_outputs.len());
         for output in contract_outputs {

--- a/mm2src/coins/utxo/utxo_builder/mod.rs
+++ b/mm2src/coins/utxo/utxo_builder/mod.rs
@@ -2,7 +2,7 @@ mod utxo_arc_builder;
 mod utxo_coin_builder;
 mod utxo_conf_builder;
 
-pub use utxo_arc_builder::{UtxoArcBuilder, UtxoArcWithIguanaPrivKeyBuilder};
+pub use utxo_arc_builder::{MergeUtxoArcOps, UtxoArcBuilder, UtxoArcWithIguanaPrivKeyBuilder};
 pub use utxo_coin_builder::{UtxoCoinBuildError, UtxoCoinBuildHwOps, UtxoCoinBuildResult, UtxoCoinBuilder,
                             UtxoCoinBuilderCommonOps, UtxoCoinWithIguanaPrivKeyBuilder,
                             UtxoFieldsWithHardwareWalletBuilder, UtxoFieldsWithIguanaPrivKeyBuilder};

--- a/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
@@ -13,7 +13,7 @@ use serde_json::Value as Json;
 
 pub struct UtxoArcBuilder<'a, F, T, HwOps>
 where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static,
+    F: Fn(UtxoArc) -> T + Send + Sync + 'static,
     HwOps: UtxoCoinBuildHwOps + Send + Sync,
 {
     ctx: &'a MmArc,
@@ -27,7 +27,7 @@ where
 
 impl<'a, F, T, HwOps> UtxoArcBuilder<'a, F, T, HwOps>
 where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static,
+    F: Fn(UtxoArc) -> T + Send + Sync + 'static,
     HwOps: UtxoCoinBuildHwOps + Send + Sync,
 {
     pub fn new(
@@ -54,7 +54,7 @@ where
 #[async_trait]
 impl<'a, F, T, HwOps> UtxoCoinBuilderCommonOps for UtxoArcBuilder<'a, F, T, HwOps>
 where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static,
+    F: Fn(UtxoArc) -> T + Send + Sync + 'static,
     HwOps: UtxoCoinBuildHwOps + Send + Sync,
 {
     fn ctx(&self) -> &MmArc { self.ctx }
@@ -68,15 +68,14 @@ where
 
 impl<'a, F, T, HwOps> UtxoFieldsWithIguanaPrivKeyBuilder for UtxoArcBuilder<'a, F, T, HwOps>
 where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static,
+    F: Fn(UtxoArc) -> T + Send + Sync + 'static,
     HwOps: UtxoCoinBuildHwOps + Send + Sync,
 {
 }
 
-#[async_trait]
 impl<'a, F, T, HwOps> UtxoFieldsWithHardwareWalletBuilder<HwOps> for UtxoArcBuilder<'a, F, T, HwOps>
 where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static,
+    F: Fn(UtxoArc) -> T + Send + Sync + 'static,
     HwOps: UtxoCoinBuildHwOps + Send + Sync,
 {
 }
@@ -101,23 +100,22 @@ where
         let utxo_weak = utxo_arc.downgrade();
         let result_coin = (self.constructor)(utxo_arc);
 
-        self.spawn_merge_utxo_loop_if_required(utxo_weak);
+        self.spawn_merge_utxo_loop_if_required(utxo_weak, self.constructor.clone());
         Ok(result_coin)
     }
 }
 
-impl<'a, F, T, HwOps> MergeUtxoArcOps<F, T> for UtxoArcBuilder<'a, F, T, HwOps>
+impl<'a, F, T, HwOps> MergeUtxoArcOps<T> for UtxoArcBuilder<'a, F, T, HwOps>
 where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static,
+    F: Fn(UtxoArc) -> T + Send + Sync + 'static,
     T: AsRef<UtxoCoinFields> + UtxoCommonOps + Send + Sync + 'static,
     HwOps: UtxoCoinBuildHwOps + Send + Sync,
 {
-    fn constructor(&self) -> F { self.constructor.clone() }
 }
 
 pub struct UtxoArcWithIguanaPrivKeyBuilder<'a, F, T>
 where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static,
+    F: Fn(UtxoArc) -> T + Send + Sync + 'static,
 {
     ctx: &'a MmArc,
     ticker: &'a str,
@@ -127,10 +125,9 @@ where
     constructor: F,
 }
 
-#[async_trait]
 impl<'a, F, T> UtxoCoinBuilderCommonOps for UtxoArcWithIguanaPrivKeyBuilder<'a, F, T>
 where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static,
+    F: Fn(UtxoArc) -> T + Send + Sync + 'static,
 {
     fn ctx(&self) -> &MmArc { self.ctx }
 
@@ -141,18 +138,16 @@ where
     fn ticker(&self) -> &str { self.ticker }
 }
 
-#[async_trait]
 impl<'a, F, T> UtxoFieldsWithIguanaPrivKeyBuilder for UtxoArcWithIguanaPrivKeyBuilder<'a, F, T> where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static
+    F: Fn(UtxoArc) -> T + Send + Sync + 'static
 {
 }
 
-impl<'a, F, T> MergeUtxoArcOps<F, T> for UtxoArcWithIguanaPrivKeyBuilder<'a, F, T>
+impl<'a, F, T> MergeUtxoArcOps<T> for UtxoArcWithIguanaPrivKeyBuilder<'a, F, T>
 where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static,
+    F: Fn(UtxoArc) -> T + Send + Sync + 'static,
     T: AsRef<UtxoCoinFields> + UtxoCommonOps + Send + Sync + 'static,
 {
-    fn constructor(&self) -> F { self.constructor.clone() }
 }
 
 #[async_trait]
@@ -172,14 +167,14 @@ where
         let utxo_weak = utxo_arc.downgrade();
         let result_coin = (self.constructor)(utxo_arc);
 
-        self.spawn_merge_utxo_loop_if_required(utxo_weak);
+        self.spawn_merge_utxo_loop_if_required(utxo_weak, self.constructor.clone());
         Ok(result_coin)
     }
 }
 
 impl<'a, F, T> UtxoArcWithIguanaPrivKeyBuilder<'a, F, T>
 where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static,
+    F: Fn(UtxoArc) -> T + Send + Sync + 'static,
     T: AsRef<UtxoCoinFields> + UtxoCommonOps + Send + Sync + 'static,
 {
     pub fn new(
@@ -201,21 +196,21 @@ where
     }
 }
 
-trait MergeUtxoArcOps<F, T>: UtxoCoinBuilderCommonOps
+pub trait MergeUtxoArcOps<T>: UtxoCoinBuilderCommonOps
 where
-    F: Fn(UtxoArc) -> T + Clone + Send + Sync + 'static,
     T: AsRef<UtxoCoinFields> + UtxoCommonOps + Send + Sync + 'static,
 {
-    fn constructor(&self) -> F;
-
-    fn spawn_merge_utxo_loop_if_required(&self, weak: UtxoWeak) {
+    fn spawn_merge_utxo_loop_if_required<F>(&self, weak: UtxoWeak, constructor: F)
+    where
+        F: Fn(UtxoArc) -> T + Send + Sync + 'static,
+    {
         if let Some(ref merge_params) = self.activation_params().utxo_merge_params {
             let fut = merge_utxo_loop(
                 weak,
                 merge_params.merge_at,
                 merge_params.check_every,
                 merge_params.max_merge_at_once,
-                self.constructor(),
+                constructor,
             );
             info!("Starting UTXO merge loop for coin {}", self.ticker());
             spawn(fut);

--- a/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
@@ -163,6 +163,7 @@ pub trait UtxoFieldsWithIguanaPrivKeyBuilder: UtxoCoinBuilderCommonOps {
         let initial_history_state = self.initial_history_state();
         let tx_cache_directory = Some(self.ctx().dbdir().join("TX_CACHE"));
         let tx_hash_algo = self.tx_hash_algo();
+        let check_utxo_maturity = self.check_utxo_maturity();
 
         let coin = UtxoCoinFields {
             conf,
@@ -176,6 +177,7 @@ pub trait UtxoFieldsWithIguanaPrivKeyBuilder: UtxoCoinBuilderCommonOps {
             recently_spent_outpoints: AsyncMutex::new(RecentlySpentOutPoints::new(my_script_pubkey)),
             tx_fee,
             tx_hash_algo,
+            check_utxo_maturity,
         };
         Ok(coin)
     }
@@ -213,6 +215,7 @@ where
         let initial_history_state = self.initial_history_state();
         let tx_cache_directory = Some(self.ctx().dbdir().join("TX_CACHE"));
         let tx_hash_algo = self.tx_hash_algo();
+        let check_utxo_maturity = self.check_utxo_maturity();
 
         let coin = UtxoCoinFields {
             conf,
@@ -226,6 +229,7 @@ where
             recently_spent_outpoints,
             tx_fee,
             tx_hash_algo,
+            check_utxo_maturity,
         };
         Ok(coin)
     }
@@ -549,6 +553,8 @@ pub trait UtxoCoinBuilderCommonOps {
             TxHashAlgo::DSHA256
         }
     }
+
+    fn check_utxo_maturity(&self) -> bool { self.activation_params().check_utxo_maturity.unwrap_or_default() }
 }
 
 /// Attempts to parse native daemon conf file and return rpcport, rpcuser and rpcpassword

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -134,11 +134,18 @@ impl UtxoCommonOps for UtxoStandardCoin {
         .await
     }
 
-    async fn ordered_mature_unspents<'a>(
+    async fn list_all_unspent_ordered<'a>(
         &'a self,
         address: &Address,
     ) -> UtxoRpcResult<(Vec<UnspentInfo>, AsyncMutexGuard<'a, RecentlySpentOutPoints>)> {
-        utxo_common::ordered_mature_unspents(self, address).await
+        utxo_common::list_all_unspent_ordered(self, address).await
+    }
+
+    async fn list_mature_unspent_ordered<'a>(
+        &'a self,
+        address: &Address,
+    ) -> UtxoRpcResult<(Vec<UnspentInfo>, AsyncMutexGuard<'a, RecentlySpentOutPoints>)> {
+        utxo_common::list_mature_unspent_ordered(self, address).await
     }
 
     fn get_verbose_transaction_from_cache_or_rpc(&self, txid: H256Json) -> UtxoRpcFut<VerboseTransactionFrom> {
@@ -417,7 +424,7 @@ impl MarketCoinOps for UtxoStandardCoin {
 
     fn my_address(&self) -> Result<String, String> { utxo_common::my_address(self) }
 
-    fn my_balance(&self) -> BalanceFut<CoinBalance> { utxo_common::my_balance(&self.utxo_arc) }
+    fn my_balance(&self) -> BalanceFut<CoinBalance> { utxo_common::my_balance(self.clone()) }
 
     fn base_coin_balance(&self) -> BalanceFut<BigDecimal> { utxo_common::base_coin_balance(self) }
 
@@ -579,7 +586,7 @@ impl AddressBalanceOps for UtxoStandardCoin {
     type Address = Address;
 
     async fn address_balance(&self, address: &Self::Address) -> BalanceResult<CoinBalance> {
-        utxo_common::address_balance(self.as_ref(), address.clone()).await
+        utxo_common::address_balance(self, address).await
     }
 }
 

--- a/mm2src/coins/utxo/utxo_withdraw.rs
+++ b/mm2src/coins/utxo/utxo_withdraw.rs
@@ -156,7 +156,7 @@ where
         let script_pubkey = output_script(&to, script_type).to_bytes();
 
         let _utxo_lock = UTXO_LOCK.lock().await;
-        let (unspents, _) = coin.ordered_mature_unspents(&self.from_address()).await?;
+        let (unspents, _) = coin.list_unspent_ordered(&self.from_address()).await?;
         let (value, fee_policy) = if req.max {
             (
                 unspents.iter().fold(0, |sum, unspent| sum + unspent.value),

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -1328,11 +1328,18 @@ impl UtxoCommonOps for ZCoin {
         .await
     }
 
-    async fn ordered_mature_unspents<'a>(
+    async fn list_all_unspent_ordered<'a>(
         &'a self,
         address: &Address,
     ) -> UtxoRpcResult<(Vec<UnspentInfo>, AsyncMutexGuard<'a, RecentlySpentOutPoints>)> {
-        utxo_common::ordered_mature_unspents(self, address).await
+        utxo_common::list_all_unspent_ordered(self, address).await
+    }
+
+    async fn list_mature_unspent_ordered<'a>(
+        &'a self,
+        address: &Address,
+    ) -> UtxoRpcResult<(Vec<UnspentInfo>, AsyncMutexGuard<'a, RecentlySpentOutPoints>)> {
+        utxo_common::list_mature_unspent_ordered(self, address).await
     }
 
     fn get_verbose_transaction_from_cache_or_rpc(&self, txid: H256Json) -> UtxoRpcFut<VerboseTransactionFrom> {

--- a/mm2src/coins_activation/src/utxo_activation/init_qtum_activation.rs
+++ b/mm2src/coins_activation/src/utxo_activation/init_qtum_activation.rs
@@ -9,8 +9,8 @@ use crate::utxo_activation::utxo_standard_activation_result::UtxoStandardActivat
 use crate::utxo_activation::utxo_standard_coin_hw_ops::UtxoStandardCoinHwOps;
 use async_trait::async_trait;
 use coins::coin_balance::EnableCoinBalanceOps;
-use coins::utxo::qtum::QtumCoin;
-use coins::utxo::utxo_builder::{UtxoArcBuilder, UtxoCoinBuilder};
+use coins::utxo::qtum::{QtumCoin, QtumCoinBuilder};
+use coins::utxo::utxo_builder::UtxoCoinBuilder;
 use coins::utxo::UtxoActivationParams;
 use coins::{lp_register_coin, CoinProtocol, MarketCoinOps, MmCoinEnum, PrivKeyBuildPolicy, RegisterCoinParams};
 use common::mm_ctx::MmArc;
@@ -57,18 +57,10 @@ impl InitStandaloneCoinActivationOps for QtumCoin {
     ) -> Result<Self, MmError<Self::ActivationError>> {
         let hw_ops = UtxoStandardCoinHwOps::new(&ctx, task_handle);
         let tx_history = activation_request.tx_history;
-        let coin = UtxoArcBuilder::new(
-            &ctx,
-            &ticker,
-            &coin_conf,
-            &activation_request,
-            priv_key_policy,
-            hw_ops,
-            QtumCoin::from,
-        )
-        .build()
-        .await
-        .mm_err(|e| InitUtxoStandardError::from_build_err(e, ticker.clone()))?;
+        let coin = QtumCoinBuilder::new(&ctx, &ticker, &coin_conf, &activation_request, priv_key_policy, hw_ops)
+            .build()
+            .await
+            .mm_err(|e| InitUtxoStandardError::from_build_err(e, ticker.clone()))?;
         lp_register_coin(&ctx, MmCoinEnum::from(coin.clone()), RegisterCoinParams {
             ticker: ticker.clone(),
             tx_history,

--- a/mm2src/docker_tests/docker_tests_common.rs
+++ b/mm2src/docker_tests/docker_tests_common.rs
@@ -13,7 +13,7 @@ use bigdecimal::BigDecimal;
 use bitcrypto::{dhash160, ChecksumType};
 use coins::qrc20::rpc_clients::for_tests::Qrc20NativeWalletOps;
 use coins::qrc20::{qrc20_coin_from_conf_and_params, Qrc20ActivationParams, Qrc20Coin};
-use coins::utxo::qtum::{qtum_coin_from_with_priv_key, QtumBasedCoin, QtumCoin};
+use coins::utxo::qtum::{qtum_coin_with_priv_key, QtumBasedCoin, QtumCoin};
 use coins::utxo::rpc_clients::{NativeClient, UtxoRpcClientEnum, UtxoRpcClientOps};
 use coins::utxo::utxo_standard::{utxo_standard_coin_with_priv_key, UtxoStandardCoin};
 use coins::utxo::{coin_daemon_data_dir, sat_from_big_decimal, zcash_params_path, UtxoActivationParams,
@@ -352,7 +352,7 @@ pub fn generate_qtum_coin_with_random_privkey(
     let priv_key = SecretKey::new(&mut rand6::thread_rng());
     let ctx = MmCtxBuilder::new().into_mm_arc();
     let params = UtxoActivationParams::from_legacy_req(&req).unwrap();
-    let coin = block_on(qtum_coin_from_with_priv_key(
+    let coin = block_on(qtum_coin_with_priv_key(
         &ctx,
         "QTUM",
         &conf,
@@ -397,7 +397,7 @@ pub fn generate_segwit_qtum_coin_with_random_privkey(
     let priv_key = SecretKey::new(&mut rand6::thread_rng());
     let ctx = MmCtxBuilder::new().into_mm_arc();
     let params = UtxoActivationParams::from_legacy_req(&req).unwrap();
-    let coin = block_on(qtum_coin_from_with_priv_key(
+    let coin = block_on(qtum_coin_with_priv_key(
         &ctx,
         "QTUM",
         &conf,

--- a/mm2src/docker_tests/qrc20_tests.rs
+++ b/mm2src/docker_tests/qrc20_tests.rs
@@ -3,7 +3,7 @@ use crate::mm2::lp_swap::{dex_fee_amount, max_taker_vol_from_available};
 use bigdecimal::BigDecimal;
 use bitcrypto::dhash160;
 use coins::qrc20::rpc_clients::for_tests::Qrc20NativeWalletOps;
-use coins::utxo::qtum::{qtum_coin_from_with_priv_key, QtumCoin};
+use coins::utxo::qtum::{qtum_coin_with_priv_key, QtumCoin};
 use coins::utxo::rpc_clients::UtxoRpcClientEnum;
 use coins::utxo::utxo_common::big_decimal_from_sat;
 use coins::utxo::{UtxoActivationParams, UtxoCommonOps};
@@ -48,7 +48,7 @@ impl QtumDockerOps {
         });
         let priv_key = hex::decode("809465b17d0a4ddb3e4c69e8f23c2cabad868f51f8bed5c765ad1d6516c3306f").unwrap();
         let params = UtxoActivationParams::from_legacy_req(&req).unwrap();
-        let coin = block_on(qtum_coin_from_with_priv_key(&ctx, "QTUM", &conf, &params, &priv_key)).unwrap();
+        let coin = block_on(qtum_coin_with_priv_key(&ctx, "QTUM", &conf, &params, &priv_key)).unwrap();
         QtumDockerOps { ctx, coin }
     }
 


### PR DESCRIPTION
* Add `QtumCoinBuilder` and `QtumCoinWithIguanaPrivKeyBuilder` that override `check_utxo_maturity`
* Add `UtxoCommonOps::list_all_unspent_ordered` that behaves as `UtxoCommonOps::list_unspent_ordered` before
* `UtxoCommonOps::list_unspent_ordered` checks the `check_utxo_maturity` flag to use either `list_all_unspent_ordered` or `list_mature_unspent_ordered`
* Rename `UtxoCommonOps::ordered_mature_unspents` to `UtxoCommonOps::list_mature_unspent_ordered`