### PR TITLE
[r2r] proper eth token ticker for gui auth service

### DIFF
--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -102,6 +102,32 @@ impl EthCoin {
             Some(d) => d as u8,
         };
 
+        let mut web3_instances = vec![];
+        for node in self.web3_instances.clone() {
+            let mut node = node;
+            let mut transport = node.web3.transport().clone();
+
+            let gui_auth = transport.gui_auth_validation_generator.map(|mut g| {
+                g.coin_ticker = ticker.clone();
+                g
+            });
+
+            transport.gui_auth_validation_generator = gui_auth;
+            let web3 = Web3::new(transport);
+
+            node.web3 = web3;
+            web3_instances.push(node);
+        }
+
+        let mut transport = self.web3.transport().clone();
+        let gui_auth = transport.gui_auth_validation_generator.map(|mut g| {
+            g.coin_ticker = ticker.clone();
+            g
+        });
+
+        transport.gui_auth_validation_generator = gui_auth;
+        let web3 = Web3::new(transport);
+
         let required_confirmations = activation_params
             .required_confirmations
             .unwrap_or_else(|| conf["required_confirmations"].as_u64().unwrap_or(1))
@@ -126,8 +152,8 @@ impl EthCoin {
             gas_station_url: self.gas_station_url.clone(),
             gas_station_decimals: self.gas_station_decimals,
             gas_station_policy: self.gas_station_policy,
-            web3: self.web3.clone(),
-            web3_instances: self.web3_instances.clone(),
+            web3,
+            web3_instances,
             history_sync_state: Mutex::new(self.history_sync_state.lock().unwrap().clone()),
             ctx: self.ctx.clone(),
             required_confirmations,


### PR DESCRIPTION
With https://github.com/KomodoPlatform/atomicdex-gui-auth/commit/95bf760edee9cc5273c8aa113c3654430edf799f we are now counting rates for each config. On API side, because we were directly cloning web instances all the assets are rated as `ETH`. This PR fixes it.