### PR TITLE
Remove unused dependencies, add unused dependencies check step to CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,15 @@ and we use [rustfmt](https://github.com/rust-lang/rustfmt) to make our code clea
     ```shell
     cargo clippy -- -D warnings
     ```
-3. Make sure that no new dependencies duplicates appear. Run the following check
+3. Make sure there are no unused dependencies. Run the following check
+   ```shell
+   cargo udeps
+   ```
+4. Make sure that no new dependencies duplicates appear. Run the following check
    ```shell
    cargo deny check bans
    ```
-4. Make sure that dependencies do not have known vulnerabilities. If they do, update them.
+5. Make sure that dependencies do not have known vulnerabilities. If they do, update them.
    ```shell
    cargo deny check advisories
    ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,10 +1075,8 @@ dependencies = [
  "web-sys",
  "web3",
  "webpki-roots",
- "winapi",
  "zbase32",
  "zcash_client_backend",
- "zcash_client_sqlite",
  "zcash_primitives",
  "zcash_proofs",
 ]
@@ -1111,20 +1109,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrayref",
- "async-std",
  "async-trait",
  "backtrace",
  "base64 0.10.1",
  "bigdecimal",
- "bitcrypto",
  "bytes 1.1.0",
  "cc",
  "cfg-if 1.0.0",
  "chrono",
  "crossbeam",
  "crossterm",
- "db_common",
- "derive_more",
  "findshlibs",
  "fnv",
  "fomat-macros 0.2.1",
@@ -1142,7 +1136,6 @@ dependencies = [
  "hyper-rustls",
  "itertools",
  "js-sys",
- "keys",
  "lazy_static",
  "libc",
  "lightning",
@@ -1158,11 +1151,7 @@ dependencies = [
  "parking_lot 0.12.0",
  "parking_lot_core 0.6.2",
  "paste",
- "primitives",
- "prost 0.8.0",
  "rand 0.7.3",
- "regex",
- "rustc-hex 2.1.0",
  "ser_error",
  "ser_error_derive",
  "serde",
@@ -1179,7 +1168,6 @@ dependencies = [
  "wasm-bindgen-test",
  "wasm-timer",
  "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -4255,7 +4243,6 @@ dependencies = [
  "wasm-bindgen-test",
  "wasm-timer",
  "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -5849,7 +5836,6 @@ dependencies = [
  "libsqlite3-sys",
  "memchr",
  "smallvec 1.6.1",
- "time 0.2.27",
 ]
 
 [[package]]
@@ -8747,24 +8733,6 @@ dependencies = [
  "subtle 2.4.0",
  "time 0.2.27",
  "zcash_note_encryption",
- "zcash_primitives",
-]
-
-[[package]]
-name = "zcash_client_sqlite"
-version = "0.3.0"
-source = "git+https://github.com/KomodoPlatform/librustzcash.git#4ffb4433942ed90c2b6035425c1c97d3e181609f"
-dependencies = [
- "bech32",
- "bs58",
- "ff 0.8.0",
- "group 0.8.0",
- "jubjub",
- "protobuf",
- "rand_core 0.5.1",
- "rusqlite",
- "time 0.2.27",
- "zcash_client_backend",
  "zcash_primitives",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "web-sys",
  "web3",
  "webpki-roots",
+ "winapi",
  "zbase32",
  "zcash_client_backend",
  "zcash_primitives",
@@ -1168,6 +1169,7 @@ dependencies = [
  "wasm-bindgen-test",
  "wasm-timer",
  "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -4243,6 +4245,7 @@ dependencies = [
  "wasm-bindgen-test",
  "wasm-timer",
  "web-sys",
+ "winapi",
 ]
 
 [[package]]

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -46,7 +46,7 @@ jobs:
           then
             cargo udeps
           else
-            export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include
+            export OPENSSL_DIR=/usr/local/opt/openssl/include
             cargo install cargo-udeps --locked
             cargo udeps
           fi

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -42,6 +42,9 @@ jobs:
         env:
           MANUAL_MM_VERSION: true
       - bash: |
+          cargo udeps
+        displayName: 'Cargo unused dependencies check'
+      - bash: |
           cargo deny check bans --hide-inclusion-graph
           cargo deny check advisories --hide-inclusion-graph
         displayName: 'Cargo deny checks'

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -42,8 +42,10 @@ jobs:
         env:
           MANUAL_MM_VERSION: true
       - bash: |
-          cargo install cargo-udeps --locked
-          cargo udeps
+          if [ $AGENT_OS = "Linux" ] || [ $AGENT_OS = "Windows_NT" ]
+          then
+            cargo udeps
+          fi
         displayName: 'Cargo unused dependencies check'
       - bash: |
           cargo deny check bans --hide-inclusion-graph

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -42,10 +42,7 @@ jobs:
         env:
           MANUAL_MM_VERSION: true
       - bash: |
-          if [ $AGENT_OS = "Linux" ] || [ $AGENT_OS = "Windows_NT" ]
-          then
-            cargo udeps
-          fi
+          cargo udeps
         displayName: 'Check unused dependencies'
       - bash: |
           cargo deny check bans --hide-inclusion-graph

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -46,7 +46,7 @@ jobs:
           then
             cargo udeps
           fi
-        displayName: 'Cargo unused dependencies check'
+        displayName: 'Check unused dependencies'
       - bash: |
           cargo deny check bans --hide-inclusion-graph
           cargo deny check advisories --hide-inclusion-graph

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -41,9 +41,9 @@ jobs:
         displayName: 'Check Tests'
         env:
           MANUAL_MM_VERSION: true
-      - uses: aig787/cargo-udeps-action@v1
-        with:
-          version: 'latest'
+      - bash: |
+          cargo install cargo-udeps --locked
+          cargo udeps
         displayName: 'Cargo unused dependencies check'
       - bash: |
           cargo deny check bans --hide-inclusion-graph

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -45,10 +45,6 @@ jobs:
           if [ $AGENT_OS = "Linux" ] || [ $AGENT_OS = "Windows_NT" ]
           then
             cargo udeps
-          else
-            export OPENSSL_DIR=/usr/local/opt/openssl
-            cargo install cargo-udeps --locked
-            cargo udeps
           fi
         displayName: 'Check unused dependencies'
       - bash: |

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -45,6 +45,10 @@ jobs:
           if [ $AGENT_OS = "Linux" ] || [ $AGENT_OS = "Windows_NT" ]
           then
             cargo udeps
+          else
+            export OPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include
+            cargo install cargo-udeps --locked
+            cargo udeps
           fi
         displayName: 'Check unused dependencies'
       - bash: |

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -46,7 +46,7 @@ jobs:
           then
             cargo udeps
           else
-            export OPENSSL_DIR=/usr/local/opt/openssl/include
+            export OPENSSL_DIR=/usr/local/opt/openssl
             cargo install cargo-udeps --locked
             cargo udeps
           fi

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -41,8 +41,9 @@ jobs:
         displayName: 'Check Tests'
         env:
           MANUAL_MM_VERSION: true
-      - bash: |
-          cargo udeps
+      - uses: aig787/cargo-udeps-action@v1
+        with:
+          version: 'latest'
         displayName: 'Cargo unused dependencies check'
       - bash: |
           cargo deny check bans --hide-inclusion-graph

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -27,12 +27,6 @@ bytes = "0.4"
 cfg-if = "1.0"
 chain = { path = "../mm2_bitcoin/chain" }
 common = { path = "../common" }
-mm2_core = { path = "../mm2_core" }
-mm2_err_handle = { path = "../mm2_err_handle" }
-mm2_net = { path = "../mm2_net" }
-mm2_db = { path = "../mm2_db" }
-mm2_io = { path = "../mm2_io" }
-mm2_test_helpers = { path = "../mm2_test_helpers" }
 crypto = { path = "../crypto" }
 db_common = { path = "../db_common" }
 derive_more = "0.99"
@@ -60,6 +54,10 @@ lightning = { git = "https://github.com/shamardy/rust-lightning", branch = "0.0.
 lightning-background-processor = { path = "lightning_background_processor" }
 lightning-invoice = { git = "https://github.com/shamardy/rust-lightning", branch = "0.0.106" }
 metrics = "0.12"
+mm2_core = { path = "../mm2_core" }
+mm2_err_handle = { path = "../mm2_err_handle" }
+mm2_io = { path = "../mm2_io" }
+mm2_net = { path = "../mm2_net" }
 mocktopus = "0.7.0"
 num-traits = "0.2"
 parking_lot = { version = "0.12.0", features = ["nightly"] }
@@ -87,11 +85,11 @@ tiny-bip39 = "0.8.0"
 # One of web3 dependencies is the old `tokio-uds 0.1.7` which fails cross-compiling to ARM.
 # We don't need the default web3 features at all since we added our own web3 transport using shared HYPER instance.
 web3 = { git = "https://github.com/artemii235/rust-web3", default-features = false }
-winapi = "0.3"
 zbase32 = "0.1.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3.27" }
+mm2_db = { path = "../mm2_db" }
 wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
 wasm-bindgen-futures = { version = "0.4.1" }
 wasm-bindgen-test = { version = "0.3.2" }
@@ -113,9 +111,11 @@ solana-transaction-status = "1"
 spl-token = { version = "3" }
 spl-associated-token-account = "1"
 zcash_client_backend = { git = "https://github.com/KomodoPlatform/librustzcash.git" }
-zcash_client_sqlite = { git = "https://github.com/KomodoPlatform/librustzcash.git" }
 zcash_primitives = { features = ["transparent-inputs"], git = "https://github.com/KomodoPlatform/librustzcash.git" }
 zcash_proofs = { git = "https://github.com/KomodoPlatform/librustzcash.git" }
+
+[dev-dependencies]
+mm2_test_helpers = { path = "../mm2_test_helpers" }
 
 [build-dependencies]
 prost-build = { version = "0.10.3", default-features = false }

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -114,6 +114,9 @@ zcash_client_backend = { git = "https://github.com/KomodoPlatform/librustzcash.g
 zcash_primitives = { features = ["transparent-inputs"], git = "https://github.com/KomodoPlatform/librustzcash.git" }
 zcash_proofs = { git = "https://github.com/KomodoPlatform/librustzcash.git" }
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3"
+
 [dev-dependencies]
 mm2_test_helpers = { path = "../mm2_test_helpers" }
 

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -81,6 +81,9 @@ metrics-core = { version = "0.5" }
 metrics-util = { version = "0.3" }
 tokio = { version = "1.7", features = ["io-util", "rt-multi-thread", "net"] }
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3"
+
 [build-dependencies]
 cc = "1.0"
 fomat-macros = "0.3"

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -14,17 +14,13 @@ track-ctx-pointer = ["shared_ref_counter/enable", "shared_ref_counter/log"]
 
 [dependencies]
 arrayref = "0.3"
-async-std = { version = "1.5", features = ["unstable"] }
 async-trait = "0.1"
 backtrace = "0.3"
 base64 = "0.10.0"
 bigdecimal = { version = "0.3", features = ["serde"] }
-bitcrypto = { path = "../mm2_bitcoin/crypto" }
 bytes = "1.1"
 cfg-if = "1.0"
 crossbeam = "0.7"
-db_common = { path = "../db_common" }
-derive_more = "0.99"
 findshlibs = "0.5"
 fnv = "1.0.6"
 fomat-macros = "0.2"
@@ -35,7 +31,6 @@ hex = "0.4.2"
 http = "0.2"
 http-body = "0.1"
 itertools = "0.10"
-keys = { path = "../mm2_bitcoin/keys" }
 lazy_static = "1.4"
 lightning = { git = "https://github.com/shamardy/rust-lightning", branch = "0.0.106" }
 log = "0.4.8"
@@ -45,28 +40,23 @@ num-traits = "0.2"
 parking_lot = { version = "0.12.0", features = ["nightly"] }
 parking_lot_core = { version = "0.6", features = ["nightly"] }
 paste = "1.0"
-primitives = { path = "../mm2_bitcoin/primitives" }
-prost = "0.8"
 rand = { version = "0.7", features = ["std", "small_rng", "wasm-bindgen"] }
-regex = "1"
-rustc-hex = "2"
 serde = "1"
 serde_bytes = "0.11"
 serde_derive = "1"
 serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
-serde_repr = "0.1.6"
 ser_error = { path = "../derives/ser_error" }
 ser_error_derive = { path = "../derives/ser_error_derive" }
-shared_ref_counter = { path = "shared_ref_counter" }
+shared_ref_counter = { path = "shared_ref_counter", optional = true }
 uuid = { version = "0.7", features = ["serde", "v4"] }
 wasm-timer = "0.2.4"
-winapi = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] } # see https://docs.rs/getrandom/0.2.0/getrandom/#webassembly-support
 gstuff = { version = "0.7", features = ["nightly"] }
 js-sys = "0.3.27"
+serde_repr = "0.1.6"
 serde-wasm-bindgen = "0.4.3"
 wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
 wasm-bindgen-futures = "0.4.21"

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -21,7 +21,6 @@ bigdecimal = { version = "0.3", features = ["serde"] }
 bytes = "1.1"
 cfg-if = "1.0"
 crossbeam = "0.7"
-findshlibs = "0.5"
 fnv = "1.0.6"
 fomat-macros = "0.2"
 futures01 = { version = "0.1", package = "futures" }
@@ -83,6 +82,9 @@ tokio = { version = "1.7", features = ["io-util", "rt-multi-thread", "net"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
+
+[target.'cfg(not(windows))'.dependencies]
+findshlibs = "0.5"
 
 [build-dependencies]
 cc = "1.0"

--- a/mm2src/mm2_core/Cargo.toml
+++ b/mm2src/mm2_core/Cargo.toml
@@ -9,26 +9,26 @@ doctest = false
 [dependencies]
 async-trait = "0.1"
 arrayref = "0.3"
-derive_more = "0.99"
-rand = { version = "0.7", features = ["std", "small_rng", "wasm-bindgen"] }
-uuid = { version = "0.7", features = ["serde", "v4"] }
-fomat-macros = "0.2"
-serde = "1"
-serde_bytes = "0.11"
-hex = "0.4.2"
-serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
-shared_ref_counter = { path = "../common/shared_ref_counter" }
 cfg-if = "1.0"
-primitives = { path = "../mm2_bitcoin/primitives" }
-keys = { path = "../mm2_bitcoin/keys" }
 common = { path = "../common" }
 db_common = { path = "../db_common" }
-mm2_rpc = { path = "../mm2_rpc" }
-lazy_static = "1.4"
+derive_more = "0.99"
+fomat-macros = "0.2"
 futures = { version = "0.3", package = "futures", features = ["compat", "async-await", "thread-pool"] }
+hex = "0.4.2"
+keys = { path = "../mm2_bitcoin/keys" }
+lazy_static = "1.4"
+primitives = { path = "../mm2_bitcoin/primitives" }
+rand = { version = "0.7", features = ["std", "small_rng", "wasm-bindgen"] }
+serde = "1"
+serde_bytes = "0.11"
+serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
+shared_ref_counter = { path = "../common/shared_ref_counter" }
+uuid = { version = "0.7", features = ["serde", "v4"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gstuff = { version = "0.7", features = ["nightly"] }
+mm2_rpc = { path = "../mm2_rpc" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 gstuff = { version = "0.7", features = ["crossterm", "nightly"] }

--- a/mm2src/mm2_db/Cargo.toml
+++ b/mm2src/mm2_db/Cargo.toml
@@ -5,22 +5,20 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+async-trait = "0.1"
 common = { path = "../common" }
-mm2_err_handle = { path = "../mm2_err_handle" }
-mm2_core = { path = "../mm2_core" }
+derive_more = "0.99"
 futures = { version = "0.3", package = "futures", features = ["compat", "async-await", "thread-pool"] }
-lazy_static = "1.4"
 hex = "0.4.2"
+js-sys = "0.3.27"
+lazy_static = "1.4"
+mm2_core = { path = "../mm2_core" }
+mm2_err_handle = { path = "../mm2_err_handle" }
 primitives = { path = "../mm2_bitcoin/primitives" }
 rand = { version = "0.7", features = ["std", "small_rng", "wasm-bindgen"] }
 serde = "1"
 serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
-async-trait = "0.1"
-derive_more = "0.99"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.27"
 wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
 wasm-bindgen-futures = { version = "0.4.1" }
 wasm-bindgen-test = { version = "0.3.2" }

--- a/mm2src/mm2_libp2p/Cargo.toml
+++ b/mm2src/mm2_libp2p/Cargo.toml
@@ -8,11 +8,9 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-async-std = { version = "1.6.2", features = ["unstable"] }
 atomicdex-gossipsub = { path = "../gossipsub" }
 derive_more = "0.99"
 libp2p-floodsub = { path = "../floodsub" }
-env_logger = "0.7.1"
 futures = { version = "0.3.1", package = "futures", features = ["compat", "async-await"] }
 futures-rustls = { version = "0.21.1" }
 hex = "0.4.2"
@@ -40,4 +38,6 @@ libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", default-features =
 wasm-bindgen-futures = "0.4.21"
 
 [dev-dependencies]
+async-std = { version = "1.6.2", features = ["unstable"] }
+env_logger = "0.7.1"
 serde_json = "1.0"

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -126,6 +126,9 @@ futures-rustls = { version = "0.21.1" }
 hyper = { version = "0.14.11", features = ["client", "http2", "server", "tcp"] }
 tokio = { version = "1.7", features = ["io-util", "rt-multi-thread", "net"] }
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3"
+
 [dev-dependencies]
 mm2_test_helpers = { path = "../mm2_test_helpers" }
 mocktopus = "0.7.0"

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -51,13 +51,6 @@ cfg-if = "1.0"
 coins = { path = "../coins" }
 coins_activation = { path = "../coins_activation" }
 common = { path = "../common" }
-mm2_test_helpers = { path = "../mm2_test_helpers" }
-mm2_err_handle = { path = "../mm2_err_handle" }
-mm2_io = { path = "../mm2_io" }
-mm2_rpc = { path = "../mm2_rpc" }
-mm2_net = { path = "../mm2_net" }
-mm2_core = { path = "../mm2_core" }
-mm2_db = { path = "../mm2_db" }
 crc32fast = { version = "1.3.2", features = ["std", "nightly"] }
 crossbeam = "0.7"
 crypto = { path = "../crypto" }
@@ -82,19 +75,24 @@ lazy_static = "1.4"
 # ledger = { path = "../ledger" }
 libc = "0.2"
 metrics = "0.12"
+mm2_core = { path = "../mm2_core" }
+mm2_err_handle = { path = "../mm2_err_handle" }
+mm2_io = { path = "../mm2_io" }
 mm2-libp2p = { path = "../mm2_libp2p" }
+mm2_net = { path = "../mm2_net" }
+mm2_rpc = { path = "../mm2_rpc" }
 num-traits = "0.2"
-rpc = { path = "../mm2_bitcoin/rpc" }
-rpc_task = { path = "../rpc_task" }
-parking_lot = { version = "0.12.0", features = ["nightly"] }
 parity-util-mem = "0.11"
+parking_lot = { version = "0.12.0", features = ["nightly"] }
 primitives = { path = "../mm2_bitcoin/primitives" }
 rand = { version = "0.7", features = ["std", "small_rng"] }
 rand6 = { version = "0.6", package = "rand" }
-rmp-serde = "0.14.3"
 # TODO: Reduce the size of regex by disabling the features we don't use.
 # cf. https://github.com/rust-lang/regex/issues/583
 regex = "1"
+rmp-serde = "0.14.3"
+rpc = { path = "../mm2_bitcoin/rpc" }
+rpc_task = { path = "../rpc_task" }
 script = { path = "../mm2_bitcoin/script" }
 secp256k1 = { version = "0.20", features = ["rand"] }
 serde = "1.0"
@@ -107,30 +105,31 @@ serialization_derive = { path = "../mm2_bitcoin/serialization_derive" }
 spv_validation = { path = "../mm2_bitcoin/spv_validation" }
 sp-runtime-interface = { version = "6.0.0", default-features = false, features = ["disable_target_static_assertions"] }
 sp-trie = { version = "6.0", default-features = false }
-
 trie-db = { version = "0.23.1", default-features = false }
 trie-root = "0.16.0"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 wasm-timer = "0.2.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+instant = {version = "0.1.12", features = ["wasm-bindgen"]}
 js-sys = { version = "0.3.27" }
+mm2_db = { path = "../mm2_db" }
+mm2_test_helpers = { path = "../mm2_test_helpers" }
 wasm-bindgen = { version = "=0.2.78", features = ["nightly"] }
 wasm-bindgen-futures = { version = "0.4.1" }
 wasm-bindgen-test = { version = "0.3.1" }
 web-sys = { version = "0.3.55", features = ["console"] }
-instant = {version = "0.1.12", features = ["wasm-bindgen"]}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dirs = { version = "1" }
+futures-rustls = { version = "0.21.1" }
 hyper = { version = "0.14.11", features = ["client", "http2", "server", "tcp"] }
 tokio = { version = "1.7", features = ["io-util", "rt-multi-thread", "net"] }
-futures-rustls = { version = "0.21.1" }
 
 [dev-dependencies]
+mm2_test_helpers = { path = "../mm2_test_helpers" }
 mocktopus = "0.7.0"
 testcontainers = { git = "https://github.com/artemii235/testcontainers-rs.git" }
-winapi = "0.3"
 
 [build-dependencies]
 chrono = "0.4"


### PR DESCRIPTION
A few notes:

- If `cargo udeps` fails on all CI agents (all operating systems), this means that the dependencies shown in the output should either be removed or are used in testing/wasm/features only, in this case these dependencies should be moved to the right target (e.g. `[dev-dependencies]`, `[target.'cfg(target_arch = "wasm32")'.dependencies]`).
- If `cargo udeps` fails on all CI agents (all operating systems) except one, then this is a dependency for this certain OS, in this case these dependencies should be moved to the right target (e.g. `[target.'cfg(windows)'.dependencies]`).