### PR TITLE
Update block headers in DB in case of a chain reorganization

### DIFF
--- a/mm2src/coins/utxo/utxo_sql_block_header_storage.rs
+++ b/mm2src/coins/utxo/utxo_sql_block_header_storage.rs
@@ -39,9 +39,9 @@ fn create_block_header_cache_table_sql(for_coin: &str) -> Result<String, MmError
 
 fn insert_block_header_in_cache_sql(for_coin: &str) -> Result<String, MmError<BlockHeaderStorageError>> {
     let table_name = get_table_name_and_validate(for_coin)?;
-    // We can simply ignore the repetitive attempt to insert the same block_height
+    // Always update the block headers with new values just in case a chain reorganization occurs.
     let sql = format!(
-        "INSERT OR IGNORE INTO {} (block_height, hex) VALUES (?1, ?2);",
+        "INSERT OR REPLACE INTO {} (block_height, hex) VALUES (?1, ?2);",
         table_name
     );
     Ok(sql)


### PR DESCRIPTION
https://github.com/KomodoPlatform/atomicDEX-API/blob/9c79755a19e3e4a6e0e5515b0586b9be3c9abf8b/mm2src/coins/utxo.rs#L1101
`blocks_limit_to_check` in coins config has to be equal to or greater than the number of blocks needed before the chain is safe from reorganization (e.g. 6 blocks for BTC) to avoid invalid SPV proofs in case of block reorganization.