### PR TITLE
[wip] Allow bestorders RPC execution with number

### DIFF
--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -503,6 +503,11 @@ pub enum OrdermatchRequest {
         action: BestOrdersAction,
         volume: BigRational,
     },
+    BestOrdersByNumber {
+        coin: String,
+        action: BestOrdersAction,
+        number: usize,
+    },
     OrderbookDepth {
         pairs: Vec<(String, String)>,
     },
@@ -555,6 +560,9 @@ pub fn process_peer_request(ctx: MmArc, request: OrdermatchRequest) -> Result<Op
         },
         OrdermatchRequest::BestOrders { coin, action, volume } => {
             best_orders::process_best_orders_p2p_request(ctx, coin, action, volume)
+        },
+        OrdermatchRequest::BestOrdersByNumber { coin, action, number } => {
+            best_orders::process_best_orders_p2p_request_by_number(ctx, coin, action, number)
         },
         OrdermatchRequest::OrderbookDepth { pairs } => orderbook_depth::process_orderbook_depth_p2p_request(ctx, pairs),
     }

--- a/mm2src/mm2_main/src/lp_ordermatch/best_orders.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/best_orders.rs
@@ -37,6 +37,19 @@ struct BestOrdersP2PRes {
     conf_infos: HashMap<Uuid, OrderConfirmationsSettings>,
 }
 
+#[derive(Debug, Deserialize)]
+pub enum RequestBestOrdersBy {
+    Volume(MmNumber),
+    Number(usize),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BestOrdersRequestV2 {
+    coin: String,
+    action: BestOrdersAction,
+    request_by: RequestBestOrdersBy,
+}
+
 pub fn process_best_orders_p2p_request(
     ctx: MmArc,
     coin: String,
@@ -99,6 +112,71 @@ pub fn process_best_orders_p2p_request(
                     if collected_volume >= required_volume {
                         break;
                     }
+                },
+                None => {
+                    log::debug!("No order with uuid {:?}", ordered.uuid);
+                    continue;
+                },
+            };
+        }
+        match action {
+            BestOrdersAction::Buy => result.insert(pair.1, best_orders),
+            BestOrdersAction::Sell => result.insert(pair.0, best_orders),
+        };
+    }
+    let response = BestOrdersP2PRes {
+        orders: result,
+        protocol_infos,
+        conf_infos,
+    };
+    let encoded = rmp_serde::to_vec(&response).expect("rmp_serde::to_vec should not fail here");
+    Ok(Some(encoded))
+}
+
+pub fn process_best_orders_p2p_request_by_number(
+    ctx: MmArc,
+    coin: String,
+    action: BestOrdersAction,
+    number: usize,
+) -> Result<Option<Vec<u8>>, String> {
+    let ordermatch_ctx = OrdermatchContext::from_ctx(&ctx).expect("ordermatch_ctx must exist at this point");
+    let orderbook = ordermatch_ctx.orderbook.lock();
+    let search_pairs_in = match action {
+        BestOrdersAction::Buy => &orderbook.pairs_existing_for_base,
+        BestOrdersAction::Sell => &orderbook.pairs_existing_for_rel,
+    };
+    let tickers = match search_pairs_in.get(&coin) {
+        Some(tickers) => tickers,
+        None => return Ok(None),
+    };
+    let mut result = HashMap::new();
+    let pairs = tickers.iter().map(|ticker| match action {
+        BestOrdersAction::Buy => (coin.clone(), ticker.clone()),
+        BestOrdersAction::Sell => (ticker.clone(), coin.clone()),
+    });
+
+    let mut protocol_infos = HashMap::new();
+    let mut conf_infos = HashMap::new();
+
+    for pair in pairs {
+        let orders = match orderbook.ordered.get(&pair) {
+            Some(orders) => orders.clone(),
+            None => {
+                log::debug!("No orders for pair {:?}", pair);
+                continue;
+            },
+        };
+        let mut best_orders = vec![];
+        let orders = orders.iter().take(number);
+        for ordered in orders {
+            match orderbook.order_set.get(&ordered.uuid) {
+                Some(o) => {
+                    let order_w_proof = orderbook.orderbook_item_with_proof(o.clone());
+                    protocol_infos.insert(order_w_proof.order.uuid, order_w_proof.order.base_rel_proto_info());
+                    if let Some(info) = order_w_proof.order.conf_settings {
+                        conf_infos.insert(order_w_proof.order.uuid, info);
+                    }
+                    best_orders.push(order_w_proof.into());
                 },
                 None => {
                     log::debug!("No order with uuid {:?}", ordered.uuid);
@@ -209,16 +287,23 @@ pub struct BestOrdersV2Response {
 
 pub async fn best_orders_rpc_v2(
     ctx: MmArc,
-    req: BestOrdersRequest,
+    req: BestOrdersRequestV2,
 ) -> Result<BestOrdersV2Response, MmError<BestOrdersRpcError>> {
     if is_wallet_only_ticker(&ctx, &req.coin) {
         return MmError::err(BestOrdersRpcError::CoinIsWalletOnly(req.coin));
     }
     let ordermatch_ctx = OrdermatchContext::from_ctx(&ctx).unwrap();
-    let p2p_request = OrdermatchRequest::BestOrders {
-        coin: ordermatch_ctx.orderbook_ticker_bypass(&req.coin),
-        action: req.action,
-        volume: req.volume.into(),
+    let p2p_request = match req.request_by {
+        RequestBestOrdersBy::Volume(mm_number) => OrdermatchRequest::BestOrders {
+            coin: ordermatch_ctx.orderbook_ticker_bypass(&req.coin),
+            action: req.action,
+            volume: mm_number.into(),
+        },
+        RequestBestOrdersBy::Number(size) => OrdermatchRequest::BestOrdersByNumber {
+            coin: ordermatch_ctx.orderbook_ticker_bypass(&req.coin),
+            action: req.action,
+            number: size,
+        },
     };
 
     let best_orders_res = request_any_relay::<BestOrdersP2PRes>(ctx.clone(), P2PRequest::Ordermatch(p2p_request))

--- a/mm2src/mm2_main/src/mm2_tests/best_orders_tests.rs
+++ b/mm2src/mm2_main/src/mm2_tests/best_orders_tests.rs
@@ -1,3 +1,4 @@
+use trie_db::Value;
 use super::*;
 
 #[cfg(feature = "zhtlc-native-tests")]
@@ -166,6 +167,361 @@ fn test_best_orders() {
 
     let best_morty_orders = response.result.get("MORTY").unwrap();
     assert_eq!(expected_price, best_morty_orders[0].price);
+    assert_eq!("MORTY", best_morty_orders[0].coin);
+    assert_eq!(1, best_morty_orders.len());
+
+    block_on(mm_bob.stop()).unwrap();
+    block_on(mm_alice.stop()).unwrap();
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_best_orders_v2_by_number() {
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
+
+    let coins = json!([
+        {"coin":"RICK","asset":"RICK","rpcport":8923,"txversion":4,"overwintered":1,"protocol":{"type":"UTXO"}},
+        {"coin":"MORTY","asset":"MORTY","rpcport":11608,"txversion":4,"overwintered":1,"protocol":{"type":"UTXO"}},
+        {"coin":"ETH","name":"ethereum","protocol":{"type":"ETH"},"rpcport":80},
+        {"coin":"JST","name":"jst","protocol":{"type":"ERC20", "protocol_data":{"platform":"ETH","contract_address":"0x2b294F029Fde858b2c62184e8390591755521d8E"}}}
+    ]);
+
+    // start bob and immediately place the orders
+    let mut mm_bob = MarketMakerIt::start(
+        json! ({
+            "gui": "nogui",
+            "netid": 9998,
+            "myipaddr": env::var ("BOB_TRADE_IP") .ok(),
+            "rpcip": env::var ("BOB_TRADE_IP") .ok(),
+            "canbind": env::var ("BOB_TRADE_PORT") .ok().map (|s| s.parse::<i64>().unwrap()),
+            "passphrase": bob_passphrase,
+            "coins": coins,
+            "rpc_password": "pass",
+            "i_am_seed": true,
+        }),
+        "pass".into(),
+        local_start!("bob"),
+    )
+    .unwrap();
+    let (_bob_dump_log, _bob_dump_dashboard) = mm_bob.mm_dump();
+    log!("Bob log path: {:?}", [mm_bob.log_path.display()]);
+
+    // Enable coins on Bob side. Print the replies in case we need the "address".
+    let bob_coins = block_on(enable_coins_eth_electrum(&mm_bob, &["http://195.201.0.6:8565"]));
+    log!("enable_coins (bob) {:?}", [bob_coins]);
+    // issue sell request on Bob side by setting base/rel price
+    log!("Issue bob sell requests");
+
+    let bob_orders = [
+        // (base, rel, price, volume, min_volume)
+        ("RICK", "MORTY", "0.9", "0.9", None),
+        ("RICK", "MORTY", "0.8", "0.9", None),
+        ("RICK", "MORTY", "0.7", "0.9", Some("0.9")),
+        ("RICK", "ETH", "0.8", "0.9", None),
+        ("MORTY", "RICK", "0.8", "0.9", None),
+        ("MORTY", "RICK", "0.9", "0.9", None),
+        ("ETH", "RICK", "0.8", "0.9", None),
+        ("MORTY", "ETH", "0.8", "0.8", None),
+        ("MORTY", "ETH", "0.7", "0.8", Some("0.8")),
+    ];
+    for (base, rel, price, volume, min_volume) in bob_orders.iter() {
+        let rc = block_on(mm_bob.rpc(&json! ({
+            "userpass": mm_bob.userpass,
+            "method": "setprice",
+            "base": base,
+            "rel": rel,
+            "price": price,
+            "volume": volume,
+            "min_volume": min_volume.unwrap_or("0.00777"),
+            "cancel_previous": false,
+        })))
+        .unwrap();
+        assert!(rc.0.is_success(), "!setprice: {}", rc.1);
+    }
+    let mm_alice = MarketMakerIt::start(
+        json! ({
+            "gui": "nogui",
+            "netid": 9998,
+            "myipaddr": env::var ("ALICE_TRADE_IP") .ok(),
+            "rpcip": env::var ("ALICE_TRADE_IP") .ok(),
+            "passphrase": "alice passphrase",
+            "coins": coins,
+            "seednodes": [mm_bob.ip.to_string()],
+            "rpc_password": "pass",
+        }),
+        "pass".into(),
+        local_start!("alice"),
+    )
+    .unwrap();
+
+    let (_alice_dump_log, _alice_dump_dashboard) = mm_alice.mm_dump();
+    log!("Alice log path: {:?}", [mm_alice.log_path.display()]);
+
+    block_on(mm_bob.wait_for_log(22., |log| {
+        log.contains("DEBUG Handling IncludedTorelaysMesh message for peer")
+    }))
+    .unwrap();
+
+    let rc = block_on(mm_alice.rpc(&json! ({
+        "userpass": mm_alice.userpass,
+        "method": "best_orders",
+        "mmrpc": "2.0",
+        "params": {
+            "coin": "RICK",
+            "action": "buy",
+            "request_by": {
+                "Number": 1 as usize
+            }
+        }
+    })))
+    .unwrap();
+    assert!(rc.0.is_success(), "!best_orders: {}", rc.1);
+    log!("rc {:?}", [rc]);
+    let response: RpcV2Response<BestOrdersV2Response> = json::from_str(&rc.1).unwrap();
+    let best_morty_orders = response.result.orders.get("MORTY").unwrap();
+    log!("Best MORTY orders when buy RICK {:?}", [best_morty_orders]);
+    assert_eq!(1, best_morty_orders.len());
+    let expected_price: BigDecimal = "0.7".parse().unwrap();
+    assert_eq!(expected_price, best_morty_orders[0].price.decimal);
+
+    let rc = block_on(mm_alice.rpc(&json! ({
+        "userpass": mm_alice.userpass,
+        "method": "best_orders",
+        "mmrpc": "2.0",
+        "params": {
+            "coin": "RICK",
+            "action": "buy",
+            "request_by": {
+                "Number": 2
+            }
+        }
+    })))
+    .unwrap();
+    assert!(rc.0.is_success(), "!best_orders: {}", rc.1);
+    log!("rc {:?}", [rc]);
+    let response: RpcV2Response<BestOrdersV2Response> = json::from_str(&rc.1).unwrap();
+    let best_morty_orders = response.result.orders.get("MORTY").unwrap();
+    log!("Best MORTY orders when buy RICK {:?}", [best_morty_orders]);
+    assert_eq!(2, best_morty_orders.len());
+    let expected_price: BigDecimal = "0.7".parse().unwrap();
+    assert_eq!(expected_price, best_morty_orders[0].price.decimal);
+    let expected_price: BigDecimal = "0.8".parse().unwrap();
+    assert_eq!(expected_price, best_morty_orders[1].price.decimal);
+
+    let rc = block_on(mm_alice.rpc(&json! ({
+        "userpass": mm_alice.userpass,
+        "method": "best_orders",
+        "mmrpc": "2.0",
+        "params": {
+            "coin": "RICK",
+            "action": "sell",
+            "request_by": {
+                "Number": 1 as usize
+            }
+        }
+    })))
+    .unwrap();
+    assert!(rc.0.is_success(), "!best_orders: {}", rc.1);
+    log!("rc {:?}", [rc]);
+    let response: RpcV2Response<BestOrdersV2Response> = json::from_str(&rc.1).unwrap();
+    let expected_price: BigDecimal = "1.25".parse().unwrap();
+    let best_morty_orders = response.result.orders.get("MORTY").unwrap();
+    log!("Best MORTY orders when sell RICK {:?}", [best_morty_orders]);
+    assert_eq!(1, best_morty_orders.len());
+    assert_eq!(expected_price, best_morty_orders[0].price.decimal);
+    let best_eth_orders = response.result.orders.get("ETH").unwrap();
+    log!("Best ETH orders when sell RICK {:?}", [best_eth_orders]);
+    assert_eq!(1, best_eth_orders.len());
+    assert_eq!(expected_price, best_eth_orders[0].price.decimal);
+
+    let rc = block_on(mm_alice.rpc(&json! ({
+        "userpass": mm_alice.userpass,
+        "method": "best_orders",
+        "mmrpc": "2.0",
+        "params": {
+            "coin": "ETH",
+            "action": "sell",
+            "request_by": {
+                "Number": 1 as usize
+            }
+        }
+    })))
+    .unwrap();
+    assert!(rc.0.is_success(), "!best_orders: {}", rc.1);
+    log!("rc {:?}", [rc]);
+    let response: RpcV2Response<BestOrdersV2Response> = json::from_str(&rc.1).unwrap();
+    let best_rick_orders = response.result.orders.get("RICK").unwrap();
+    log!("Best RICK orders when sell ETH {:?}", [best_rick_orders]);
+    assert_eq!(1, best_rick_orders.len());
+    let expected_price: BigDecimal = "1.25".parse().unwrap();
+    assert_eq!(expected_price, best_rick_orders[0].price.decimal);
+
+    block_on(mm_bob.stop()).unwrap();
+    block_on(mm_alice.stop()).unwrap();
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_best_orders_v2_by_volume() {
+    let bob_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
+
+    let coins = json!([
+        {"coin":"RICK","asset":"RICK","rpcport":8923,"txversion":4,"overwintered":1,"protocol":{"type":"UTXO"}},
+        {"coin":"MORTY","asset":"MORTY","rpcport":11608,"txversion":4,"overwintered":1,"protocol":{"type":"UTXO"}},
+        {"coin":"ETH","name":"ethereum","protocol":{"type":"ETH"},"rpcport":80},
+        {"coin":"JST","name":"jst","protocol":{"type":"ERC20", "protocol_data":{"platform":"ETH","contract_address":"0x2b294F029Fde858b2c62184e8390591755521d8E"}}}
+    ]);
+
+    // start bob and immediately place the orders
+    let mut mm_bob = MarketMakerIt::start(
+        json! ({
+            "gui": "nogui",
+            "netid": 9998,
+            "myipaddr": env::var ("BOB_TRADE_IP") .ok(),
+            "rpcip": env::var ("BOB_TRADE_IP") .ok(),
+            "canbind": env::var ("BOB_TRADE_PORT") .ok().map (|s| s.parse::<i64>().unwrap()),
+            "passphrase": bob_passphrase,
+            "coins": coins,
+            "rpc_password": "pass",
+            "i_am_seed": true,
+        }),
+        "pass".into(),
+        local_start!("bob"),
+    )
+    .unwrap();
+    let (_bob_dump_log, _bob_dump_dashboard) = mm_bob.mm_dump();
+    log!("Bob log path: {:?}", [mm_bob.log_path.display()]);
+
+    // Enable coins on Bob side. Print the replies in case we need the "address".
+    let bob_coins = block_on(enable_coins_eth_electrum(&mm_bob, &["http://195.201.0.6:8565"]));
+    log!("enable_coins (bob): {:?}", [bob_coins]);
+    // issue sell request on Bob side by setting base/rel price
+    log!("Issue bob sell requests");
+
+    let bob_orders = [
+        // (base, rel, price, volume, min_volume)
+        ("RICK", "MORTY", "0.9", "0.9", None),
+        ("RICK", "MORTY", "0.8", "0.9", None),
+        ("RICK", "MORTY", "0.7", "0.9", Some("0.9")),
+        ("RICK", "ETH", "0.8", "0.9", None),
+        ("MORTY", "RICK", "0.8", "0.9", None),
+        ("MORTY", "RICK", "0.9", "0.9", None),
+        ("ETH", "RICK", "0.8", "0.9", None),
+        ("MORTY", "ETH", "0.8", "0.8", None),
+        ("MORTY", "ETH", "0.7", "0.8", Some("0.8")),
+    ];
+    for (base, rel, price, volume, min_volume) in bob_orders.iter() {
+        let rc = block_on(mm_bob.rpc(&json! ({
+            "userpass": mm_bob.userpass,
+            "method": "setprice",
+            "base": base,
+            "rel": rel,
+            "price": price,
+            "volume": volume,
+            "min_volume": min_volume.unwrap_or("0.00777"),
+            "cancel_previous": false,
+        })))
+        .unwrap();
+        assert!(rc.0.is_success(), "!setprice: {}", rc.1);
+    }
+    let mm_alice = MarketMakerIt::start(
+        json! ({
+            "gui": "nogui",
+            "netid": 9998,
+            "myipaddr": env::var ("ALICE_TRADE_IP") .ok(),
+            "rpcip": env::var ("ALICE_TRADE_IP") .ok(),
+            "passphrase": "alice passphrase",
+            "coins": coins,
+            "seednodes": [mm_bob.ip.to_string()],
+            "rpc_password": "pass",
+        }),
+        "pass".into(),
+        local_start!("alice"),
+    )
+    .unwrap();
+
+    let (_alice_dump_log, _alice_dump_dashboard) = mm_alice.mm_dump();
+    log!("Alice log path: {:?}", [mm_alice.log_path.display()]);
+
+    block_on(mm_bob.wait_for_log(22., |log| {
+        log.contains("DEBUG Handling IncludedTorelaysMesh message for peer")
+    }))
+    .unwrap();
+
+    let rc = block_on(mm_alice.rpc(&json! ({
+        "userpass": mm_alice.userpass,
+        "method": "best_orders",
+        "mmrpc": "2.0",
+        "params": {
+            "coin": "RICK",
+            "action": "buy",
+            "request_by": {
+                "Volume": 1.7 as f32
+            }
+        }
+    })))
+    .unwrap();
+    assert!(rc.0.is_success(), "!best_orders: {}", rc.1);
+    log!("rc {:?}", [rc]);
+    let response: RpcV2Response<BestOrdersV2Response> = json::from_str(&rc.1).unwrap();
+    // MORTY
+    let best_morty_orders = response.result.orders.get("MORTY").unwrap();
+    log!("Best MORTY orders when buy RICK {:?}", [best_morty_orders]);
+    let expected_price: BigDecimal = "0.7".parse().unwrap();
+    assert_eq!(expected_price, best_morty_orders[0].price.decimal);
+    let expected_price: BigDecimal = "0.8".parse().unwrap();
+    assert_eq!(expected_price, best_morty_orders[1].price.decimal);
+    // ETH
+    let expected_price: BigDecimal = "0.8".parse().unwrap();
+    let best_eth_orders = response.result.orders.get("ETH").unwrap();
+    log!("Best ETH orders when buy RICK {:?}", [best_eth_orders]);
+    assert_eq!(expected_price, best_eth_orders[0].price.decimal);
+
+    let rc = block_on(mm_alice.rpc(&json! ({
+        "userpass": mm_alice.userpass,
+        "method": "best_orders",
+        "mmrpc": "2.0",
+        "params": {
+            "coin": "RICK",
+            "action": "sell",
+            "request_by": {
+                "Volume": 0.1
+            }
+        }
+    })))
+    .unwrap();
+    assert!(rc.0.is_success(), "!best_orders: {}", rc.1);
+    log!("rc {:?}", [rc]);
+    let response: RpcV2Response<BestOrdersV2Response> = json::from_str(&rc.1).unwrap();
+    let expected_price: BigDecimal = "1.25".parse().unwrap();
+    let best_morty_orders = response.result.orders.get("MORTY").unwrap();
+    log!("Best MORTY orders when sell RICK {:?}",[best_morty_orders]);
+    assert_eq!(expected_price, best_morty_orders[0].price.decimal);
+    assert_eq!(1, best_morty_orders.len());
+    let best_eth_orders = response.result.orders.get("ETH").unwrap();
+    log!("Best ETH orders when sell RICK {:?}", [best_morty_orders]);
+    assert_eq!(expected_price, best_eth_orders[0].price.decimal);
+
+    let rc = block_on(mm_alice.rpc(&json! ({
+        "userpass": mm_alice.userpass,
+        "method": "best_orders",
+        "mmrpc": "2.0",
+        "params": {
+            "coin": "ETH",
+            "action": "sell",
+            "request_by": {
+                "Volume": 0.1
+            }
+        }
+    })))
+    .unwrap();
+    assert!(rc.0.is_success(), "!best_orders: {}", rc.1);
+    log!("rc {:?}", [rc]);
+    let response: RpcV2Response<BestOrdersV2Response> = json::from_str(&rc.1).unwrap();
+    let expected_price: BigDecimal = "1.25".parse().unwrap();
+    let best_morty_orders = response.result.orders.get("MORTY").unwrap();
+    log!("Best MORTY orders when sell ETH {:?}", [best_morty_orders]);
+    assert_eq!(expected_price, best_morty_orders[0].price.decimal);
     assert_eq!("MORTY", best_morty_orders[0].coin);
     assert_eq!(1, best_morty_orders.len());
 


### PR DESCRIPTION
Implementation of the code to solve the problem "Allow bestorders RPC execution without volume argument" https://github.com/KomodoPlatform/atomicDEX-API/issues/1314

Changes have been made to the files:
1.best_orders.rs
Function process_best_orders_p2p_request_by_number was added
In fn best_orders_rpc_v2 instead of req: BestOrdersRequest there is req: BestOrdersRequestV2

2.lp_ordermatch.rs
OrdermatchRequest::BestOrdersByNumber was added, it is matched in function process_peer_request, result goes in function best_orders::process_best_orders_p2p_request_by_number

3. tests added in best_orders_tests