### PR TITLE
[r2r] Fix and improve some aspects of Hardware wallet integration

### DIFF
--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -191,7 +191,7 @@ use eth::{eth_coin_from_conf_and_request, EthCoin, EthTxFeeDetails, SignedEthTx}
 pub mod hd_pubkey;
 
 pub mod hd_wallet;
-use hd_wallet::{HDAddress, HDAccountAddressId};
+use hd_wallet::{HDAccountAddressId, HDAddress};
 
 pub mod hd_wallet_storage;
 #[cfg(not(target_arch = "wasm32"))] pub mod lightning;

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -191,7 +191,7 @@ use eth::{eth_coin_from_conf_and_request, EthCoin, EthTxFeeDetails, SignedEthTx}
 pub mod hd_pubkey;
 
 pub mod hd_wallet;
-use hd_wallet::{HDAddress, HDAddressId};
+use hd_wallet::{HDAddress, HDAccountAddressId};
 
 pub mod hd_wallet_storage;
 #[cfg(not(target_arch = "wasm32"))] pub mod lightning;
@@ -706,7 +706,7 @@ pub trait GetWithdrawSenderAddress {
 #[serde(untagged)]
 pub enum WithdrawFrom {
     // AccountId { account_id: u32 },
-    AddressId(HDAddressId),
+    AddressId(HDAccountAddressId),
     /// Don't use `Bip44DerivationPath` or `RpcDerivationPath` because if there is an error in the path,
     /// `serde::Deserialize` returns "data did not match any variant of untagged enum WithdrawFrom".
     /// It's better to show the user an informative error.

--- a/mm2src/coins/rpc_command/get_new_address.rs
+++ b/mm2src/coins/rpc_command/get_new_address.rs
@@ -81,6 +81,7 @@ impl From<NewAddressDerivingError> for GetNewAddressRpcError {
             NewAddressDerivingError::WalletStorageError(storage) => {
                 GetNewAddressRpcError::WalletStorageError(storage.to_string())
             },
+            NewAddressDerivingError::Internal(internal) => GetNewAddressRpcError::Internal(internal),
         }
     }
 }
@@ -89,6 +90,7 @@ impl From<AddressDerivingError> for GetNewAddressRpcError {
     fn from(e: AddressDerivingError) -> Self {
         match e {
             AddressDerivingError::Bip32Error(bip32) => GetNewAddressRpcError::ErrorDerivingAddress(bip32.to_string()),
+            AddressDerivingError::Internal(internal) => GetNewAddressRpcError::Internal(internal),
         }
     }
 }
@@ -233,7 +235,7 @@ pub mod common_impl {
         let last_address_id = known_addresses_number - 1;
 
         for address_id in (0..=last_address_id).rev() {
-            let HDAddress { address, .. } = coin.derive_address(hd_account, chain, address_id)?;
+            let HDAddress { address, .. } = coin.derive_address(hd_account, chain, address_id).await?;
             if address_scanner.is_address_used(&address).await? {
                 return Ok(());
             }

--- a/mm2src/coins/rpc_command/hd_account_balance_rpc_error.rs
+++ b/mm2src/coins/rpc_command/hd_account_balance_rpc_error.rs
@@ -88,6 +88,7 @@ impl From<AddressDerivingError> for HDAccountBalanceRpcError {
             AddressDerivingError::Bip32Error(bip32) => {
                 HDAccountBalanceRpcError::ErrorDerivingAddress(bip32.to_string())
             },
+            AddressDerivingError::Internal(internal) => HDAccountBalanceRpcError::Internal(internal),
         }
     }
 }

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -948,13 +948,15 @@ impl HDWalletCoinOps for QtumCoin {
     type HDWallet = UtxoHDWallet;
     type HDAccount = UtxoHDAccount;
 
-    fn derive_address(
+    async fn derive_addresses<Ids>(
         &self,
         hd_account: &Self::HDAccount,
-        chain: Bip44Chain,
-        address_id: u32,
-    ) -> MmResult<HDAddress<Self::Address, Self::Pubkey>, AddressDerivingError> {
-        utxo_common::derive_address(self, hd_account, chain, address_id)
+        address_ids: Ids,
+    ) -> MmResult<Vec<HDAddress<Self::Address, Self::Pubkey>>, AddressDerivingError>
+    where
+        Ids: Iterator<Item = HDAddressId> + Send,
+    {
+        utxo_common::derive_addresses(self, hd_account, address_ids).await
     }
 
     async fn create_new_account<'a, XPubExtractor>(

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -10,7 +10,7 @@ use crate::utxo::rpc_clients::{electrum_script_hash, BlockHashOrHeight, UnspentI
 use crate::utxo::spv::SimplePaymentVerification;
 use crate::utxo::tx_cache::TxCacheResult;
 use crate::utxo::utxo_withdraw::{InitUtxoWithdraw, StandardUtxoWithdraw, UtxoWithdraw};
-use crate::{CanRefundHtlc, CoinBalance, CoinWithDerivationMethod, GetWithdrawSenderAddress, HDAddressId,
+use crate::{CanRefundHtlc, CoinBalance, CoinWithDerivationMethod, GetWithdrawSenderAddress, HDAccountAddressId,
             RawTransactionError, RawTransactionRequest, RawTransactionRes, SearchForSwapTxSpendInput, SignatureError,
             SignatureResult, SwapOps, TradePreimageValue, TransactionFut, TxFeeDetails, TxMarshalingErr,
             ValidateAddressResult, ValidatePaymentInput, VerificationError, VerificationResult, WithdrawFrom,
@@ -96,30 +96,118 @@ pub async fn get_tx_fee(coin: &UtxoCoinFields) -> UtxoRpcResult<ActualTxFee> {
     }
 }
 
-pub fn derive_address<T: UtxoCommonOps>(
+/// [`HDWalletCoinOps::derive_addresses`] native implementation.
+///
+/// # Important
+///
+/// The [`HDAddressesCache::cache`] mutex is locked once for the entire duration of this function.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn derive_addresses<T, Ids>(
     coin: &T,
     hd_account: &UtxoHDAccount,
-    chain: Bip44Chain,
-    address_id: u32,
-) -> MmResult<HDAddress<Address, Public>, AddressDerivingError> {
-    let change_child = chain.to_child_number();
-    let address_id_child = ChildNumber::from(address_id);
+    address_ids: Ids,
+) -> MmResult<Vec<UtxoHDAddress>, AddressDerivingError>
+where
+    T: UtxoCommonOps,
+    Ids: Iterator<Item = HDAddressId>,
+{
+    let mut hd_addresses_cache = hd_account.derived_addresses.lock().await;
 
-    let derived_pubkey = hd_account
-        .extended_pubkey
-        .derive_child(change_child)?
-        .derive_child(address_id_child)?;
-    let address = coin.address_from_extended_pubkey(&derived_pubkey);
-    let pubkey = Public::Compressed(H264::from(derived_pubkey.public_key().serialize()));
+    let mut result = Vec::new();
+    for hd_address_id in address_ids {
+        // Check if the given HD address has been derived already.
+        if let Some(hd_address) = hd_addresses_cache.get(&hd_address_id) {
+            result.push(hd_address.clone());
+            continue;
+        }
 
-    let mut derivation_path = hd_account.account_derivation_path.to_derivation_path();
-    derivation_path.push(change_child);
-    derivation_path.push(address_id_child);
-    Ok(HDAddress {
-        address,
-        pubkey,
-        derivation_path,
-    })
+        let change_child = hd_address_id.chain.to_child_number();
+        let address_id_child = ChildNumber::from(hd_address_id.address_id);
+
+        let derived_pubkey = hd_account
+            .extended_pubkey
+            .derive_child(change_child)?
+            .derive_child(address_id_child)?;
+        let address = coin.address_from_extended_pubkey(&derived_pubkey);
+        let pubkey = Public::Compressed(H264::from(derived_pubkey.public_key().serialize()));
+
+        let mut derivation_path = hd_account.account_derivation_path.to_derivation_path();
+        derivation_path.push(change_child);
+        derivation_path.push(address_id_child);
+
+        let hd_address = HDAddress {
+            address,
+            pubkey,
+            derivation_path,
+        };
+
+        // Cache the derived `hd_address`.
+        hd_addresses_cache.insert(hd_address_id, hd_address.clone());
+        result.push(hd_address);
+    }
+
+    Ok(result)
+}
+
+/// [`HDWalletCoinOps::derive_addresses`] WASM implementation.
+///
+/// # Important
+///
+/// This function locks [`HDAddressesCache::cache`] mutex at each iteration.
+///
+/// # Performance
+///
+/// Locking the [`HDAddressesCache::cache`] mutex at each iteration may significantly degrade performance.
+/// But this is required at least for now due the facts that:
+/// 1) mm2 runs in the same thread as `KomodoPlatform/air_dex` runs;
+/// 2) [`ExtendedPublicKey::derive_child`] is a synchronous operation, and it takes a long time.
+/// So we need to periodically invoke Javascript runtime to handle UI events and other asynchronous tasks.
+#[cfg(target_arch = "wasm32")]
+pub async fn derive_addresses<T, Ids>(
+    coin: &T,
+    hd_account: &UtxoHDAccount,
+    address_ids: Ids,
+) -> MmResult<Vec<UtxoHDAddress>, AddressDerivingError>
+where
+    T: UtxoCommonOps,
+    Ids: Iterator<Item = HDAddressId>,
+{
+    let mut result = Vec::new();
+    for hd_address_id in address_ids {
+        let mut hd_addresses_cache = hd_account.derived_addresses.lock().await;
+
+        // Check if the given HD address has been derived already.
+        if let Some(hd_address) = hd_addresses_cache.get(&hd_address_id) {
+            result.push(hd_address.clone());
+            continue;
+        }
+
+        let change_child = hd_address_id.chain.to_child_number();
+        let address_id_child = ChildNumber::from(hd_address_id.address_id);
+
+        let derived_pubkey = hd_account
+            .extended_pubkey
+            .derive_child(change_child)?
+            .derive_child(address_id_child)?;
+        let address = coin.address_from_extended_pubkey(&derived_pubkey);
+        let pubkey = Public::Compressed(H264::from(derived_pubkey.public_key().serialize()));
+
+        let mut derivation_path = hd_account.account_derivation_path.to_derivation_path();
+        derivation_path.push(change_child);
+        derivation_path.push(address_id_child);
+
+        let hd_address = HDAddress {
+            address,
+            pubkey,
+            derivation_path,
+        };
+
+        // Cache the derived `hd_address`.
+        hd_addresses_cache.insert(hd_address_id, hd_address.clone());
+        result.push(hd_address);
+    }
+
+    Ok(result)
 }
 
 pub async fn create_new_account<'a, Coin, XPubExtractor>(
@@ -164,6 +252,7 @@ where
         // We don't know how many addresses are used by the user at this moment.
         external_addresses_number: 0,
         internal_addresses_number: 0,
+        derived_addresses: HDAddressesCache::default(),
     };
 
     let accounts = hd_wallet.accounts.lock().await;
@@ -286,24 +375,31 @@ where
             address: checking_address,
             derivation_path: checking_address_der_path,
             ..
-        } = coin.derive_address(hd_account, chain, checking_address_id)?;
+        } = coin.derive_address(hd_account, chain, checking_address_id).await?;
 
         match coin.is_address_used(&checking_address, address_scanner).await? {
             // We found a non-empty address, so we have to fill up the balance list
             // with zeros starting from `last_non_empty_address_id = checking_address_id - unused_addresses_counter`.
             AddressBalanceStatus::Used(non_empty_balance) => {
                 let last_non_empty_address_id = checking_address_id - unused_addresses_counter;
-                for empty_address_id in last_non_empty_address_id..checking_address_id {
-                    let empty_address = coin.derive_address(hd_account, chain, empty_address_id)?;
 
-                    balances.push(HDAddressBalance {
-                        address: empty_address.address.to_string(),
-                        derivation_path: RpcDerivationPath(empty_address.derivation_path),
-                        chain,
-                        balance: CoinBalance::default(),
-                    });
-                }
+                // First, derive all empty addresses and put it into `balances` with default balance.
+                let address_ids = (last_non_empty_address_id..checking_address_id)
+                    .into_iter()
+                    .map(|address_id| HDAddressId { chain, address_id });
+                let empty_addresses =
+                    coin.derive_addresses(hd_account, address_ids)
+                        .await?
+                        .into_iter()
+                        .map(|empty_address| HDAddressBalance {
+                            address: empty_address.address.to_string(),
+                            derivation_path: RpcDerivationPath(empty_address.derivation_path),
+                            chain,
+                            balance: CoinBalance::default(),
+                        });
+                balances.extend(empty_addresses);
 
+                // Then push this non-empty address.
                 balances.push(HDAddressBalance {
                     address: checking_address.to_string(),
                     derivation_path: RpcDerivationPath(checking_address_der_path),
@@ -1935,9 +2031,9 @@ pub async fn get_withdraw_hd_sender<T>(
     hd_wallet: &T::HDWallet,
 ) -> MmResult<WithdrawSenderAddress<Address, Public>, WithdrawError>
 where
-    T: HDWalletCoinOps<Address = Address, Pubkey = Public>,
+    T: HDWalletCoinOps<Address = Address, Pubkey = Public> + Sync,
 {
-    let HDAddressId {
+    let HDAccountAddressId {
         account_id,
         chain,
         address_id,
@@ -1956,7 +2052,7 @@ where
                 );
                 return MmError::err(WithdrawError::UnexpectedFromAddress(error));
             }
-            HDAddressId::from(derivation_path)
+            HDAccountAddressId::from(derivation_path)
         },
     };
 
@@ -1964,7 +2060,7 @@ where
         .get_account(account_id)
         .await
         .or_mm_err(|| WithdrawError::UnknownAccount { account_id })?;
-    let hd_address = coin.derive_address(&hd_account, chain, address_id)?;
+    let hd_address = coin.derive_address(&hd_account, chain, address_id).await?;
 
     let is_address_activated = hd_account
         .is_address_activated(chain, address_id)

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -708,13 +708,15 @@ impl HDWalletCoinOps for UtxoStandardCoin {
     type HDWallet = UtxoHDWallet;
     type HDAccount = UtxoHDAccount;
 
-    fn derive_address(
+    async fn derive_addresses<Ids>(
         &self,
         hd_account: &Self::HDAccount,
-        chain: Bip44Chain,
-        address_id: u32,
-    ) -> MmResult<HDAddress<Self::Address, Self::Pubkey>, AddressDerivingError> {
-        utxo_common::derive_address(self, hd_account, chain, address_id)
+        address_ids: Ids,
+    ) -> MmResult<Vec<HDAddress<Self::Address, Self::Pubkey>>, AddressDerivingError>
+    where
+        Ids: Iterator<Item = HDAddressId> + Send,
+    {
+        utxo_common::derive_addresses(self, hd_account, address_ids).await
     }
 
     async fn create_new_account<'a, XPubExtractor>(

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -3487,6 +3487,7 @@ fn test_account_balance_rpc() {
         account_derivation_path: Bip44PathToAccount::from_str("m/44'/141'/0'").unwrap(),
         external_addresses_number: 7,
         internal_addresses_number: 3,
+        derived_addresses: HDAddressesCache::default(),
     });
     hd_accounts.insert(1, UtxoHDAccount {
         account_id: 1,
@@ -3494,6 +3495,7 @@ fn test_account_balance_rpc() {
         account_derivation_path: Bip44PathToAccount::from_str("m/44'/141'/1'").unwrap(),
         external_addresses_number: 0,
         internal_addresses_number: 1,
+        derived_addresses: HDAddressesCache::default(),
     });
     fields.derivation_method = DerivationMethod::HDWallet(UtxoHDWallet {
         hd_wallet_storage: HDWalletCoinStorage::default(),
@@ -3811,6 +3813,7 @@ fn test_scan_for_new_addresses() {
         account_derivation_path: Bip44PathToAccount::from_str("m/44'/141'/0'").unwrap(),
         external_addresses_number: 3,
         internal_addresses_number: 1,
+        derived_addresses: HDAddressesCache::default(),
     });
     hd_accounts.insert(1, UtxoHDAccount {
         account_id: 1,
@@ -3818,6 +3821,7 @@ fn test_scan_for_new_addresses() {
         account_derivation_path: Bip44PathToAccount::from_str("m/44'/141'/1'").unwrap(),
         external_addresses_number: 0,
         internal_addresses_number: 2,
+        derived_addresses: HDAddressesCache::default(),
     });
     fields.derivation_method = DerivationMethod::HDWallet(UtxoHDWallet {
         hd_wallet_storage: HDWalletCoinStorage::default(),
@@ -3944,6 +3948,7 @@ fn test_get_new_address() {
         account_derivation_path: Bip44PathToAccount::from_str("m/44'/141'/0'").unwrap(),
         external_addresses_number: 4,
         internal_addresses_number: 0,
+        derived_addresses: HDAddressesCache::default(),
     };
     // Put multiple the same accounts for tests,
     // since every successful `get_new_address_rpc` changes the state of the account.

--- a/mm2src/crypto/src/bip44.rs
+++ b/mm2src/crypto/src/bip44.rs
@@ -122,7 +122,7 @@ pub enum Bip44Index {
     AddressId = 4,
 }
 
-#[derive(Debug, Copy, Clone, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Copy, Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[repr(u32)]
 pub enum Bip44Chain {
     External = 0,


### PR DESCRIPTION
* Optimize `HDWalletCoinOps::derive_address` by adding HD addresses cache
* Add `HDWalletCoinOps::derive_addresses` that is optimized to derive multiple addresses
* Remove `TryUnzip` as it's not used more