### PR TITLE
update cc and cmake dependencies to be compatible with Visual Studio …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 dependencies = [
  "jobserver",
 ]
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.46"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
…2022

without these updated cc and cmake, as old cc/cmake don't know anything about existing Visual Studio 17 2022 compiler prost-build crate will fail on x86_64-pc-windows-msvc host with the following error:

```
error: failed to run custom build command for `prost-build v0.10.3`

Caused by:
  process didn't exit successfully: `C:\work\atomicDEX-API\target\release\build\prost-build-1ac4fc454bf4b145\build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-changed=C:\Users\user\.cargo\registry\src\github.com-1ecc6299db9ec823\prost-build-0.10.3\third-party\protobuf\cmake
  CMAKE_TOOLCHAIN_FILE_x86_64-pc-windows-msvc = None
  CMAKE_TOOLCHAIN_FILE_x86_64_pc_windows_msvc = None
  HOST_CMAKE_TOOLCHAIN_FILE = None
  CMAKE_TOOLCHAIN_FILE = None
  CMAKE_GENERATOR_x86_64-pc-windows-msvc = None
  CMAKE_GENERATOR_x86_64_pc_windows_msvc = None
  HOST_CMAKE_GENERATOR = None
  CMAKE_GENERATOR = None
  CMAKE_PREFIX_PATH_x86_64-pc-windows-msvc = None
  CMAKE_PREFIX_PATH_x86_64_pc_windows_msvc = None
  HOST_CMAKE_PREFIX_PATH = None
  CMAKE_PREFIX_PATH = None
  CMAKE_x86_64-pc-windows-msvc = None
  CMAKE_x86_64_pc_windows_msvc = None
  HOST_CMAKE = None
  CMAKE = None

  --- stderr
  thread 'main' panicked at '

  unsupported or unknown VisualStudio version: 17.0
  if another version is installed consider running the appropriate vcvars script before building this crate
  ', C:\Users\user\.cargo\registry\src\github.com-1ecc6299db9ec823\cmake-0.1.46\src\lib.rs:877:25
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```