### PR TITLE
Don't respond to GetKnownPeers p2p msg if the number of peers requested exceeds the default number (#1445)

### DIFF
--- a/mm2src/mm2_libp2p/src/peers_exchange.rs
+++ b/mm2src/mm2_libp2p/src/peers_exchange.rs
@@ -298,6 +298,10 @@ impl NetworkBehaviourEventProcess<RequestResponseEvent<PeersExchangeRequest, Pee
             RequestResponseEvent::Message { message, peer } => match message {
                 RequestResponseMessage::Request { request, channel, .. } => match request {
                     PeersExchangeRequest::GetKnownPeers { num } => {
+                        // Should not send a response in such case
+                        if num > DEFAULT_PEERS_NUM {
+                            return;
+                        }
                         let response = PeersExchangeResponse::KnownPeers {
                             peers: self.get_random_known_peers(num),
                         };


### PR DESCRIPTION
* return random known peers with a maximum of DEFAULT_PEERS_NUM

* Do not respond to GetKnownPeers p2p msg if requested number is greater than DEFAULT_PEERS_NUM