### PR TITLE
Temporary ignore RUSTSEC-2020-0071 (time crate potential segfault).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3831,7 +3831,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
  "value-bag",
 ]
 
@@ -3852,19 +3851,11 @@ dependencies = [
  "chrono",
  "derivative",
  "fnv",
- "humantime 2.1.0",
  "libc",
  "log 0.4.14",
  "log-mdc",
- "parking_lot 0.11.1",
- "regex",
- "serde",
- "serde-value",
- "serde_json",
- "serde_yaml",
  "thiserror",
  "thread-id",
- "typemap",
  "winapi",
 ]
 
@@ -4594,15 +4585,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "ordered-float"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "ouroboros"
@@ -6168,16 +6150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
 ]
 
 [[package]]
@@ -8017,12 +7989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
 name = "trezor"
 version = "0.1.1"
 dependencies = [
@@ -8150,15 +8116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typemap"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
-dependencies = [
- "unsafe-any",
-]
-
-[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8254,15 +8211,6 @@ checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array 0.14.5",
  "subtle 2.4.0",
-]
-
-[[package]]
-name = "unsafe-any"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
-dependencies = [
- "traitobject",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -49,8 +49,10 @@ notice = "warn"
 # output a note when they are encountered.
 
 # RUSTSEC-2021-0113 is related to metrics-util crate that is not actively used for now despite being still present in deps tree
+# RUSTSEC-2020-0071 is related to time crate, which is used only by chrono in our deps tree, remove when https://github.com/chronotope/chrono/issues/700 is resolved
 ignore = [
-    "RUSTSEC-2021-0113"
+    "RUSTSEC-2021-0113",
+    "RUSTSEC-2020-0071",
     #"RUSTSEC-0000-0000",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -84,7 +84,7 @@ hyper = { version = "0.14.11", features = ["client", "http2", "server", "tcp"] }
 # got "invalid certificate: UnknownIssuer" for https://ropsten.infura.io on iOS using default-features
 hyper-rustls = { version = "0.23", default-features = false, features = ["http1", "http2", "webpki-tokio"] }
 libc = { version = "0.2" }
-log4rs = { version = "1.0" }
+log4rs = { version = "1.0", default-features = false, features = ["console_appender", "pattern_encoder"] }
 metrics = { version = "0.12" }
 metrics-runtime = { version = "0.13", default-features = false, features = ["metrics-observer-prometheus"] }
 metrics-core = { version = "0.5" }


### PR DESCRIPTION
Also disabled default features for log4rs, which reduced the number of deps a bit.

@sergeyboyko0791 @ozkanonur @shamardy Requesting your review mostly for ACK.