### PR TITLE
[r2r] Fix `task::*::cancel` if the RPC task is an awaiting status

### DIFF
--- a/mm2src/coins/rpc_command/hd_account_balance_rpc_error.rs
+++ b/mm2src/coins/rpc_command/hd_account_balance_rpc_error.rs
@@ -97,7 +97,7 @@ impl From<AddressDerivingError> for HDAccountBalanceRpcError {
 impl From<RpcTaskError> for HDAccountBalanceRpcError {
     fn from(e: RpcTaskError) -> Self {
         match e {
-            RpcTaskError::Canceled => HDAccountBalanceRpcError::Internal("Canceled".to_owned()),
+            RpcTaskError::Cancelled => HDAccountBalanceRpcError::Internal("Cancelled".to_owned()),
             RpcTaskError::Timeout(timeout) => HDAccountBalanceRpcError::Timeout(timeout),
             RpcTaskError::NoSuchTask(_)
             // `UnexpectedTaskStatus` and `UnexpectedUserAction` are not expected at the balance request.

--- a/mm2src/coins/rpc_command/init_create_account.rs
+++ b/mm2src/coins/rpc_command/init_create_account.rs
@@ -121,7 +121,7 @@ impl From<RpcTaskError> for CreateAccountRpcError {
     fn from(e: RpcTaskError) -> Self {
         let error = e.to_string();
         match e {
-            RpcTaskError::Canceled => CreateAccountRpcError::Internal("Canceled".to_owned()),
+            RpcTaskError::Cancelled => CreateAccountRpcError::Internal("Cancelled".to_owned()),
             RpcTaskError::Timeout(timeout) => CreateAccountRpcError::Timeout(timeout),
             RpcTaskError::NoSuchTask(_) | RpcTaskError::UnexpectedTaskStatus { .. } => {
                 CreateAccountRpcError::Internal(error)

--- a/mm2src/coins/utxo/utxo_withdraw.rs
+++ b/mm2src/coins/utxo/utxo_withdraw.rs
@@ -78,7 +78,7 @@ impl From<RpcTaskError> for WithdrawError {
     fn from(e: RpcTaskError) -> Self {
         let error = e.to_string();
         match e {
-            RpcTaskError::Canceled => WithdrawError::InternalError("Canceled".to_owned()),
+            RpcTaskError::Cancelled => WithdrawError::InternalError("Cancelled".to_owned()),
             RpcTaskError::Timeout(timeout) => WithdrawError::Timeout(timeout),
             RpcTaskError::NoSuchTask(_) | RpcTaskError::UnexpectedTaskStatus { .. } => {
                 WithdrawError::InternalError(error)

--- a/mm2src/mm2_main/src/lp_init/init_hw.rs
+++ b/mm2src/mm2_main/src/lp_init/init_hw.rs
@@ -66,7 +66,7 @@ impl From<RpcTaskError> for InitHwError {
     fn from(e: RpcTaskError) -> Self {
         let error = e.to_string();
         match e {
-            RpcTaskError::Canceled => InitHwError::Internal("Canceled".to_owned()),
+            RpcTaskError::Cancelled => InitHwError::Internal("Cancelled".to_owned()),
             RpcTaskError::Timeout(timeout) => InitHwError::Timeout(timeout),
             RpcTaskError::NoSuchTask(_) | RpcTaskError::UnexpectedTaskStatus { .. } => InitHwError::Internal(error),
             RpcTaskError::UnexpectedUserAction { expected } => InitHwError::UnexpectedUserAction { expected },

--- a/mm2src/mm2_main/src/lp_init/init_metamask.rs
+++ b/mm2src/mm2_main/src/lp_init/init_metamask.rs
@@ -57,7 +57,7 @@ impl From<RpcTaskError> for InitMetamaskError {
     fn from(e: RpcTaskError) -> Self {
         let error = e.to_string();
         match e {
-            RpcTaskError::Canceled => InitMetamaskError::Internal("Canceled".to_owned()),
+            RpcTaskError::Cancelled => InitMetamaskError::Internal("Cancelled".to_owned()),
             RpcTaskError::Timeout(timeout) => InitMetamaskError::Timeout(timeout),
             RpcTaskError::NoSuchTask(_) | RpcTaskError::UnexpectedTaskStatus { .. } => {
                 InitMetamaskError::Internal(error)

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -108,7 +108,7 @@ impl From<AdexBehaviourError> for P2PInitError {
 #[derive(Clone, Debug, Display, EnumFromTrait, Serialize, SerializeErrorType)]
 #[serde(tag = "error_type", content = "error_data")]
 pub enum MmInitError {
-    Canceled,
+    Cancelled,
     #[from_trait(WithTimeout::timeout)]
     #[display(fmt = "Initialization timeout {:?}", _0)]
     Timeout(Duration),
@@ -224,7 +224,7 @@ impl From<RpcTaskError> for MmInitError {
     fn from(e: RpcTaskError) -> Self {
         let error = e.to_string();
         match e {
-            RpcTaskError::Canceled => MmInitError::Canceled,
+            RpcTaskError::Cancelled => MmInitError::Cancelled,
             RpcTaskError::Timeout(timeout) => MmInitError::Timeout(timeout),
             RpcTaskError::NoSuchTask(_)
             | RpcTaskError::UnexpectedTaskStatus { .. }

--- a/mm2src/rpc_task/src/handle.rs
+++ b/mm2src/rpc_task/src/handle.rs
@@ -53,12 +53,17 @@ impl<Task: RpcTask> RpcTaskHandle<Task> {
         user_action_rx
             .timeout(timeout)
             .await?
-            .map_to_mm(|_canceled| RpcTaskError::Canceled)
+            .map_to_mm(|_canceled| RpcTaskError::Cancelled)
     }
 
     pub(crate) fn finish(self, result: Result<Task::Item, MmError<Task::Error>>) {
         let task_status = Self::prepare_task_result(result);
         self.lock_and_then(|mut task_manager| task_manager.update_task_status(self.task_id, task_status))
+            .warn_log();
+    }
+
+    pub(crate) fn on_cancelled(self) {
+        self.lock_and_then(|mut task_manager| task_manager.on_task_cancelling_finished(self.task_id))
             .warn_log();
     }
 

--- a/mm2src/rpc_task/src/lib.rs
+++ b/mm2src/rpc_task/src/lib.rs
@@ -52,7 +52,7 @@ pub enum RpcTaskError {
     UnexpectedUserAction {
         expected: String,
     },
-    Canceled,
+    Cancelled,
     Internal(String),
 }
 
@@ -61,6 +61,7 @@ pub enum TaskStatusError {
     Idle,
     InProgress,
     AwaitingUserAction,
+    Cancelled,
     Finished,
 }
 


### PR DESCRIPTION
The issue was:
1. `cancel_init_trezor`:
https://github.com/KomodoPlatform/atomicDEX-API/blob/6c90c28a29723dad6c48296bed3093686188eeb2/mm2src/mm2_main/src/lp_init/init_hw.rs#L209
2. `RpcTaskManager::cancel_task`:
https://github.com/KomodoPlatform/atomicDEX-API/blob/6c90c28a29723dad6c48296bed3093686188eeb2/mm2src/rpc_task/src/manager.rs#L111-L112
3. A corresponding item is removed from the `RpcTaskManager::tasks`:
https://github.com/KomodoPlatform/atomicDEX-API/blob/6c90c28a29723dad6c48296bed3093686188eeb2/mm2src/rpc_task/src/manager.rs#L21-L22
4. If the task is in `Awaiting` status, `abort_handle` **AND** `action_sender` are dropped
https://github.com/KomodoPlatform/atomicDEX-API/blob/6c90c28a29723dad6c48296bed3093686188eeb2/mm2src/rpc_task/src/manager.rs#L269-L274
5. I don't know why, but `action_sender` channel is closed before `abort_handle`, so the task finishes with an error, but we expect that it should abort.