### PR TITLE
[r2r] split qtum utxo

### DIFF
--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -3331,8 +3331,7 @@ fn test_split_qtum() {
     let script: Script = output_script(p2pkh_address, ScriptType::P2PKH);
     let key_pair = coin.as_ref().priv_key_policy.key_pair_or_err().unwrap();
     let (unspents, _) = block_on(coin.get_mature_unspent_ordered_list(p2pkh_address)).expect("Unspent list is empty");
-    let unspents_mature = unspents.mature;
-    println!("unspents_mature vec = {:?}", unspents_mature);
+    log!("Mature unspents vec = "[unspents.mature]);
     let outputs = vec![
         TransactionOutput {
             value: 100_000_000,
@@ -3341,12 +3340,12 @@ fn test_split_qtum() {
         40
     ];
     let builder = UtxoTxBuilder::new(&coin)
-        .add_available_inputs(unspents_mature)
+        .add_available_inputs(unspents.mature)
         .add_outputs(outputs);
     let (unsigned, data) = block_on(builder.build()).unwrap();
-    let min_fee = 400000;
-    assert!(data.fee_amount > min_fee);
-    println!("unsigned tx = {:?}", unsigned);
+    // fee_amount must be higher than the minimum fee
+    assert!(data.fee_amount > 400_000);
+    log!("Unsigned tx = "[unsigned]);
     let signature_version = match p2pkh_address.addr_format {
         UtxoAddressFormat::Segwit => SignatureVersion::WitnessV0,
         _ => coin.as_ref().conf.signature_version,
@@ -3360,9 +3359,9 @@ fn test_split_qtum() {
         coin.as_ref().conf.fork_id,
     )
     .unwrap();
-    println!("signed tx = {:?}", signed);
+    log!("Signed tx = "[signed]);
     let res = block_on(coin.broadcast_tx(&signed)).unwrap();
-    println!("res = {:?}", res);
+    log!("Res = "[res]);
 }
 
 /// `QtumCoin` hasn't to check UTXO maturity if `check_utxo_maturity` is `false`.

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -3327,12 +3327,10 @@ fn test_split_qtum() {
     let ctx = MmCtxBuilder::new().into_mm_arc();
     let params = UtxoActivationParams::from_legacy_req(&req).unwrap();
     let coin = block_on(qtum_coin_with_priv_key(&ctx, "QTUM", &conf, &params, &priv_key)).unwrap();
-    let address_out = Address::from("qXxsj5RtciAby9T7m98AgAATL4zTi4UwDG");
-    let script: Script = output_script(&address_out, ScriptType::P2PKH);
     let p2pkh_address = coin.as_ref().derivation_method.unwrap_iguana();
+    let script: Script = output_script(p2pkh_address, ScriptType::P2PKH);
     let key_pair = coin.as_ref().priv_key_policy.key_pair_or_err().unwrap();
-    let (unspents, _) =
-        block_on(coin.get_mature_unspent_ordered_list(&address_out)).expect("Expected an empty unspent list");
+    let (unspents, _) = block_on(coin.get_mature_unspent_ordered_list(p2pkh_address)).expect("Unspent list is empty");
     let unspents_mature = unspents.mature;
     println!("unspents_mature vec = {:?}", unspents_mature);
     let outputs = vec![
@@ -3347,9 +3345,9 @@ fn test_split_qtum() {
         .add_outputs(outputs);
     let (unsigned, data) = block_on(builder.build()).unwrap();
     let min_fee = 400000;
-    assert_eq!(data.fee_amount > min_fee, true);
+    assert!(data.fee_amount > min_fee);
     println!("unsigned tx = {:?}", unsigned);
-    let signature_version = match &p2pkh_address.addr_format {
+    let signature_version = match p2pkh_address.addr_format {
         UtxoAddressFormat::Segwit => SignatureVersion::WitnessV0,
         _ => coin.as_ref().conf.signature_version,
     };

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -3290,6 +3290,82 @@ fn test_qtum_without_check_utxo_maturity() {
     assert!(unsafe { GET_MATURE_UNSPENT_ORDERED_LIST_CALLED });
 }
 
+#[test]
+#[ignore]
+fn test_split_qtum() {
+    let priv_key = [
+        3, 98, 177, 3, 108, 39, 234, 144, 131, 178, 103, 103, 127, 80, 230, 166, 53, 68, 147, 215, 42, 216, 144, 72,
+        172, 110, 180, 13, 123, 179, 10, 49,
+    ];
+    let conf = json!({
+      "coin": "tQTUM",
+      "name": "qtumtest",
+      "fname": "Qtum test",
+      "rpcport": 13889,
+      "pubtype": 120,
+      "p2shtype": 110,
+      "wiftype": 239,
+      "segwit": true,
+      "txfee": 400000,
+      "mm2": 1,
+      "required_confirmations": 1,
+      "mature_confirmations": 2000,
+      "avg_blocktime": 0.53,
+      "protocol": {
+        "type": "QTUM"
+      }
+    });
+    let req = json!({
+        "method": "electrum",
+        "servers": [
+            {"url":"electrum1.cipig.net:10071"},
+            {"url":"electrum2.cipig.net:10071"},
+            {"url":"electrum3.cipig.net:10071"},
+        ],
+    });
+    let ctx = MmCtxBuilder::new().into_mm_arc();
+    let params = UtxoActivationParams::from_legacy_req(&req).unwrap();
+    let coin = block_on(qtum_coin_with_priv_key(&ctx, "QTUM", &conf, &params, &priv_key)).unwrap();
+    let address_out = Address::from("qXxsj5RtciAby9T7m98AgAATL4zTi4UwDG");
+    let script: Script = output_script(&address_out, ScriptType::P2PKH);
+    let p2pkh_address = coin.as_ref().derivation_method.unwrap_iguana();
+    let key_pair = coin.as_ref().priv_key_policy.key_pair_or_err().unwrap();
+    let (unspents, _) =
+        block_on(coin.get_mature_unspent_ordered_list(&address_out)).expect("Expected an empty unspent list");
+    let unspents_mature = unspents.mature;
+    println!("unspents_mature vec = {:?}", unspents_mature);
+    let outputs = vec![
+        TransactionOutput {
+            value: 100_000_000,
+            script_pubkey: script.to_bytes(),
+        };
+        40
+    ];
+    let builder = UtxoTxBuilder::new(&coin)
+        .add_available_inputs(unspents_mature)
+        .add_outputs(outputs);
+    let (unsigned, data) = block_on(builder.build()).unwrap();
+    let min_fee = 400000;
+    assert_eq!(data.fee_amount > min_fee, true);
+    println!("unsigned tx = {:?}", unsigned);
+    let signature_version = match &p2pkh_address.addr_format {
+        UtxoAddressFormat::Segwit => SignatureVersion::WitnessV0,
+        _ => coin.as_ref().conf.signature_version,
+    };
+    let prev_script = Builder::build_p2pkh(&p2pkh_address.hash);
+    let signed = sign_tx(
+        unsigned,
+        key_pair,
+        prev_script,
+        signature_version,
+        coin.as_ref().conf.fork_id,
+    )
+    .unwrap();
+    println!("signed tx = {:?}", signed);
+    let res = block_on(coin.broadcast_tx(&signed)).unwrap();
+    println!("res = {:?}", res);
+}
+
 /// `QtumCoin` hasn't to check UTXO maturity if `check_utxo_maturity` is `false`.
 /// https://github.com/KomodoPlatform/atomicDEX-API/issues/1181
 #[test]

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -3290,6 +3290,7 @@ fn test_qtum_without_check_utxo_maturity() {
     assert!(unsafe { GET_MATURE_UNSPENT_ORDERED_LIST_CALLED });
 }
 
+/// The test is for splitting some mature unspent `QTUM` out points into 40 outputs with amount `1 QTUM` in each
 #[test]
 #[ignore]
 fn test_split_qtum() {


### PR DESCRIPTION
The task is to send a QTUM from one address to the same and have multiple identical outputs with amount 100000000.

The private key for the coin corresponds to the same address that is used for script in TransactionOutput.
New 40 unspent outs with amount 1 QTUM you can see there https://pastebin.com/ar3nt88g (to see the whole code, please click raw).
Previous unspents vec was received using rpc_client.list_unspent(). Actual test code use coin.get_mature_unspent_ordered_list() to get vector of mature unspents. In new log https://pastebin.com/Airux7jv there are some new unspents due to couple iterations of test code, but we still can see outpoints with old hashes (from https://pastebin.com/ar3nt88g), so we can be sure, that program access the same coin address. 
