### PR TITLE
[r2r] Rename lib and create separate CI build profile.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,24 +514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bip32"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873faa4363bfc54c36a48321da034c92a0645a363eed34d948683ffc1706e37f"
-dependencies = [
- "bs58",
- "hmac 0.11.0",
- "k256",
- "once_cell",
- "pbkdf2 0.9.0",
- "rand_core 0.6.3",
- "ripemd160",
- "sha2 0.9.9",
- "subtle 2.4.0",
- "zeroize",
-]
-
-[[package]]
 name = "bitcoin"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,7 +1040,7 @@ dependencies = [
  "base58",
  "base64 0.10.1",
  "bincode",
- "bip32 0.2.2",
+ "bip32",
  "bitcoin",
  "bitcoin_hashes",
  "bitcrypto",
@@ -1341,7 +1323,6 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6989fdb6267eccb52762530b79ce0b385f4eaeb8b786522a95512e9bebb268c2"
 dependencies = [
- "bip32 0.3.0",
  "cosmos-sdk-proto",
  "ecdsa",
  "eyre",
@@ -1543,7 +1524,7 @@ version = "1.0.0"
 dependencies = [
  "arrayref",
  "async-trait",
- "bip32 0.2.2",
+ "bip32",
  "bitcrypto",
  "bs58",
  "common",
@@ -3065,7 +3046,7 @@ name = "hw_common"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "bip32 0.2.2",
+ "bip32",
  "common",
  "derive_more",
  "futures 0.3.15",
@@ -3411,7 +3392,6 @@ dependencies = [
  "elliptic-curve",
  "sec1",
  "sha2 0.9.9",
- "sha3",
 ]
 
 [[package]]
@@ -8474,7 +8454,7 @@ name = "trezor"
 version = "0.1.1"
 dependencies = [
  "async-trait",
- "bip32 0.2.2",
+ "bip32",
  "byteorder 1.4.3",
  "common",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,9 @@ debug-assertions = false
 [profile.release.overrides."*"]
 # Turns debugging symbols off for the out-of-workspace dependencies.
 debug = false
+
+[profile.ci]
+inherits = "dev"
+# full debug info is not required
+debug = 1
+debug-assertions = false

--- a/azure-pipelines-android-job.yml
+++ b/azure-pipelines-android-job.yml
@@ -45,10 +45,10 @@ jobs:
           mkdir upload
           mv target/armv7-linux-androideabi/ci/libmm2lib.a upload/libmm2.a
           zip upload/mm2-$(COMMIT_HASH)-android-armv7-CI upload/libmm2.a -j
-          rm -rf upload/libmm2.a
+          rm upload/libmm2.a
           mv target/aarch64-linux-android/ci/libmm2lib.a upload/libmm2.a
           zip upload/mm2-$(COMMIT_HASH)-android-aarch64-CI upload/libmm2.a -j
-          rm -rf upload/libmm2.a
+          rm upload/libmm2.a
         displayName: 'Prepare upload'
       - task: CopyFilesOverSSH@0
         inputs:

--- a/azure-pipelines-android-job.yml
+++ b/azure-pipelines-android-job.yml
@@ -23,28 +23,28 @@ jobs:
           echo "##vso[task.setvariable variable=COMMIT_HASH]${TAG}"
         displayName: Setup ENV
       - bash: |
-          VERSION=2.1.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_android_armv7_Release
+          VERSION=2.1.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_android_armv7_CI
           if ! grep -q $VERSION MM_VERSION; then
             echo $VERSION > MM_VERSION
           fi
           cat MM_VERSION
           export PATH=$PATH:/home/azureagent/android-ndk/arch-ndk/x86_64/android-ndk/bin
-          CC_armv7_linux_androideabi=armv7a-linux-androideabi21-clang CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=armv7a-linux-androideabi21-clang cargo rustc --target=armv7-linux-androideabi --lib --release --crate-type=staticlib --package mm2_main
+          CC_armv7_linux_androideabi=armv7a-linux-androideabi21-clang CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=armv7a-linux-androideabi21-clang cargo rustc --target=armv7-linux-androideabi --lib --profile ci --crate-type=staticlib --package mm2_main
         displayName: 'Build armv7'
       - bash: |
-          VERSION=2.1.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_android_aarch64_Release
+          VERSION=2.1.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_android_aarch64_CI
           if ! grep -q $VERSION MM_VERSION; then
             echo $VERSION > MM_VERSION
           fi
           cat MM_VERSION
           export PATH=$PATH:/home/azureagent/android-ndk/arch-ndk/x86_64/android-ndk/bin
-          CC_aarch64_linux_android=aarch64-linux-android21-clang CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android21-clang cargo rustc --target=aarch64-linux-android --lib --release --crate-type=staticlib --package mm2_main
+          CC_aarch64_linux_android=aarch64-linux-android21-clang CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android21-clang cargo rustc --target=aarch64-linux-android --lib --profile ci --crate-type=staticlib --package mm2_main
         displayName: 'Build aarch64'
       - bash: |
           rm -rf upload
           mkdir upload
-          zip upload/mm2-$(COMMIT_HASH)-android-armv7-Release target/armv7-linux-androideabi/release/libmm2.a -j
-          zip upload/mm2-$(COMMIT_HASH)-android-aarch64-Release target/aarch64-linux-android/release/libmm2.a -j
+          zip upload/mm2-$(COMMIT_HASH)-android-armv7-CI target/armv7-linux-androideabi/ci/libmm2.a -j
+          zip upload/mm2-$(COMMIT_HASH)-android-aarch64-CI target/aarch64-linux-android/ci/libmm2.a -j
         displayName: 'Prepare upload'
       - task: CopyFilesOverSSH@0
         inputs:

--- a/azure-pipelines-android-job.yml
+++ b/azure-pipelines-android-job.yml
@@ -43,8 +43,12 @@ jobs:
       - bash: |
           rm -rf upload
           mkdir upload
-          zip upload/mm2-$(COMMIT_HASH)-android-armv7-CI target/armv7-linux-androideabi/ci/libmm2.a -j
-          zip upload/mm2-$(COMMIT_HASH)-android-aarch64-CI target/aarch64-linux-android/ci/libmm2.a -j
+          mv target/armv7-linux-androideabi/ci/libmm2lib.a upload/libmm2.a
+          zip upload/mm2-$(COMMIT_HASH)-android-armv7-CI upload/libmm2.a -j
+          rm -rf upload/libmm2.a
+          mv target/aarch64-linux-android/ci/libmm2lib.a upload/libmm2.a
+          zip upload/mm2-$(COMMIT_HASH)-android-aarch64-CI upload/libmm2.a -j
+          rm -rf upload/libmm2.a
         displayName: 'Prepare upload'
       - task: CopyFilesOverSSH@0
         inputs:

--- a/azure-pipelines-build-stage-job.yml
+++ b/azure-pipelines-build-stage-job.yml
@@ -35,18 +35,18 @@ jobs:
       - bash: |
           rm -rf upload
           mkdir upload
-          VERSION=2.1.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_$(Agent.OS)_Release
+          VERSION=2.1.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_$(Agent.OS)_CI
           if ! grep -q $VERSION MM_VERSION; then
             echo $VERSION > MM_VERSION
           fi
           cat MM_VERSION
           if [ $AGENT_OS = "Darwin" ]
           then
-            cargo build --bin mm2 --release --target x86_64-apple-darwin
+            cargo build --bin mm2 --profile ci --target x86_64-apple-darwin
           else
-            cargo build --bin mm2 --release
+            cargo build --bin mm2 --profile ci
           fi
-        displayName: 'Build MM2 Release'
+        displayName: 'Build MM2'
         condition: ne ( variables['Build.Reason'], 'PullRequest' )
         env:
           MANUAL_MM_VERSION: true
@@ -80,9 +80,9 @@ jobs:
       - bash: |
           if [ $AGENT_OS = "Darwin" ]
           then
-            cargo test --all --target x86_64-apple-darwin -- --test-threads=16
+            cargo test --all --target x86_64-apple-darwin --profile ci -- --test-threads=16
           else
-            cargo test --all -- --test-threads=32
+            cargo test --all --profile ci -- --test-threads=32
           fi
         displayName: 'Test MM2'
         timeoutInMinutes: 22
@@ -105,16 +105,16 @@ jobs:
         # Run unconditionally even if previous steps failed
         condition: true
       - bash: |
-          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release target/release/mm2 -j
+          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-CI target/ci/mm2 -j
         displayName: 'Prepare release build upload Linux'
         condition: and ( eq( variables['Agent.OS'], 'Linux' ), ne ( variables['Build.Reason'], 'PullRequest' ) )
       - bash: |
-          cd target/x86_64-apple-darwin/release
-          zip ../../../upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-Release mm2.dSYM mm2 -r
+          cd target/x86_64-apple-darwin/ci
+          zip ../../../upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-CI mm2.dSYM mm2 -r
         displayName: 'Prepare release build upload MacOS'
         condition: and ( eq( variables['Agent.OS'], 'Darwin' ), ne ( variables['Build.Reason'], 'PullRequest' ) )
       - powershell: |
-          7z a .\upload\mm2-$(COMMIT_HASH)-$(Agent.OS)-Release.zip .\target\release\mm2.exe .\target\release\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
+          7z a .\upload\mm2-$(COMMIT_HASH)-$(Agent.OS)-CI.zip .\target\ci\mm2.exe .\target\ci\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
         displayName: 'Prepare release build upload Windows'
         condition: and ( eq( variables['Agent.OS'], 'Windows_NT' ), ne ( variables['Build.Reason'], 'PullRequest' ) )
       # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/copy-files-over-ssh?view=vsts

--- a/azure-pipelines-build-stage-job.yml
+++ b/azure-pipelines-build-stage-job.yml
@@ -106,16 +106,15 @@ jobs:
         condition: true
       - bash: |
           zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-CI target/ci/mm2 -j
-        displayName: 'Prepare release build upload Linux'
+        displayName: 'Prepare CI build upload Linux'
         condition: and ( eq( variables['Agent.OS'], 'Linux' ), ne ( variables['Build.Reason'], 'PullRequest' ) )
       - bash: |
-          cd target/x86_64-apple-darwin/ci
-          zip ../../../upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-CI mm2.dSYM mm2 -r
-        displayName: 'Prepare release build upload MacOS'
+          zip upload/mm2-$(COMMIT_HASH)-$(Agent.OS)-CI target/x86_64-apple-darwin/ci/mm2.dSYM mm2 -r
+        displayName: 'Prepare CI build upload MacOS'
         condition: and ( eq( variables['Agent.OS'], 'Darwin' ), ne ( variables['Build.Reason'], 'PullRequest' ) )
       - powershell: |
           7z a .\upload\mm2-$(COMMIT_HASH)-$(Agent.OS)-CI.zip .\target\ci\mm2.exe .\target\ci\*.dll "$Env:windir\system32\msvcr100.dll" "$Env:windir\system32\msvcp140.dll" "$Env:windir\system32\vcruntime140.dll"
-        displayName: 'Prepare release build upload Windows'
+        displayName: 'Prepare CI build upload Windows'
         condition: and ( eq( variables['Agent.OS'], 'Windows_NT' ), ne ( variables['Build.Reason'], 'PullRequest' ) )
       # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/copy-files-over-ssh?view=vsts
       - task: CopyFilesOverSSH@0

--- a/azure-pipelines-ios-job.yml
+++ b/azure-pipelines-ios-job.yml
@@ -33,7 +33,9 @@ jobs:
       - bash: |
           rm -rf upload
           mkdir upload
-          zip upload/mm2-$(COMMIT_HASH)-ios-aarch64-CI target/aarch64-apple-ios/ci/libmm2.a -j
+          mv target/aarch64-apple-ios/ci/libmm2lib.a upload/libmm2.a
+          zip upload/mm2-$(COMMIT_HASH)-ios-aarch64-CI upload/libmm2.a -j
+          rm -rf upload/libmm2.a
         displayName: 'Prepare upload'
       - task: CopyFilesOverSSH@0
         inputs:

--- a/azure-pipelines-ios-job.yml
+++ b/azure-pipelines-ios-job.yml
@@ -23,17 +23,17 @@ jobs:
           echo "##vso[task.setvariable variable=COMMIT_HASH]${TAG}"
         displayName: Setup ENV
       - bash: |
-          VERSION=2.1.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_ios_aarch64_Release
+          VERSION=2.1.$(Build.BuildId)_$(Build.SourceBranchName)_$(COMMIT_HASH)_ios_aarch64_CI
           if ! grep -q $VERSION MM_VERSION; then
             echo $VERSION > MM_VERSION
           fi
           cat MM_VERSION
-          cargo rustc --target aarch64-apple-ios --lib --release --package mm2_main --crate-type=staticlib
+          cargo rustc --target aarch64-apple-ios --lib --profile ci --package mm2_main --crate-type=staticlib
         displayName: 'Build iOS lib'
       - bash: |
           rm -rf upload
           mkdir upload
-          zip upload/mm2-$(COMMIT_HASH)-ios-aarch64-Release target/aarch64-apple-ios/release/libmm2.a -j
+          zip upload/mm2-$(COMMIT_HASH)-ios-aarch64-CI target/aarch64-apple-ios/ci/libmm2.a -j
         displayName: 'Prepare upload'
       - task: CopyFilesOverSSH@0
         inputs:

--- a/azure-pipelines-ios-job.yml
+++ b/azure-pipelines-ios-job.yml
@@ -35,7 +35,7 @@ jobs:
           mkdir upload
           mv target/aarch64-apple-ios/ci/libmm2lib.a upload/libmm2.a
           zip upload/mm2-$(COMMIT_HASH)-ios-aarch64-CI upload/libmm2.a -j
-          rm -rf upload/libmm2.a
+          rm upload/libmm2.a
         displayName: 'Prepare upload'
       - task: CopyFilesOverSSH@0
         inputs:

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -32,12 +32,12 @@ jobs:
         env:
           MANUAL_MM_VERSION: true
       - bash: |
-          cargo clippy -- -D warnings
+          cargo clippy --profile ci -- -D warnings
         displayName: 'Check Clippy warnings'
         env:
           MANUAL_MM_VERSION: true
       - bash: |
-          cargo check --tests
+          cargo check --tests --profile ci
         displayName: 'Check Tests'
         env:
           MANUAL_MM_VERSION: true

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -32,7 +32,12 @@ jobs:
         env:
           MANUAL_MM_VERSION: true
       - bash: |
-          cargo clippy --profile ci -- -D warnings
+          if [ $AGENT_OS = "Darwin" ]
+          then
+            cargo clippy --profile ci --target x86_64-apple-darwin -- -D warnings
+          else
+            cargo clippy --profile ci -- -D warnings
+          fi
         displayName: 'Check Clippy warnings'
         env:
           MANUAL_MM_VERSION: true

--- a/azure-pipelines-lint-stage-job.yml
+++ b/azure-pipelines-lint-stage-job.yml
@@ -42,7 +42,12 @@ jobs:
         env:
           MANUAL_MM_VERSION: true
       - bash: |
-          cargo check --tests --profile ci
+          if [ $AGENT_OS = "Darwin" ]
+          then
+            cargo check --tests --profile ci --target x86_64-apple-darwin
+          else
+            cargo check --tests --profile ci
+          fi
         displayName: 'Check Tests'
         env:
           MANUAL_MM_VERSION: true

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "0.4"
 cfg-if = "1.0"
 chain = { path = "../mm2_bitcoin/chain" }
 common = { path = "../common" }
-cosmrs = { version = "0.7" }
+cosmrs = { version = "0.7", default-features = false }
 crossbeam = "0.7"
 crypto = { path = "../crypto" }
 db_common = { path = "../db_common" }

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -28,7 +28,7 @@ doctest = false
 bench = false
 
 [lib]
-name = "mm2"
+name = "mm2lib"
 crate-type = ["cdylib", "lib"]
 test = false
 doctest = false

--- a/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
@@ -16,11 +16,11 @@ use crypto::Secp256k1Secret;
 use ethereum_types::H160;
 use futures01::Future;
 use http::StatusCode;
-use mm2::mm2::lp_swap::{dex_fee_amount, max_taker_vol_from_available};
 use mm2_core::mm_ctx::{MmArc, MmCtxBuilder};
 use mm2_number::BigDecimal;
 use mm2_test_helpers::structs::{trade_preimage_error, EnableElectrumResponse, OrderbookResponse, RpcErrorResponse,
                                 RpcSuccessResponse, TransactionDetails};
+use mm2lib::mm2::lp_swap::{dex_fee_amount, max_taker_vol_from_available};
 use rand6::Rng;
 use serde_json::{self as json, Value as Json};
 use std::convert::TryFrom;

--- a/mm2src/mm2_main/tests/docker_tests/swaps_confs_settings_sync_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swaps_confs_settings_sync_tests.rs
@@ -1,9 +1,9 @@
 use crate::generate_utxo_coin_with_random_privkey;
 use crate::integration_tests_common::enable_native;
 use common::block_on;
-use mm2::mm2::lp_ordermatch::OrderConfirmationsSettings;
-use mm2::mm2::lp_swap::get_payment_locktime;
 use mm2_test_helpers::for_tests::{mm_dump, MarketMakerIt};
+use mm2lib::mm2::lp_ordermatch::OrderConfirmationsSettings;
+use mm2lib::mm2::lp_swap::get_payment_locktime;
 use serde_json::Value as Json;
 use std::thread;
 use std::time::Duration;

--- a/mm2src/mm2_main/tests/integration_tests_common/mod.rs
+++ b/mm2src/mm2_main/tests/integration_tests_common/mod.rs
@@ -2,12 +2,12 @@ use common::executor::Timer;
 use common::log::LogLevel;
 use common::{block_on, log, now_ms};
 use crypto::privkey::key_pair_from_seed;
-use mm2::mm2::{lp_main, LpMainParams};
 use mm2_test_helpers::electrums::{morty_electrums, rick_electrums};
 use mm2_test_helpers::for_tests::{enable_native as enable_native_impl, init_utxo_electrum, init_utxo_status,
                                   init_z_coin_light, init_z_coin_status, MarketMakerIt};
 use mm2_test_helpers::structs::{CoinActivationResult, EnableElectrumResponse, InitTaskResult, InitUtxoStatus,
                                 InitZcoinStatus, RpcV2Response, UtxoStandardActivationResult};
+use mm2lib::mm2::{lp_main, LpMainParams};
 use serde_json::{self as json, Value as Json};
 use std::collections::HashMap;
 use std::env::var;

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -3,7 +3,6 @@ use common::executor::Timer;
 use common::{cfg_native, cfg_wasm32, get_utc_timestamp, log};
 use crypto::privkey::key_pair_from_seed;
 use http::{HeaderMap, StatusCode};
-use mm2::mm2::lp_ordermatch::MIN_ORDER_KEEP_ALIVE_INTERVAL;
 use mm2_metrics::{MetricType, MetricsJson};
 use mm2_number::{BigDecimal, BigRational, Fraction, MmNumber};
 use mm2_test_helpers::electrums::*;
@@ -21,6 +20,7 @@ use mm2_test_helpers::for_tests::{btc_segwit_conf, btc_with_spv_conf, check_rece
                                   QRC20_ELECTRUMS, RICK, RICK_ELECTRUM_ADDRS, TAKER_SUCCESS_EVENTS};
 use mm2_test_helpers::get_passphrase;
 use mm2_test_helpers::structs::*;
+use mm2lib::mm2::lp_ordermatch::MIN_ORDER_KEEP_ALIVE_INTERVAL;
 use serde_json::{self as json, json, Value as Json};
 use std::collections::HashMap;
 use std::env::{self, var};

--- a/mm2src/mm2_main/tests/mm2_tests/orderbook_sync_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/orderbook_sync_tests.rs
@@ -2,7 +2,6 @@ use crate::integration_tests_common::{enable_coins_eth_electrum, enable_coins_ri
                                       enable_electrum_json, enable_z_coin_light};
 use common::{block_on, log};
 use http::StatusCode;
-use mm2::mm2::lp_ordermatch::MIN_ORDER_KEEP_ALIVE_INTERVAL;
 use mm2_number::{BigDecimal, BigRational, MmNumber};
 use mm2_test_helpers::electrums::rick_electrums;
 use mm2_test_helpers::for_tests::{get_passphrase, orderbook_v2, rick_conf, zombie_conf, MarketMakerIt, Mm2TestConf,
@@ -10,6 +9,7 @@ use mm2_test_helpers::for_tests::{get_passphrase, orderbook_v2, rick_conf, zombi
 use mm2_test_helpers::get_passphrase;
 use mm2_test_helpers::structs::{EnableElectrumResponse, GetPublicKeyResult, OrderbookEntryAggregate,
                                 OrderbookResponse, OrderbookV2Response, RpcV2Response, SetPriceResponse};
+use mm2lib::mm2::lp_ordermatch::MIN_ORDER_KEEP_ALIVE_INTERVAL;
 use serde_json::{self as json, json, Value as Json};
 use std::env;
 use std::str::FromStr;


### PR DESCRIPTION
- Separate profile inherited from dev speeds up compilation significantly. We don't need optimizations for nightly builds anyway because they are intended for testing purposes.
- Renamed lib to "mm2lib"
- Disabled default features of cosmrs - wasn't using them.