### PR TITLE
[r2r] safe number type casting

### DIFF
--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -98,6 +98,7 @@ pub mod jsonrpc_client;
 pub mod fmt;
 #[macro_use]
 pub mod log;
+pub mod number_type_casting;
 
 pub mod crash_reports;
 pub mod custom_futures;

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -98,12 +98,12 @@ pub mod jsonrpc_client;
 pub mod fmt;
 #[macro_use]
 pub mod log;
-pub mod number_type_casting;
 
 pub mod crash_reports;
 pub mod custom_futures;
 pub mod custom_iter;
 #[path = "executor/mod.rs"] pub mod executor;
+pub mod number_type_casting;
 pub mod seri;
 #[path = "patterns/state_machine.rs"] pub mod state_machine;
 pub mod time_cache;

--- a/mm2src/common/executor/wasm_executor.rs
+++ b/mm2src/common/executor/wasm_executor.rs
@@ -1,5 +1,6 @@
 use crate::executor::AbortOnDropHandle;
 use crate::now_float;
+use crate::number_type_casting::SafeTypeCastingNumbers;
 use futures::future::{abortable, FutureExt};
 use futures::task::{Context, Poll};
 use std::future::Future;
@@ -84,7 +85,7 @@ impl Timer {
         // we should hold the closure until the callback function is called
         let closure = Closure::new(move || on_timeout(&state_c));
 
-        let timeout_id = setTimeout(&closure, delay_ms as u32);
+        let timeout_id = setTimeout(&closure, delay_ms.into_or_max());
         Timer {
             timeout_id,
             _closure: closure,

--- a/mm2src/common/number_type_casting.rs
+++ b/mm2src/common/number_type_casting.rs
@@ -35,17 +35,7 @@ impl_safe_number_type_cast!(usize, u32);
 impl_safe_number_type_cast!(usize, u16);
 impl_safe_number_type_cast!(usize, u8);
 
-// ISIZE
-impl_safe_number_type_cast!(isize, i32);
-impl_safe_number_type_cast!(isize, i16);
-impl_safe_number_type_cast!(isize, i8);
-
-impl_safe_number_type_cast!(isize, u32);
-impl_safe_number_type_cast!(isize, u16);
-impl_safe_number_type_cast!(isize, u8);
-
 // U128
-impl_safe_number_type_cast!(u128, isize);
 impl_safe_number_type_cast!(u128, i128);
 impl_safe_number_type_cast!(u128, i64);
 impl_safe_number_type_cast!(u128, i32);
@@ -59,19 +49,6 @@ impl_safe_number_type_cast!(u128, u16);
 impl_safe_number_type_cast!(u128, u8);
 impl_safe_number_type_cast!(u128, usize);
 
-// I128
-impl_safe_number_type_cast!(i128, i64);
-impl_safe_number_type_cast!(i128, i32);
-impl_safe_number_type_cast!(i128, i16);
-impl_safe_number_type_cast!(i128, i8);
-impl_safe_number_type_cast!(i128, isize);
-
-impl_safe_number_type_cast!(i128, u64);
-impl_safe_number_type_cast!(i128, u32);
-impl_safe_number_type_cast!(i128, u16);
-impl_safe_number_type_cast!(i128, u8);
-impl_safe_number_type_cast!(i128, usize);
-
 // U64
 impl_safe_number_type_cast!(u64, i64);
 impl_safe_number_type_cast!(u64, i32);
@@ -84,42 +61,22 @@ impl_safe_number_type_cast!(u64, u16);
 impl_safe_number_type_cast!(u64, u8);
 impl_safe_number_type_cast!(u64, usize);
 
-// I64
-impl_safe_number_type_cast!(i64, i32);
-impl_safe_number_type_cast!(i64, i16);
-impl_safe_number_type_cast!(i64, i8);
-impl_safe_number_type_cast!(i64, isize);
-
-impl_safe_number_type_cast!(i64, u32);
-impl_safe_number_type_cast!(i64, u16);
-impl_safe_number_type_cast!(i64, u8);
-impl_safe_number_type_cast!(i64, usize);
-
 // U32
 impl_safe_number_type_cast!(u32, i32);
 impl_safe_number_type_cast!(u32, i16);
 impl_safe_number_type_cast!(u32, i8);
+impl_safe_number_type_cast!(u32, isize);
 
 impl_safe_number_type_cast!(u32, u16);
 impl_safe_number_type_cast!(u32, u8);
-
-// I32
-impl_safe_number_type_cast!(i32, i16);
-impl_safe_number_type_cast!(i32, i8);
-
-impl_safe_number_type_cast!(i32, u16);
-impl_safe_number_type_cast!(i32, u8);
+impl_safe_number_type_cast!(u32, usize);
 
 // U16
 impl_safe_number_type_cast!(u16, i16);
 impl_safe_number_type_cast!(u16, i8);
+impl_safe_number_type_cast!(u16, isize);
 
 impl_safe_number_type_cast!(u16, u8);
-
-// I16
-impl_safe_number_type_cast!(i16, i8);
-
-impl_safe_number_type_cast!(i16, u8);
 
 // U8
 impl_safe_number_type_cast!(u8, i8);

--- a/mm2src/common/number_type_casting.rs
+++ b/mm2src/common/number_type_casting.rs
@@ -25,6 +25,7 @@ macro_rules! impl_safe_number_type_cast {
 }
 
 // USIZE
+#[cfg(target_pointer_width = "64")]
 impl_safe_number_type_cast!(usize, i64);
 impl_safe_number_type_cast!(usize, i32);
 impl_safe_number_type_cast!(usize, i16);
@@ -69,11 +70,13 @@ impl_safe_number_type_cast!(u32, isize);
 
 impl_safe_number_type_cast!(u32, u16);
 impl_safe_number_type_cast!(u32, u8);
+#[cfg(target_pointer_width = "16")]
 impl_safe_number_type_cast!(u32, usize);
 
 // U16
 impl_safe_number_type_cast!(u16, i16);
 impl_safe_number_type_cast!(u16, i8);
+#[cfg(target_pointer_width = "16")]
 impl_safe_number_type_cast!(u16, isize);
 
 impl_safe_number_type_cast!(u16, u8);

--- a/mm2src/common/number_type_casting.rs
+++ b/mm2src/common/number_type_casting.rs
@@ -1,0 +1,124 @@
+/// This module contains type casting functions for numbers in a
+/// safe way.
+///
+/// The problem comes with when casting a type that supports higher value
+/// than the target type's highest value.
+///
+/// eg:
+/// ```rs
+/// let x: u64 = 4294967295 + 10;
+/// assert_eq!(x as u32, std::u32::MAX, "{} is not {}", x as u32, std::u32::MAX);
+/// ```
+
+pub trait SafeTypeCastingNumbers<T>: Sized {
+    fn into_or(self, or: T) -> T;
+    fn into_or_max(self) -> T;
+}
+
+macro_rules! impl_safe_number_type_cast {
+    ($from: ident, $to: ident) => {
+        impl SafeTypeCastingNumbers<$to> for $from {
+            fn into_or(self, or: $to) -> $to { std::convert::TryFrom::try_from(self).unwrap_or(or) }
+            fn into_or_max(self) -> $to { std::convert::TryFrom::try_from(self).unwrap_or(std::$to::MAX) }
+        }
+    };
+}
+
+// USIZE
+impl_safe_number_type_cast!(usize, isize);
+impl_safe_number_type_cast!(usize, i128);
+impl_safe_number_type_cast!(usize, i64);
+impl_safe_number_type_cast!(usize, i32);
+impl_safe_number_type_cast!(usize, i16);
+impl_safe_number_type_cast!(usize, i8);
+
+impl_safe_number_type_cast!(usize, u128);
+impl_safe_number_type_cast!(usize, u64);
+impl_safe_number_type_cast!(usize, u32);
+impl_safe_number_type_cast!(usize, u16);
+impl_safe_number_type_cast!(usize, u8);
+
+// ISIZE
+impl_safe_number_type_cast!(isize, i128);
+impl_safe_number_type_cast!(isize, i64);
+impl_safe_number_type_cast!(isize, i32);
+impl_safe_number_type_cast!(isize, i16);
+impl_safe_number_type_cast!(isize, i8);
+
+impl_safe_number_type_cast!(isize, u128);
+impl_safe_number_type_cast!(isize, u64);
+impl_safe_number_type_cast!(isize, u32);
+impl_safe_number_type_cast!(isize, u16);
+impl_safe_number_type_cast!(isize, u8);
+
+// U128
+impl_safe_number_type_cast!(u128, isize);
+impl_safe_number_type_cast!(u128, i128);
+impl_safe_number_type_cast!(u128, i64);
+impl_safe_number_type_cast!(u128, i32);
+impl_safe_number_type_cast!(u128, i16);
+impl_safe_number_type_cast!(u128, i8);
+
+impl_safe_number_type_cast!(u128, u64);
+impl_safe_number_type_cast!(u128, u32);
+impl_safe_number_type_cast!(u128, u16);
+impl_safe_number_type_cast!(u128, u8);
+
+// I128
+impl_safe_number_type_cast!(i128, i64);
+impl_safe_number_type_cast!(i128, i32);
+impl_safe_number_type_cast!(i128, i16);
+impl_safe_number_type_cast!(i128, i8);
+
+impl_safe_number_type_cast!(i128, u64);
+impl_safe_number_type_cast!(i128, u32);
+impl_safe_number_type_cast!(i128, u16);
+impl_safe_number_type_cast!(i128, u8);
+
+// U64
+impl_safe_number_type_cast!(u64, i64);
+impl_safe_number_type_cast!(u64, i32);
+impl_safe_number_type_cast!(u64, i16);
+impl_safe_number_type_cast!(u64, i8);
+
+impl_safe_number_type_cast!(u64, u32);
+impl_safe_number_type_cast!(u64, u16);
+impl_safe_number_type_cast!(u64, u8);
+
+// I64
+impl_safe_number_type_cast!(i64, i32);
+impl_safe_number_type_cast!(i64, i16);
+impl_safe_number_type_cast!(i64, i8);
+
+impl_safe_number_type_cast!(i64, u32);
+impl_safe_number_type_cast!(i64, u16);
+impl_safe_number_type_cast!(i64, u8);
+
+// U32
+impl_safe_number_type_cast!(u32, i32);
+impl_safe_number_type_cast!(u32, i16);
+impl_safe_number_type_cast!(u32, i8);
+
+impl_safe_number_type_cast!(u32, u16);
+impl_safe_number_type_cast!(u32, u8);
+
+// I32
+impl_safe_number_type_cast!(i32, i16);
+impl_safe_number_type_cast!(i32, i8);
+
+impl_safe_number_type_cast!(i32, u16);
+impl_safe_number_type_cast!(i32, u8);
+
+// U16
+impl_safe_number_type_cast!(u16, i16);
+impl_safe_number_type_cast!(u16, i8);
+
+impl_safe_number_type_cast!(u16, u8);
+
+// I16
+impl_safe_number_type_cast!(i16, i8);
+
+impl_safe_number_type_cast!(i16, u8);
+
+// U8
+impl_safe_number_type_cast!(u8, i8);

--- a/mm2src/common/number_type_casting.rs
+++ b/mm2src/common/number_type_casting.rs
@@ -25,28 +25,21 @@ macro_rules! impl_safe_number_type_cast {
 }
 
 // USIZE
-impl_safe_number_type_cast!(usize, isize);
-impl_safe_number_type_cast!(usize, i128);
 impl_safe_number_type_cast!(usize, i64);
 impl_safe_number_type_cast!(usize, i32);
 impl_safe_number_type_cast!(usize, i16);
 impl_safe_number_type_cast!(usize, i8);
+impl_safe_number_type_cast!(usize, isize);
 
-impl_safe_number_type_cast!(usize, u128);
-impl_safe_number_type_cast!(usize, u64);
 impl_safe_number_type_cast!(usize, u32);
 impl_safe_number_type_cast!(usize, u16);
 impl_safe_number_type_cast!(usize, u8);
 
 // ISIZE
-impl_safe_number_type_cast!(isize, i128);
-impl_safe_number_type_cast!(isize, i64);
 impl_safe_number_type_cast!(isize, i32);
 impl_safe_number_type_cast!(isize, i16);
 impl_safe_number_type_cast!(isize, i8);
 
-impl_safe_number_type_cast!(isize, u128);
-impl_safe_number_type_cast!(isize, u64);
 impl_safe_number_type_cast!(isize, u32);
 impl_safe_number_type_cast!(isize, u16);
 impl_safe_number_type_cast!(isize, u8);
@@ -58,41 +51,49 @@ impl_safe_number_type_cast!(u128, i64);
 impl_safe_number_type_cast!(u128, i32);
 impl_safe_number_type_cast!(u128, i16);
 impl_safe_number_type_cast!(u128, i8);
+impl_safe_number_type_cast!(u128, isize);
 
 impl_safe_number_type_cast!(u128, u64);
 impl_safe_number_type_cast!(u128, u32);
 impl_safe_number_type_cast!(u128, u16);
 impl_safe_number_type_cast!(u128, u8);
+impl_safe_number_type_cast!(u128, usize);
 
 // I128
 impl_safe_number_type_cast!(i128, i64);
 impl_safe_number_type_cast!(i128, i32);
 impl_safe_number_type_cast!(i128, i16);
 impl_safe_number_type_cast!(i128, i8);
+impl_safe_number_type_cast!(i128, isize);
 
 impl_safe_number_type_cast!(i128, u64);
 impl_safe_number_type_cast!(i128, u32);
 impl_safe_number_type_cast!(i128, u16);
 impl_safe_number_type_cast!(i128, u8);
+impl_safe_number_type_cast!(i128, usize);
 
 // U64
 impl_safe_number_type_cast!(u64, i64);
 impl_safe_number_type_cast!(u64, i32);
 impl_safe_number_type_cast!(u64, i16);
 impl_safe_number_type_cast!(u64, i8);
+impl_safe_number_type_cast!(u64, isize);
 
 impl_safe_number_type_cast!(u64, u32);
 impl_safe_number_type_cast!(u64, u16);
 impl_safe_number_type_cast!(u64, u8);
+impl_safe_number_type_cast!(u64, usize);
 
 // I64
 impl_safe_number_type_cast!(i64, i32);
 impl_safe_number_type_cast!(i64, i16);
 impl_safe_number_type_cast!(i64, i8);
+impl_safe_number_type_cast!(i64, isize);
 
 impl_safe_number_type_cast!(i64, u32);
 impl_safe_number_type_cast!(i64, u16);
 impl_safe_number_type_cast!(i64, u8);
+impl_safe_number_type_cast!(i64, usize);
 
 // U32
 impl_safe_number_type_cast!(u32, i32);

--- a/mm2src/mm2_main/src/mm2_lib/mm2_wasm_lib.rs
+++ b/mm2src/mm2_main/src/mm2_lib/mm2_wasm_lib.rs
@@ -128,7 +128,7 @@ pub fn mm2_main(params: JsValue, log_cb: js_sys::Function) -> Result<(), JsValue
     };
 
     // At this moment we still don't have `MmCtx` context to use its `MmCtx::abortable_system` spawner.
-    unsafe { executor::spawn_local(fut) };
+    executor::spawn_local(fut);
     Ok(())
 }
 


### PR DESCRIPTION
I think we should replace all the possible overflow cases with this implementation. Should we cover that in this PR? @artemii235 

Atm it only covers [this line](https://github.com/KomodoPlatform/atomicDEX-API/blob/ee078e58e47b43762314fc2d89b030990d0fcc24/mm2src/common/executor/wasm_executor.rs#L88) because @sergeyboyko0791 specifically asked for it [here](https://github.com/KomodoPlatform/atomicDEX-API/pull/1515#issuecomment-1295103002).

Opened from: https://github.com/KomodoPlatform/atomicDEX-API/pull/1515#issuecomment-1295127521
Resolves: #1500