### PR TITLE
[r2r] Fix P2P OrdermatchRequest backward compatibility.

### DIFF
--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -507,13 +507,13 @@ pub enum OrdermatchRequest {
         action: BestOrdersAction,
         volume: BigRational,
     },
+    OrderbookDepth {
+        pairs: Vec<(String, String)>,
+    },
     BestOrdersByNumber {
         coin: String,
         action: BestOrdersAction,
         number: usize,
-    },
-    OrderbookDepth {
-        pairs: Vec<(String, String)>,
     },
 }
 


### PR DESCRIPTION
New enum variants should be added to the end to keep the rmp_serde serialization numeration. 