### PR TITLE
provide custom swap locktime functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ default-run = "mm2"
 native = []
 zhtlc = ["coins/zhtlc"]
 track-ctx-pointer = ["common/track-ctx-pointer"]
+custom-swap-locktime = [] # only for testing purposes, should never be activated on release builds.
 
 [[bin]]
 name = "mm2"

--- a/mm2src/docker_tests/swaps_confs_settings_sync_tests.rs
+++ b/mm2src/docker_tests/swaps_confs_settings_sync_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::mm2::lp_ordermatch::OrderConfirmationsSettings;
-use crate::mm2::lp_swap::PAYMENT_LOCKTIME;
+use crate::mm2::lp_swap::get_payment_locktime;
 
 struct SwapConfirmationsSettings {
     maker_coin_confs: u64,
@@ -374,7 +374,7 @@ fn test_buy_maker_should_use_taker_confs_and_notas_for_maker_payment_if_taker_re
         taker_settings,
         expected_maker,
         expected_taker,
-        PAYMENT_LOCKTIME * 4,
+        get_payment_locktime() * 4,
     );
 }
 
@@ -413,7 +413,7 @@ fn test_buy_maker_should_not_use_taker_confs_and_notas_for_maker_payment_if_take
         taker_settings,
         expected_maker,
         expected_taker,
-        PAYMENT_LOCKTIME * 4,
+        get_payment_locktime() * 4,
     );
 }
 
@@ -452,7 +452,7 @@ fn test_buy_taker_should_use_maker_confs_and_notas_for_taker_payment_if_maker_re
         taker_settings,
         expected_maker,
         expected_taker,
-        PAYMENT_LOCKTIME * 4,
+        get_payment_locktime() * 4,
     );
 }
 
@@ -491,7 +491,7 @@ fn test_buy_taker_should_not_use_maker_confs_and_notas_for_taker_payment_if_make
         taker_settings,
         expected_maker,
         expected_taker,
-        PAYMENT_LOCKTIME * 4,
+        get_payment_locktime() * 4,
     );
 }
 
@@ -530,7 +530,7 @@ fn test_buy_nodes_should_properly_sync_locktime_if_conf_sync_ends_up_without_not
         taker_settings,
         expected_maker,
         expected_taker,
-        PAYMENT_LOCKTIME,
+        get_payment_locktime(),
     );
 }
 
@@ -569,7 +569,7 @@ fn test_sell_maker_should_use_taker_confs_and_notas_for_maker_payment_if_taker_r
         taker_settings,
         expected_maker,
         expected_taker,
-        PAYMENT_LOCKTIME * 4,
+        get_payment_locktime() * 4,
     );
 }
 
@@ -608,7 +608,7 @@ fn test_sell_maker_should_not_use_taker_confs_and_notas_for_maker_payment_if_tak
         taker_settings,
         expected_maker,
         expected_taker,
-        PAYMENT_LOCKTIME * 4,
+        get_payment_locktime() * 4,
     );
 }
 
@@ -647,7 +647,7 @@ fn test_sell_taker_should_use_maker_confs_and_notas_for_taker_payment_if_maker_r
         taker_settings,
         expected_maker,
         expected_taker,
-        PAYMENT_LOCKTIME * 4,
+        get_payment_locktime() * 4,
     );
 }
 
@@ -686,7 +686,7 @@ fn test_sell_taker_should_not_use_maker_confs_and_notas_for_taker_payment_if_mak
         taker_settings,
         expected_maker,
         expected_taker,
-        PAYMENT_LOCKTIME * 4,
+        get_payment_locktime() * 4,
     );
 }
 
@@ -725,6 +725,6 @@ fn test_sell_nodes_should_properly_sync_locktime_if_conf_sync_ends_up_without_no
         taker_settings,
         expected_maker,
         expected_taker,
-        PAYMENT_LOCKTIME,
+        get_payment_locktime(),
     );
 }

--- a/mm2src/lp_swap.rs
+++ b/mm2src/lp_swap.rs
@@ -277,7 +277,7 @@ const PAYMENT_LOCKTIME: u64 = 3600 * 2 + 300 * 2;
 /// Default atomic swap payment locktime, in seconds.
 /// Maker sends payment with LOCKTIME * 2
 /// Taker sends payment with LOCKTIME
-pub(crate) static PAYMENT_LOCKTIME: AtomicU64 = AtomicU64::new(900);
+pub(crate) static PAYMENT_LOCKTIME: AtomicU64 = AtomicU64::new(super::CUSTOM_PAYMENT_LOCKTIME_DEFAULT);
 
 #[inline]
 /// Returns `PAYMENT_LOCKTIME`

--- a/mm2src/lp_swap.rs
+++ b/mm2src/lp_swap.rs
@@ -81,6 +81,9 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex, Weak};
 use uuid::Uuid;
 
+#[cfg(feature = "custom-swap-locktime")]
+use std::{env, ffi::OsString};
+
 #[path = "lp_swap/check_balance.rs"] mod check_balance;
 #[path = "lp_swap/maker_swap.rs"] mod maker_swap;
 #[path = "lp_swap/my_swaps_storage.rs"] mod my_swaps_storage;
@@ -274,7 +277,9 @@ const PAYMENT_LOCKTIME: u64 = 3600 * 2 + 300 * 2;
 /// Reads `payment_locktime` from cli or MM2.json configuration and returns it.
 /// Returns 900 when `payment_locktime` is invalid or not provided.
 pub fn get_payment_locktime_from_mm2config() -> u64 {
-    let conf = super::get_mm2config(None).unwrap();
+    let args: Vec<OsString> = env::args_os().collect();
+    let first_arg = args.get(1).and_then(|arg| arg.to_str());
+    let conf = super::get_mm2config(first_arg).unwrap();
 
     match conf["payment_locktime"].as_u64() {
         Some(lt) => lt,

--- a/mm2src/lp_swap.rs
+++ b/mm2src/lp_swap.rs
@@ -282,8 +282,7 @@ lazy_static! {
 }
 
 #[inline]
-/// Returns `PAYMENT_LOCKTIME` or result of `get_payment_locktime_from_mm2config()`
-/// depended on the activation of `custom-swap-locktime` feature.
+/// Returns `PAYMENT_LOCKTIME`
 pub fn get_payment_locktime() -> u64 {
     #[cfg(not(feature = "custom-swap-locktime"))]
     return PAYMENT_LOCKTIME;

--- a/mm2src/mm2.rs
+++ b/mm2src/mm2.rs
@@ -31,6 +31,8 @@ use common::mm_ctx::MmCtxBuilder;
 #[cfg(feature = "custom-swap-locktime")] use common::log::warn;
 #[cfg(feature = "custom-swap-locktime")]
 use lp_swap::PAYMENT_LOCKTIME;
+#[cfg(feature = "custom-swap-locktime")]
+use std::sync::atomic::Ordering;
 
 use derive_more::Display;
 use gstuff::slurp;
@@ -212,7 +214,7 @@ fn check_password_policy() {
 /// Reads `payment_locktime` from conf arg and assigns it into `PAYMENT_LOCKTIME` in lp_swap.
 /// Assigns 900 if `payment_locktime` is invalid or not provided.
 fn initialize_payment_locktime(conf: &Json) {
-    *PAYMENT_LOCKTIME.lock().unwrap() = match conf["payment_locktime"].as_u64() {
+    let val = match conf["payment_locktime"].as_u64() {
         Some(lt) => lt,
         None => {
             let def = 900;
@@ -224,6 +226,8 @@ fn initialize_payment_locktime(conf: &Json) {
             def
         },
     };
+
+    PAYMENT_LOCKTIME.store(val, Ordering::Relaxed);
 }
 
 /// * `ctx_cb` - callback used to share the `MmCtx` ID with the call site.

--- a/mm2src/mm2.rs
+++ b/mm2src/mm2.rs
@@ -209,6 +209,8 @@ fn check_password_policy() {
 }
 
 #[cfg(feature = "custom-swap-locktime")]
+/// Reads `payment_locktime` from conf arg and assigns it into `PAYMENT_LOCKTIME` in lp_swap.
+/// Assigns 900 if `payment_locktime` is invalid or not provided.
 fn initialize_payment_locktime(conf: &Json) {
     *PAYMENT_LOCKTIME.lock().unwrap() = match conf["payment_locktime"].as_u64() {
         Some(lt) => lt,

--- a/mm2src/mm2.rs
+++ b/mm2src/mm2.rs
@@ -377,13 +377,10 @@ pub fn mm2_main() {
     }
 }
 
-/// Parses the `first_arg` as JSON and runs LP_main.
-/// Attempts to load the config from `MM2.json` file if `first_arg` is None
-///
-/// * `ctx_cb` - Invoked with the MM context handle,
-///              allowing the `run_lp_main` caller to communicate with MM.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn run_lp_main(first_arg: Option<&str>, ctx_cb: &dyn Fn(u32)) -> Result<(), String> {
+/// Parses and returns the `first_arg` as JSON.
+/// Attempts to load the config from `MM2.json` file if `first_arg` is None
+pub fn get_mm2config(first_arg: Option<&str>) -> Result<Json, String> {
     let conf_path = env::var("MM_CONF_PATH").unwrap_or_else(|_| "MM2.json".into());
     let conf_from_file = slurp(&conf_path);
     let conf = match first_arg {
@@ -423,6 +420,17 @@ pub fn run_lp_main(first_arg: Option<&str>, ctx_cb: &dyn Fn(u32)) -> Result<(), 
             },
         }
     }
+
+    Ok(conf)
+}
+
+/// Runs LP_main with result of `get_mm2config()`.
+///
+/// * `ctx_cb` - Invoked with the MM context handle,
+///              allowing the `run_lp_main` caller to communicate with MM.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn run_lp_main(first_arg: Option<&str>, ctx_cb: &dyn Fn(u32)) -> Result<(), String> {
+    let conf = get_mm2config(first_arg)?;
 
     let log_filter = LogLevel::from_env();
 


### PR DESCRIPTION
This PR allows you to provide custom payment_locktime from either CLI or MM2.json. The property name should be `payment_locktime`. When it's not provided or invalid type, it will be processed as 900 seconds.

Example MM2.json:
```json
{
  "payment_locktime": 1453
}
```
Example Command-Line
```
mm2 "{ \"payment_locktime\": 1453 }"
```


#### For security and performance concerns, this functionality will be compiled into binary only if you build mm2 with `custom-swap-locktime` feature enabled.


closes #1246
 
Signed-off-by: ozkanonur <work@onurozkan.dev>