### PR TITLE
avoid colliding filenames for mm2 binary/library on msvc build

### DIFF
--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -33,7 +33,7 @@ name = "docker_tests"
 path = "src/docker_tests.rs"
 
 [lib]
-name = "mm2"
+name = "mm2_lib"
 path = "src/mm2_lib.rs"
 crate-type = ["cdylib", "staticlib"]
 test = false


### PR DESCRIPTION
when we build for host x86_64-pc-windows-msvc compiler tried to create mm2.pdb file twice, first time when build binary mm2.exe and second time when build library mm2.dll ... in some cases build can be failed bcz system will unable to overwrite mm2.pdb.

Also, we have following warning at the begin of build:

```
The bin target `mm2` in package `mm2_main v0.1.0 (C:\Users\builder\AppData\Local\Jenkins\.jenkins\workspace\mm2\mm2src\mm2_main)` has the same output filename as the lib target `mm2` in package `mm2_main v0.1.0 (C:\Users\builder\AppData\Local\Jenkins\.jenkins\workspace\mm2\mm2src\mm2_main)`.
Colliding filename is: C:\Users\builder\AppData\Local\Jenkins\.jenkins\workspace\mm2\target\release\deps\mm2.pdb
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
warning: output filename collision.
```

With this change binary and lib files will not collide in target directory, for binary the following files will be created:

mm2.d
mm2.dll
mm2.exe
mm2.dll.exp
mm2.lib
mm2.dll.lib
mm2.pdb

And for library:

mm2_lib.d
mm2_lib.dll
mm2_lib.dll.exp
mm2_lib.lib
mm2_lib.dll.lib
mm2_lib.pdb