### PR TITLE
Add RPC call to get raw transaction encoded in hex

### DIFF
--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -537,9 +537,9 @@ async fn get_raw_transaction_impl(coin: EthCoin, req: RawTransactionRequest) -> 
         .map_err(|e| RawTransactionError::InvalidHashError(e.to_string()))?;
     let web3_tx = web3_tx.or_mm_err(|| RawTransactionError::Transport(req.tx_hash))?;
     let raw = signed_tx_from_web3_tx(web3_tx).unwrap();
-    return Ok(RawTransactionRes {
+    Ok(RawTransactionRes {
         tx_hex: BytesJson(rlp::encode(&raw)),
-    });
+    })
 }
 
 async fn withdraw_impl(ctx: MmArc, coin: EthCoin, req: WithdrawRequest) -> WithdrawResult {

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -31,7 +31,7 @@ use common::{now_ms, small_rng, DEX_FEE_ADDR_RAW_PUBKEY};
 use derive_more::Display;
 use ethabi::{Contract, Token};
 use ethcore_transaction::{Action, Transaction as UnSignedEthTx, UnverifiedTransaction};
-use ethereum_types::{Address, H160, U256};
+use ethereum_types::{Address, H160, H256, U256};
 use ethkey::{public_to_address, KeyPair, Public};
 use futures::compat::Future01CompatExt;
 use futures::future::{join_all, select, Either, FutureExt, TryFutureExt};
@@ -56,7 +56,8 @@ use web3::{self, Web3};
 
 use super::{BalanceError, BalanceFut, CoinBalance, CoinProtocol, CoinTransportMetrics, CoinsContext, FeeApproxStage,
             FoundSwapTxSpend, HistorySyncState, MarketCoinOps, MmCoin, NegotiateSwapContractAddrErr, NumConversError,
-            NumConversResult, RpcClientType, RpcTransportEventHandler, RpcTransportEventHandlerShared, SwapOps,
+            NumConversResult, RawTransactionError, RawTransactionFut, RawTransactionRequest, RawTransactionRes,
+            RawTransactionResult, RpcClientType, RpcTransportEventHandler, RpcTransportEventHandlerShared, SwapOps,
             TradeFee, TradePreimageError, TradePreimageFut, TradePreimageResult, TradePreimageValue, Transaction,
             TransactionDetails, TransactionEnum, TransactionFut, ValidateAddressResult, WithdrawError, WithdrawFee,
             WithdrawFut, WithdrawRequest, WithdrawResult};
@@ -522,6 +523,23 @@ impl EthCoinImpl {
     pub fn address_from_str(&self, address: &str) -> Result<Address, String> {
         Ok(try_s!(valid_addr_from_str(address)))
     }
+}
+
+async fn get_raw_transaction_impl(coin: EthCoin, req: RawTransactionRequest) -> RawTransactionResult {
+    let hash = H256::from_str(&req.tx_hash[2..req.tx_hash.len()])
+        .map_to_mm(|e| RawTransactionError::InvalidHashError(e.to_string()))?;
+    let web3_tx = coin
+        .web3
+        .eth()
+        .transaction(TransactionId::Hash(hash))
+        .compat()
+        .await
+        .map_err(|e| RawTransactionError::InvalidHashError(e.to_string()))?;
+    let web3_tx = web3_tx.or_mm_err(|| RawTransactionError::Transport(req.tx_hash))?;
+    let raw = signed_tx_from_web3_tx(web3_tx).unwrap();
+    return Ok(RawTransactionRes {
+        tx_hex: BytesJson(rlp::encode(&raw)),
+    });
 }
 
 async fn withdraw_impl(ctx: MmArc, coin: EthCoin, req: WithdrawRequest) -> WithdrawResult {
@@ -2888,6 +2906,10 @@ impl EthTxFeeDetails {
 #[async_trait]
 impl MmCoin for EthCoin {
     fn is_asset_chain(&self) -> bool { false }
+
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+        Box::new(get_raw_transaction_impl(self.clone(), req).boxed().compat())
+    }
 
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {
         let ctx = try_f!(MmArc::from_weak(&self.ctx).or_mm_err(|| WithdrawError::InternalError("!ctx".to_owned())));

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -536,7 +536,7 @@ async fn get_raw_transaction_impl(coin: EthCoin, req: RawTransactionRequest) -> 
         .await
         .map_err(|e| RawTransactionError::Transport(e.to_string()))?;
     let web3_tx = web3_tx.or_mm_err(|| RawTransactionError::HashNotExist(req.tx_hash))?;
-    let raw = signed_tx_from_web3_tx(web3_tx).unwrap();
+    let raw = signed_tx_from_web3_tx(web3_tx).map_to_mm(|e| RawTransactionError::InternalError(e.to_string()))?;
     Ok(RawTransactionRes {
         tx_hex: BytesJson(rlp::encode(&raw)),
     })

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -526,6 +526,9 @@ impl EthCoinImpl {
 }
 
 async fn get_raw_transaction_impl(coin: EthCoin, req: RawTransactionRequest) -> RawTransactionResult {
+    if req.tx_hash.len() < 2 {
+        return MmError::err(RawTransactionError::InvalidHashError(req.tx_hash));
+    }
     let hash = H256::from_str(&req.tx_hash[2..req.tx_hash.len()])
         .map_to_mm(|e| RawTransactionError::InvalidHashError(e.to_string()))?;
     let web3_tx = coin

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -536,7 +536,7 @@ async fn get_raw_transaction_impl(coin: EthCoin, req: RawTransactionRequest) -> 
         .await
         .map_err(|e| RawTransactionError::Transport(e.to_string()))?;
     let web3_tx = web3_tx.or_mm_err(|| RawTransactionError::HashNotExist(req.tx_hash))?;
-    let raw = signed_tx_from_web3_tx(web3_tx).map_to_mm(|e| RawTransactionError::InternalError(e.to_string()))?;
+    let raw = signed_tx_from_web3_tx(web3_tx).map_to_mm(RawTransactionError::InternalError)?;
     Ok(RawTransactionRes {
         tx_hex: BytesJson(rlp::encode(&raw)),
     })

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -534,8 +534,8 @@ async fn get_raw_transaction_impl(coin: EthCoin, req: RawTransactionRequest) -> 
         .transaction(TransactionId::Hash(hash))
         .compat()
         .await
-        .map_err(|e| RawTransactionError::InvalidHashError(e.to_string()))?;
-    let web3_tx = web3_tx.or_mm_err(|| RawTransactionError::Transport(req.tx_hash))?;
+        .map_err(|e| RawTransactionError::Transport(e.to_string()))?;
+    let web3_tx = web3_tx.or_mm_err(|| RawTransactionError::HashNotExist(req.tx_hash))?;
     let raw = signed_tx_from_web3_tx(web3_tx).unwrap();
     Ok(RawTransactionRes {
         tx_hex: BytesJson(rlp::encode(&raw)),

--- a/mm2src/coins/lightning.rs
+++ b/mm2src/coins/lightning.rs
@@ -3,9 +3,9 @@ use crate::utxo::rpc_clients::UtxoRpcClientEnum;
 use crate::utxo::utxo_common::{big_decimal_from_sat_unsigned, UtxoTxBuilder};
 use crate::utxo::{sat_from_big_decimal, BlockchainNetwork, FeePolicy, UtxoCommonOps, UtxoTxGenerationOps};
 use crate::{BalanceFut, CoinBalance, FeeApproxStage, FoundSwapTxSpend, HistorySyncState, MarketCoinOps, MmCoin,
-            NegotiateSwapContractAddrErr, SwapOps, TradeFee, TradePreimageFut, TradePreimageResult,
-            TradePreimageValue, TransactionEnum, TransactionFut, UtxoStandardCoin, ValidateAddressResult,
-            ValidatePaymentInput, WithdrawError, WithdrawFut, WithdrawRequest};
+            NegotiateSwapContractAddrErr, RawTransactionFut, RawTransactionRequest, SwapOps, TradeFee,
+            TradePreimageFut, TradePreimageResult, TradePreimageValue, TransactionEnum, TransactionFut,
+            UtxoStandardCoin, ValidateAddressResult, ValidatePaymentInput, WithdrawError, WithdrawFut, WithdrawRequest};
 use async_trait::async_trait;
 use bigdecimal::BigDecimal;
 use bitcoin::blockdata::script::Script;
@@ -438,6 +438,10 @@ impl MarketCoinOps for LightningCoin {
 #[async_trait]
 impl MmCoin for LightningCoin {
     fn is_asset_chain(&self) -> bool { false }
+
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+        Box::new(self.platform_coin().get_raw_transaction(req))
+    }
 
     fn withdraw(&self, _req: WithdrawRequest) -> WithdrawFut {
         let fut = async move {

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -167,6 +167,50 @@ pub type TradePreimageFut<T> = Box<dyn Future<Item = T, Error = MmError<TradePre
 pub type CoinFindResult<T> = Result<T, MmError<CoinFindError>>;
 pub type TxHistoryFut<T> = Box<dyn Future<Item = T, Error = MmError<TxHistoryError>> + Send>;
 pub type TxHistoryResult<T> = Result<T, MmError<TxHistoryError>>;
+pub type RawTransactionResult = Result<RawTransactionRes, MmError<RawTransactionError>>;
+pub type RawTransactionFut = Box<dyn Future<Item = RawTransactionRes, Error = MmError<RawTransactionError>> + Send>;
+
+#[derive(Debug, Deserialize, Display, Serialize, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum RawTransactionError {
+    #[display(fmt = "No such coin {}", coin)]
+    NoSuchCoin { coin: String },
+    #[display(fmt = "Invalid  hash: {}", _0)]
+    InvalidHashError(String),
+    #[display(fmt = "Transport error: {}", _0)]
+    Transport(String),
+}
+
+impl HttpStatusCode for RawTransactionError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            RawTransactionError::NoSuchCoin { .. } | RawTransactionError::InvalidHashError(_) => {
+                StatusCode::BAD_REQUEST
+            },
+            RawTransactionError::Transport(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl From<CoinFindError> for RawTransactionError {
+    fn from(e: CoinFindError) -> Self {
+        match e {
+            CoinFindError::NoSuchCoin { coin } => RawTransactionError::NoSuchCoin { coin },
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct RawTransactionRequest {
+    pub coin: String,
+    pub tx_hash: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct RawTransactionRes {
+    /// Raw bytes of signed transaction in hexadecimal string, this should be sent as is to send_raw_transaction RPC to broadcast the transaction
+    pub tx_hex: BytesJson,
+}
 
 #[derive(Debug, Display)]
 pub enum TxHistoryError {
@@ -1363,6 +1407,8 @@ pub trait MmCoin: SwapOps + MarketCoinOps + fmt::Debug + Send + Sync + 'static {
 
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut;
 
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut;
+
     /// Maximum number of digits after decimal point used to denominate integer coin units (satoshis, wei, etc.)
     fn decimals(&self) -> u8;
 
@@ -2175,6 +2221,11 @@ pub async fn validate_address(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>
 pub async fn withdraw(ctx: MmArc, req: WithdrawRequest) -> WithdrawResult {
     let coin = lp_coinfind_or_err(&ctx, &req.coin).await?;
     coin.withdraw(req).compat().await
+}
+
+pub async fn get_raw_transaction(ctx: MmArc, req: RawTransactionRequest) -> RawTransactionResult {
+    let coin = lp_coinfind_or_err(&ctx, &req.coin).await?;
+    coin.get_raw_transaction(req).compat().await
 }
 
 pub async fn remove_delegation(ctx: MmArc, req: RemoveDelegateRequest) -> DelegationResult {

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -168,7 +168,8 @@ pub type CoinFindResult<T> = Result<T, MmError<CoinFindError>>;
 pub type TxHistoryFut<T> = Box<dyn Future<Item = T, Error = MmError<TxHistoryError>> + Send>;
 pub type TxHistoryResult<T> = Result<T, MmError<TxHistoryError>>;
 pub type RawTransactionResult = Result<RawTransactionRes, MmError<RawTransactionError>>;
-pub type RawTransactionFut = Box<dyn Future<Item = RawTransactionRes, Error = MmError<RawTransactionError>> + Send>;
+pub type RawTransactionFut<'a> =
+    Box<dyn Future<Item = RawTransactionRes, Error = MmError<RawTransactionError>> + Send + 'a>;
 
 #[derive(Debug, Deserialize, Display, Serialize, SerializeErrorType)]
 #[serde(tag = "error_type", content = "error_data")]

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -179,15 +179,21 @@ pub enum RawTransactionError {
     InvalidHashError(String),
     #[display(fmt = "Transport error: {}", _0)]
     Transport(String),
+    #[display(fmt = "Hash does not exist: {}", _0)]
+    HashNotExist(String),
+    #[display(fmt = "Internal error: {}", _0)]
+    InternalError(String),
 }
 
 impl HttpStatusCode for RawTransactionError {
     fn status_code(&self) -> StatusCode {
         match self {
-            RawTransactionError::NoSuchCoin { .. } | RawTransactionError::InvalidHashError(_) => {
-                StatusCode::BAD_REQUEST
+            RawTransactionError::NoSuchCoin { .. }
+            | RawTransactionError::InvalidHashError(_)
+            | RawTransactionError::HashNotExist(_) => StatusCode::BAD_REQUEST,
+            RawTransactionError::Transport(_) | RawTransactionError::InternalError(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
             },
-            RawTransactionError::Transport(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/mm2src/coins/qrc20.rs
+++ b/mm2src/coins/qrc20.rs
@@ -12,10 +12,11 @@ use crate::utxo::{qtum, ActualTxFee, AdditionalTxData, BroadcastTxErr, FeePolicy
                   UtxoCommonOps, UtxoFromLegacyReqErr, UtxoTx, UtxoTxBroadcastOps, UtxoTxGenerationOps,
                   VerboseTransactionFrom, UTXO_LOCK};
 use crate::{BalanceError, BalanceFut, CoinBalance, FeeApproxStage, FoundSwapTxSpend, HistorySyncState, MarketCoinOps,
-            MmCoin, NegotiateSwapContractAddrErr, PrivKeyNotAllowed, SwapOps, TradeFee, TradePreimageError,
-            TradePreimageFut, TradePreimageResult, TradePreimageValue, TransactionDetails, TransactionEnum,
-            TransactionFut, TransactionType, UnexpectedDerivationMethod, ValidateAddressResult, ValidatePaymentInput,
-            WithdrawError, WithdrawFee, WithdrawFut, WithdrawRequest, WithdrawResult};
+            MmCoin, NegotiateSwapContractAddrErr, PrivKeyNotAllowed, RawTransactionFut, RawTransactionRequest,
+            SwapOps, TradeFee, TradePreimageError, TradePreimageFut, TradePreimageResult, TradePreimageValue,
+            TransactionDetails, TransactionEnum, TransactionFut, TransactionType, UnexpectedDerivationMethod,
+            ValidateAddressResult, ValidatePaymentInput, WithdrawError, WithdrawFee, WithdrawFut, WithdrawRequest,
+            WithdrawResult};
 use async_trait::async_trait;
 use bigdecimal::BigDecimal;
 use bitcrypto::{dhash160, sha256};
@@ -1113,6 +1114,10 @@ impl MmCoin for Qrc20Coin {
 
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {
         Box::new(qrc20_withdraw(self.clone(), req).boxed().compat())
+    }
+
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+        Box::new(utxo_common::get_raw_transaction(self.clone(), req).boxed().compat())
     }
 
     fn decimals(&self) -> u8 { utxo_common::decimals(&self.utxo) }

--- a/mm2src/coins/qrc20.rs
+++ b/mm2src/coins/qrc20.rs
@@ -1117,7 +1117,7 @@ impl MmCoin for Qrc20Coin {
     }
 
     fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
-        Box::new(utxo_common::get_raw_transaction(self.clone(), req).boxed().compat())
+        Box::new(utxo_common::get_raw_transaction(&self.utxo, req).boxed().compat())
     }
 
     fn decimals(&self) -> u8 { utxo_common::decimals(&self.utxo) }

--- a/mm2src/coins/solana.rs
+++ b/mm2src/coins/solana.rs
@@ -2,8 +2,9 @@ use super::{CoinBalance, HistorySyncState, MarketCoinOps, MmCoin, SwapOps, Trade
 use crate::solana::solana_common::{lamports_to_sol, PrepareTransferData, SufficientBalanceError};
 use crate::solana::spl::SplTokenInfo;
 use crate::{BalanceError, BalanceFut, FeeApproxStage, FoundSwapTxSpend, NegotiateSwapContractAddrErr,
-            TradePreimageFut, TradePreimageResult, TradePreimageValue, TransactionDetails, TransactionType,
-            ValidateAddressResult, ValidatePaymentInput, WithdrawError, WithdrawFut, WithdrawRequest, WithdrawResult};
+            RawTransactionFut, RawTransactionRequest, TradePreimageFut, TradePreimageResult, TradePreimageValue,
+            TransactionDetails, TransactionType, ValidateAddressResult, ValidatePaymentInput, WithdrawError,
+            WithdrawFut, WithdrawRequest, WithdrawResult};
 use async_trait::async_trait;
 use base58::ToBase58;
 use bigdecimal::BigDecimal;
@@ -562,6 +563,8 @@ impl MmCoin for SolanaCoin {
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {
         Box::new(Box::pin(withdraw_impl(self.clone(), req)).compat())
     }
+
+    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut { unimplemented!() }
 
     fn decimals(&self) -> u8 { self.decimals }
 

--- a/mm2src/coins/solana/spl.rs
+++ b/mm2src/coins/solana/spl.rs
@@ -1,9 +1,10 @@
 use super::{CoinBalance, HistorySyncState, MarketCoinOps, MmCoin, SwapOps, TradeFee, TransactionEnum, TransactionFut};
 use crate::solana::solana_common::{ui_amount_to_amount, PrepareTransferData, SufficientBalanceError};
 use crate::solana::{solana_common, AccountError, SolanaCommonOps, SolanaFeeDetails};
-use crate::{BalanceFut, FeeApproxStage, FoundSwapTxSpend, NegotiateSwapContractAddrErr, SolanaCoin, TradePreimageFut,
-            TradePreimageResult, TradePreimageValue, TransactionDetails, TransactionType, ValidateAddressResult,
-            ValidatePaymentInput, WithdrawError, WithdrawFut, WithdrawRequest, WithdrawResult};
+use crate::{BalanceFut, FeeApproxStage, FoundSwapTxSpend, NegotiateSwapContractAddrErr, RawTransactionFut,
+            RawTransactionRequest, SolanaCoin, TradePreimageFut, TradePreimageResult, TradePreimageValue,
+            TransactionDetails, TransactionType, ValidateAddressResult, ValidatePaymentInput, WithdrawError,
+            WithdrawFut, WithdrawRequest, WithdrawResult};
 use async_trait::async_trait;
 use bigdecimal::BigDecimal;
 use bincode::serialize;
@@ -407,6 +408,8 @@ impl MmCoin for SplToken {
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {
         Box::new(Box::pin(withdraw_impl(self.clone(), req)).compat())
     }
+
+    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut { unimplemented!() }
 
     fn decimals(&self) -> u8 { self.conf.decimals }
 

--- a/mm2src/coins/test_coin.rs
+++ b/mm2src/coins/test_coin.rs
@@ -1,4 +1,5 @@
-use super::{CoinBalance, HistorySyncState, MarketCoinOps, MmCoin, SwapOps, TradeFee, TransactionEnum, TransactionFut};
+use super::{CoinBalance, HistorySyncState, MarketCoinOps, MmCoin, RawTransactionFut, RawTransactionRequest, SwapOps,
+            TradeFee, TransactionEnum, TransactionFut};
 use crate::{BalanceFut, FeeApproxStage, FoundSwapTxSpend, NegotiateSwapContractAddrErr, TradePreimageFut,
             TradePreimageResult, TradePreimageValue, ValidateAddressResult, ValidatePaymentInput, WithdrawFut,
             WithdrawRequest};
@@ -233,6 +234,8 @@ impl SwapOps for TestCoin {
 #[allow(clippy::forget_ref, clippy::forget_copy, clippy::cast_ref_to_mut)]
 impl MmCoin for TestCoin {
     fn is_asset_chain(&self) -> bool { unimplemented!() }
+
+    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut { unimplemented!() }
 
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut { unimplemented!() }
 

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -89,9 +89,10 @@ use self::rpc_clients::{electrum_script_hash, ElectrumClient, ElectrumRpcRequest
                         NativeClient, UnspentInfo, UtxoRpcClientEnum, UtxoRpcError, UtxoRpcFut, UtxoRpcResult};
 use super::{BalanceError, BalanceFut, BalanceResult, CoinsContext, DerivationMethod, FeeApproxStage, FoundSwapTxSpend,
             HistorySyncState, KmdRewardsDetails, MarketCoinOps, MmCoin, NumConversError, NumConversResult,
-            PrivKeyNotAllowed, PrivKeyPolicy, RpcTransportEventHandler, RpcTransportEventHandlerShared, TradeFee,
-            TradePreimageError, TradePreimageFut, TradePreimageResult, Transaction, TransactionDetails,
-            TransactionEnum, TransactionFut, UnexpectedDerivationMethod, WithdrawError, WithdrawRequest};
+            PrivKeyNotAllowed, PrivKeyPolicy, RawTransactionFut, RawTransactionRequest, RawTransactionResult,
+            RpcTransportEventHandler, RpcTransportEventHandlerShared, TradeFee, TradePreimageError, TradePreimageFut,
+            TradePreimageResult, Transaction, TransactionDetails, TransactionEnum, TransactionFut,
+            UnexpectedDerivationMethod, WithdrawError, WithdrawRequest};
 use crate::coin_balance::{EnableCoinScanPolicy, HDAddressBalanceScanner};
 use crate::hd_wallet::{HDAccountOps, HDAccountsMutex, HDAddress, HDWalletCoinOps, HDWalletOps, InvalidBip44ChainError};
 use crate::hd_wallet_storage::{HDAccountStorageItem, HDWalletCoinStorage, HDWalletStorageError, HDWalletStorageResult};

--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -6,8 +6,8 @@ use crate::utxo::slp::{parse_slp_script, ParseSlpScriptError, SlpGenesisParams, 
 use crate::utxo::utxo_builder::{UtxoArcBuilder, UtxoCoinBuilder};
 use crate::utxo::utxo_common::big_decimal_from_sat_unsigned;
 use crate::{BlockHeightAndTime, CanRefundHtlc, CoinBalance, CoinProtocol, NegotiateSwapContractAddrErr,
-            PrivKeyBuildPolicy, SwapOps, TradePreimageValue, TransactionType, TxFeeDetails, ValidateAddressResult,
-            ValidatePaymentInput, WithdrawFut};
+            PrivKeyBuildPolicy, RawTransactionFut, RawTransactionRequest, SwapOps, TradePreimageValue,
+            TransactionType, TxFeeDetails, ValidateAddressResult, ValidatePaymentInput, WithdrawFut};
 use common::log::warn;
 use common::mm_metrics::MetricsArc;
 use common::mm_number::MmNumber;
@@ -1132,6 +1132,10 @@ impl UtxoStandardOps for BchCoin {
 #[async_trait]
 impl MmCoin for BchCoin {
     fn is_asset_chain(&self) -> bool { utxo_common::is_asset_chain(&self.utxo_arc) }
+
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+        Box::new(utxo_common::get_raw_transaction(self.clone(), req).boxed().compat())
+    }
 
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {
         Box::new(utxo_common::withdraw(self.clone(), req).boxed().compat())

--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -1134,7 +1134,7 @@ impl MmCoin for BchCoin {
     fn is_asset_chain(&self) -> bool { utxo_common::is_asset_chain(&self.utxo_arc) }
 
     fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
-        Box::new(utxo_common::get_raw_transaction(self.clone(), req).boxed().compat())
+        Box::new(utxo_common::get_raw_transaction(&self.utxo_arc, req).boxed().compat())
     }
 
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -730,6 +730,10 @@ impl MarketCoinOps for QtumCoin {
 impl MmCoin for QtumCoin {
     fn is_asset_chain(&self) -> bool { utxo_common::is_asset_chain(&self.utxo_arc) }
 
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+        Box::new(utxo_common::get_raw_transaction(self.clone(), req).boxed().compat())
+    }
+
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {
         Box::new(utxo_common::withdraw(self.clone(), req).boxed().compat())
     }

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -731,7 +731,7 @@ impl MmCoin for QtumCoin {
     fn is_asset_chain(&self) -> bool { utxo_common::is_asset_chain(&self.utxo_arc) }
 
     fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
-        Box::new(utxo_common::get_raw_transaction(self.clone(), req).boxed().compat())
+        Box::new(utxo_common::get_raw_transaction(&self.utxo_arc, req).boxed().compat())
     }
 
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {

--- a/mm2src/coins/utxo/slp.rs
+++ b/mm2src/coins/utxo/slp.rs
@@ -1491,7 +1491,13 @@ impl From<SlpFeeDetails> for TxFeeDetails {
 impl MmCoin for SlpToken {
     fn is_asset_chain(&self) -> bool { false }
 
-    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut { unimplemented!() }
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+        Box::new(
+            utxo_common::get_raw_transaction(self.platform_coin.clone(), req)
+                .boxed()
+                .compat(),
+        )
+    }
 
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {
         let coin = self.clone();

--- a/mm2src/coins/utxo/slp.rs
+++ b/mm2src/coins/utxo/slp.rs
@@ -1493,7 +1493,7 @@ impl MmCoin for SlpToken {
 
     fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
         Box::new(
-            utxo_common::get_raw_transaction(self.platform_coin.clone(), req)
+            utxo_common::get_raw_transaction(self.platform_coin.as_ref(), req)
                 .boxed()
                 .compat(),
         )

--- a/mm2src/coins/utxo/slp.rs
+++ b/mm2src/coins/utxo/slp.rs
@@ -11,10 +11,11 @@ use crate::utxo::{generate_and_send_tx, sat_from_big_decimal, ActualTxFee, Addit
                   FeePolicy, GenerateTxError, RecentlySpentOutPoints, UtxoCoinConf, UtxoCoinFields, UtxoCommonOps,
                   UtxoTx, UtxoTxBroadcastOps, UtxoTxGenerationOps};
 use crate::{BalanceFut, CoinBalance, FeeApproxStage, FoundSwapTxSpend, HistorySyncState, MarketCoinOps, MmCoin,
-            NegotiateSwapContractAddrErr, NumConversError, PrivKeyNotAllowed, SwapOps, TradeFee, TradePreimageError,
-            TradePreimageFut, TradePreimageResult, TradePreimageValue, TransactionDetails, TransactionEnum,
-            TransactionFut, TxFeeDetails, UnexpectedDerivationMethod, ValidateAddressResult, ValidatePaymentInput,
-            WithdrawError, WithdrawFee, WithdrawFut, WithdrawRequest};
+            NegotiateSwapContractAddrErr, NumConversError, PrivKeyNotAllowed, RawTransactionFut,
+            RawTransactionRequest, SwapOps, TradeFee, TradePreimageError, TradePreimageFut, TradePreimageResult,
+            TradePreimageValue, TransactionDetails, TransactionEnum, TransactionFut, TxFeeDetails,
+            UnexpectedDerivationMethod, ValidateAddressResult, ValidatePaymentInput, WithdrawError, WithdrawFee,
+            WithdrawFut, WithdrawRequest};
 
 use async_trait::async_trait;
 use bitcrypto::dhash160;
@@ -1489,6 +1490,8 @@ impl From<SlpFeeDetails> for TxFeeDetails {
 #[async_trait]
 impl MmCoin for SlpToken {
     fn is_asset_chain(&self) -> bool { false }
+
+    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut { unimplemented!() }
 
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {
         let coin = self.clone();

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -1805,13 +1805,9 @@ pub fn min_trading_vol(coin: &UtxoCoinFields) -> MmNumber {
 
 pub fn is_asset_chain(coin: &UtxoCoinFields) -> bool { coin.conf.asset_chain }
 
-pub async fn get_raw_transaction<T>(coin: T, req: RawTransactionRequest) -> RawTransactionResult
-where
-    T: AsRef<UtxoCoinFields> + UtxoCommonOps + MarketCoinOps,
-{
+pub async fn get_raw_transaction(coin: &UtxoCoinFields, req: RawTransactionRequest) -> RawTransactionResult {
     let hash = H256Json::from_str(&req.tx_hash).map_to_mm(|e| RawTransactionError::InvalidHashError(e.to_string()))?;
     let hex = coin
-        .as_ref()
         .rpc_client
         .get_transaction_bytes(&hash)
         .compat()

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -506,6 +506,10 @@ impl MarketCoinOps for UtxoStandardCoin {
 impl MmCoin for UtxoStandardCoin {
     fn is_asset_chain(&self) -> bool { utxo_common::is_asset_chain(&self.utxo_arc) }
 
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+        Box::new(utxo_common::get_raw_transaction(self.clone(), req).boxed().compat())
+    }
+
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {
         Box::new(utxo_common::withdraw(self.clone(), req).boxed().compat())
     }

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -507,7 +507,7 @@ impl MmCoin for UtxoStandardCoin {
     fn is_asset_chain(&self) -> bool { utxo_common::is_asset_chain(&self.utxo_arc) }
 
     fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
-        Box::new(utxo_common::get_raw_transaction(self.clone(), req).boxed().compat())
+        Box::new(utxo_common::get_raw_transaction(&self.utxo_arc, req).boxed().compat())
     }
 
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -8,9 +8,10 @@ use crate::utxo::{sat_from_big_decimal, utxo_common, ActualTxFee, AdditionalTxDa
                   UtxoAddressFormat, UtxoArc, UtxoCoinFields, UtxoCommonOps, UtxoFeeDetails, UtxoTxBroadcastOps,
                   UtxoTxGenerationOps, UtxoWeak, VerboseTransactionFrom};
 use crate::{BalanceFut, CoinBalance, FeeApproxStage, FoundSwapTxSpend, HistorySyncState, MarketCoinOps, MmCoin,
-            NegotiateSwapContractAddrErr, NumConversError, SwapOps, TradeFee, TradePreimageFut, TradePreimageResult,
-            TradePreimageValue, TransactionDetails, TransactionEnum, TransactionFut, TxFeeDetails,
-            UnexpectedDerivationMethod, ValidateAddressResult, ValidatePaymentInput, WithdrawFut, WithdrawRequest};
+            NegotiateSwapContractAddrErr, NumConversError, RawTransactionFut, RawTransactionRequest, SwapOps,
+            TradeFee, TradePreimageFut, TradePreimageResult, TradePreimageValue, TransactionDetails, TransactionEnum,
+            TransactionFut, TxFeeDetails, UnexpectedDerivationMethod, ValidateAddressResult, ValidatePaymentInput,
+            WithdrawFut, WithdrawRequest};
 use crate::{Transaction, WithdrawError};
 use async_trait::async_trait;
 use bitcrypto::dhash160;
@@ -1206,6 +1207,8 @@ impl MmCoin for ZCoin {
         };
         Box::new(fut.boxed().compat())
     }
+
+    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut { unimplemented!() }
 
     fn decimals(&self) -> u8 { self.utxo_arc.decimals }
 

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -54,7 +54,7 @@ use zcash_primitives::transaction::builder::Builder as ZTxBuilder;
 use zcash_primitives::transaction::components::{Amount, TxOut};
 use zcash_primitives::transaction::Transaction as ZTransaction;
 use zcash_primitives::{consensus, constants::mainnet as z_mainnet_constants, sapling::PaymentAddress,
-                       zip32::ExtendedSpendingKey};
+                       zip32::ExtendedFullViewingKey, zip32::ExtendedSpendingKey};
 use zcash_proofs::prover::LocalTxProver;
 
 mod z_htlc;
@@ -213,8 +213,8 @@ impl ZCoin {
 
         let z_unspents = self.my_spendable_z_unspents_ordered().await?;
         let mut selected_unspents = Vec::new();
-        let mut total_input_amount = BigDecimal::from(0);
-        let mut change = BigDecimal::from(0);
+        let mut total_input_amount = BigDecimal::from(0u8);
+        let mut change = BigDecimal::from(0u8);
 
         let mut received_by_me = 0u64;
 
@@ -240,7 +240,10 @@ impl ZCoin {
         let mut tx_builder = ZTxBuilder::new(ARRRConsensusParams {}, current_block.into());
 
         let mut ext = HashMap::new();
-        ext.insert(AccountId::default(), (&self.z_fields.z_spending_key).into());
+        ext.insert(
+            AccountId::default(),
+            ExtendedFullViewingKey::from(&self.z_fields.z_spending_key),
+        );
         let mut selected_notes_with_witness: Vec<(_, IncrementalWitness<Node>)> =
             Vec::with_capacity(selected_unspents.len());
 
@@ -287,7 +290,7 @@ impl ZCoin {
             tx_builder.add_sapling_output(z_out.viewing_key, z_out.to_addr, z_out.amount, z_out.memo)?;
         }
 
-        if change > BigDecimal::from(0) {
+        if change > BigDecimal::from(0u8) {
             let change_sat = sat_from_big_decimal(&change, self.utxo_arc.decimals)?;
             received_by_me += change_sat;
 
@@ -1208,8 +1211,8 @@ impl MmCoin for ZCoin {
         Box::new(fut.boxed().compat())
     }
 
-    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut {
-        Box::new(utxo_common::get_raw_transaction(self.clone(), req).boxed().compat())
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+        Box::new(utxo_common::get_raw_transaction(&self.utxo_arc, req).boxed().compat())
     }
 
     fn decimals(&self) -> u8 { self.utxo_arc.decimals }

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -1208,7 +1208,9 @@ impl MmCoin for ZCoin {
         Box::new(fut.boxed().compat())
     }
 
-    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut { unimplemented!() }
+    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut {
+        Box::new(utxo_common::get_raw_transaction(self.clone(), req).boxed().compat())
+    }
 
     fn decimals(&self) -> u8 { self.utxo_arc.decimals }
 

--- a/mm2src/mm2_tests.rs
+++ b/mm2src/mm2_tests.rs
@@ -5311,6 +5311,145 @@ async fn test_qrc20_history_impl() {
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
+fn test_get_raw_transaction() {
+    let coins = json! ([
+        {"coin":"RICK","asset":"RICK","required_confirmations":0,"txversion":4,"overwintered":1,"protocol":{"type":"UTXO"}},
+        {"coin":"ETH","name":"ethereum","protocol":{"type":"ETH"}},
+    ]);
+    let mm = MarketMakerIt::start(
+        json! ({
+            "gui": "nogui",
+            "netid": 9998,
+            "passphrase": "boob",
+            "coins": coins,
+            "i_am_seed": true,
+            "rpc_password": "pass",
+            "metrics_interval": 30.,
+        }),
+        "pass".into(),
+        local_start!("bob"),
+    )
+    .unwrap();
+    let (_dump_log, _dump_dashboard) = mm.mm_dump();
+    log!({ "log path: {}", mm.log_path.display() });
+    // RICK
+    let _electrum = block_on(enable_electrum(&mm, "RICK", false, &[
+        "electrum3.cipig.net:10017",
+        "electrum2.cipig.net:10017",
+        "electrum1.cipig.net:10017",
+    ]));
+    let raw = block_on(mm.rpc(json! ({
+        "mmrpc": "2.0",
+        "userpass": mm.userpass,
+        "method": "get_raw_transaction",
+        "params": {
+            "coin": "RICK",
+            "tx_hash": "989360b0225b4e05fa13643e2e306c8eb5c52fa611615dfd30195089010b1c7b",
+        },
+        "id": 0,
+    })))
+    .unwrap();
+    assert!(raw.0.is_success(), "get_raw_transaction for coin RICK: {}", raw.1);
+    let res: RpcSuccessResponse<RawTransactionResult> =
+        json::from_str(&raw.1).expect("Expected 'RpcSuccessResponse<RawTransactionResult>'");
+    let expected_hex = "0400008085202f89025655b6fec358091a4a6b34107e69b10bd7660056d8f2a1e5f8eef0db6aec960100000000494830450221008c89db5e2d93d7674fe152e37344dfd24a0b1d4d382a7e0bcfc5d8190a141d72022050ce4ef929429e7e1a6c4ebd3f72a1a2aa25da1e0df65553a2c657658077ed1d01feffffff79cc137b70c39c9c7c2b9230c818ec684ffe731bf1ae821f91ba9d3e526f55f00000000049483045022100868c71f4a8e1452a3bc8b1d053a846959ab7df63fb0d147e9173f69818bbb1f3022060c7e045a34cf6af61bc3a74dc2db7b8bfa4949bc5919acceed40fc07d8706d201feffffff0240043a0000000000232102afdbba3e3c90db5f0f4064118f79cf308f926c68afd64ea7afc930975663e4c4ac201efc01000000001976a914347f2aedf63bac168c2cc4f075a2850435e20ac188ac96d3c96036dd0e000000000000000000000000";
+    assert_eq!(res.result.tx_hex, expected_hex);
+
+    // ETH
+    let eth = block_on(mm.rpc(json! ({
+        "userpass": mm.userpass,
+        "method": "enable",
+        "coin": "ETH",
+        "urls": &["https://ropsten.infura.io/v3/c01c1b4cf66642528547624e1d6d9d6b"],
+        // Dev chain swap contract address
+        "swap_contract_address": "0xa09ad3cd7e96586ebd05a2607ee56b56fb2db8fd",
+        "mm2": 1,
+    })))
+    .unwrap();
+    assert_eq!(eth.0, StatusCode::OK, "'enable' failed: {}", eth.1);
+    let raw = block_on(mm.rpc(json! ({
+        "mmrpc": "2.0",
+        "userpass": mm.userpass,
+        "method": "get_raw_transaction",
+        "params": {
+            "coin": "ETH",
+            "tx_hash": "0xbdef3970c00752b0dc811cd93faadfd75a7a52e6b8e0b608c5519edcad801359",
+        },
+        "id": 0,
+    })))
+    .unwrap();
+    assert!(raw.0.is_success(), "get_raw_transaction for coin ETH: {}", raw.1);
+    let res: RpcSuccessResponse<RawTransactionResult> =
+        json::from_str(&raw.1).expect("Expected 'RpcSuccessResponse<RawTransactionResult>'");
+    let expected_hex = "f8a975843b9aca0083024f8394fab46e002bbf0b4509813474841e0716e673013680b84440c10f190000000000000000000000003ef8b4a81ab3444864377dde648268f00e3cd0700000000000000000000000000000000000000000000000004563918244f4000029a0ee799246e00354e173c2236aac52dca3d9e75ac98d2ac48ce67fdab42712c82ca06c42b9db9ebf22fa2aeb85927ba8275ea057f5bffdc2d4bd923606415a18b58a";
+    assert_eq!(res.result.tx_hex, expected_hex);
+
+    // invalid coin
+    let zombi_coin = String::from("ZOMBI");
+    let raw = block_on(mm.rpc(json! ({
+        "mmrpc": "2.0",
+        "userpass": mm.userpass,
+        "method": "get_raw_transaction",
+        "params": {
+            "coin": zombi_coin,
+            "tx_hash": "0xbdef3970c00752b0dc811cd93faadfd75a7a52e6b8e0b608c5519edcad801359",
+        },
+        "id": 1,
+    })))
+    .unwrap();
+    assert!(
+        raw.0.is_client_error(),
+        "get_raw_transaction should have failed, but got: {}",
+        raw.1
+    );
+    let error: RpcErrorResponse<raw_transaction_error::InvalidCoin> = json::from_str(&raw.1).unwrap();
+    let expected_error = raw_transaction_error::InvalidCoin { coin: zombi_coin };
+    assert_eq!(error.error_type, "NoSuchCoin");
+    assert_eq!(error.error_data, Some(expected_error));
+
+    // invalid hash
+    let raw = block_on(mm.rpc(json! ({
+        "mmrpc": "2.0",
+        "userpass": mm.userpass,
+        "method": "get_raw_transaction",
+        "params": {
+            "coin": "ETH",
+            "tx_hash": "xxx",
+        },
+        "id": 2,
+    })))
+    .unwrap();
+    assert!(
+        raw.0.is_client_error(),
+        "get_raw_transaction should have failed, but got: {}",
+        raw.1
+    );
+    let error: RpcErrorResponse<String> = json::from_str(&raw.1).unwrap();
+    assert_eq!(error.error_type, "InvalidHashError");
+
+    // valid hash but transport error
+    let raw = block_on(mm.rpc(json! ({
+        "mmrpc": "2.0",
+        "userpass": mm.userpass,
+        "method": "get_raw_transaction",
+        "params": {
+            "coin": "ETH",
+            "tx_hash": "0xbdef3970c00752b0dc811cd93faadfd75a7a52e6b8e0b608c000000000000000",
+        },
+        "id": 3,
+    })))
+    .unwrap();
+    assert!(
+        raw.0.is_server_error(),
+        "get_raw_transaction should have failed, but got: {}",
+        raw.1
+    );
+    let error: RpcErrorResponse<String> = json::from_str(&raw.1).unwrap();
+    assert_eq!(error.error_type, "Transport");
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
 fn test_qrc20_tx_history() { block_on(test_qrc20_history_impl()); }
 
 #[wasm_bindgen_test]

--- a/mm2src/mm2_tests.rs
+++ b/mm2src/mm2_tests.rs
@@ -5427,7 +5427,7 @@ fn test_get_raw_transaction() {
     let error: RpcErrorResponse<String> = json::from_str(&raw.1).unwrap();
     assert_eq!(error.error_type, "InvalidHashError");
 
-    // valid hash but transport error
+    // valid hash but hash not exist
     let raw = block_on(mm.rpc(json! ({
         "mmrpc": "2.0",
         "userpass": mm.userpass,
@@ -5440,12 +5440,12 @@ fn test_get_raw_transaction() {
     })))
     .unwrap();
     assert!(
-        raw.0.is_server_error(),
+        raw.0.is_client_error(),
         "get_raw_transaction should have failed, but got: {}",
         raw.1
     );
     let error: RpcErrorResponse<String> = json::from_str(&raw.1).unwrap();
-    assert_eq!(error.error_type, "Transport");
+    assert_eq!(error.error_type, "HashNotExist");
 }
 
 #[test]

--- a/mm2src/mm2_tests.rs
+++ b/mm2src/mm2_tests.rs
@@ -5407,6 +5407,44 @@ fn test_get_raw_transaction() {
     assert_eq!(error.error_type, "NoSuchCoin");
     assert_eq!(error.error_data, Some(expected_error));
 
+    // empty hash
+    let raw = block_on(mm.rpc(json! ({
+        "mmrpc": "2.0",
+        "userpass": mm.userpass,
+        "method": "get_raw_transaction",
+        "params": {
+            "coin": "ETH",
+            "tx_hash": "",
+        },
+        "id": 2,
+    })))
+    .unwrap();
+    assert!(
+        raw.0.is_client_error(),
+        "get_raw_transaction should have failed, but got: {}",
+        raw.1
+    );
+    let error: RpcErrorResponse<String> = json::from_str(&raw.1).unwrap();
+    assert_eq!(error.error_type, "InvalidHashError");
+    // invalid hash without 0x prefix
+    let raw = block_on(mm.rpc(json! ({
+        "mmrpc": "2.0",
+        "userpass": mm.userpass,
+        "method": "get_raw_transaction",
+        "params": {
+            "coin": "ETH",
+            "tx_hash": "bdef3970c00752b0dc811cd93faadfd75a7a52e6b8e0b608c000000000000000",
+        },
+        "id": 2,
+    })))
+    .unwrap();
+    assert!(
+        raw.0.is_client_error(),
+        "get_raw_transaction should have failed, but got: {}",
+        raw.1
+    );
+    let error: RpcErrorResponse<String> = json::from_str(&raw.1).unwrap();
+    assert_eq!(error.error_type, "InvalidHashError");
     // invalid hash
     let raw = block_on(mm.rpc(json! ({
         "mmrpc": "2.0",
@@ -5414,7 +5452,7 @@ fn test_get_raw_transaction() {
         "method": "get_raw_transaction",
         "params": {
             "coin": "ETH",
-            "tx_hash": "xxx",
+            "tx_hash": "xx",
         },
         "id": 2,
     })))

--- a/mm2src/mm2_tests/structs.rs
+++ b/mm2src/mm2_tests/structs.rs
@@ -521,6 +521,13 @@ pub struct MaxTakerVolResponse {
     pub coin: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawTransactionResult {
+    /// Raw bytes of signed transaction in hexadecimal string, this should be sent as is to send_raw_transaction RPC to broadcast the transaction
+    pub tx_hex: String,
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum TransactionType {
     StakingDelegation,

--- a/mm2src/mm2_tests/structs.rs
+++ b/mm2src/mm2_tests/structs.rs
@@ -528,6 +528,14 @@ pub struct RawTransactionResult {
     pub tx_hex: String,
 }
 
+pub mod raw_transaction_error {
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    pub struct InvalidCoin {
+        pub coin: String,
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum TransactionType {
     StakingDelegation,

--- a/mm2src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/rpc/dispatcher/dispatcher.rs
@@ -16,7 +16,7 @@ use coins::utxo::bch::BchCoin;
 use coins::utxo::qtum::QtumCoin;
 use coins::utxo::slp::SlpToken;
 use coins::utxo::utxo_standard::UtxoStandardCoin;
-use coins::{add_delegation, get_staking_infos, remove_delegation, withdraw};
+use coins::{add_delegation, get_raw_transaction, get_staking_infos, remove_delegation, withdraw};
 use coins_activation::{enable_l2, enable_platform_coin_with_tokens, enable_token, init_standalone_coin,
                        init_standalone_coin_status, init_standalone_coin_user_action};
 use common::log::{error, warn};
@@ -123,6 +123,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "enable_slp" => handle_mmrpc(ctx, request, enable_token::<SlpToken>).await,
         "get_new_address" => handle_mmrpc(ctx, request, get_new_address).await,
         "get_public_key" => handle_mmrpc(ctx, request, get_public_key).await,
+        "get_raw_transaction" => handle_mmrpc(ctx, request, get_raw_transaction).await,
         "get_staking_infos" => handle_mmrpc(ctx, request, get_staking_infos).await,
         "init_create_new_account" => handle_mmrpc(ctx, request, init_create_new_account).await,
         "init_create_new_account_status" => handle_mmrpc(ctx, request, init_create_new_account_status).await,


### PR DESCRIPTION
Add func `get_raw_transaction` for all coins that implemented this feature.

coins:
- `eth`
- `qrc20`
- `utxo` coins except `slp`
- `bch`
- `lightning`
- other coins like `slp` and `z_coin` should be add in the future

also add unit test to check the result of this func.

@artemii235 