### PR TITLE
[r2r] use avg_blocktime from platform/utxo coin for l2/lightning

### DIFF
--- a/mm2src/coins/lightning.rs
+++ b/mm2src/coins/lightning.rs
@@ -154,6 +154,9 @@ impl LightningCoin {
     pub fn platform_coin(&self) -> &UtxoStandardCoin { &self.platform.coin }
 
     #[inline]
+    fn avg_blocktime(&self) -> u64 { self.platform.avg_blocktime }
+
+    #[inline]
     fn my_node_id(&self) -> String { self.channel_manager.get_our_node_id().to_string() }
 
     pub(crate) async fn list_channels(&self) -> Vec<ChannelDetails> {
@@ -479,7 +482,7 @@ impl LightningCoin {
         }
     }
 
-    fn estimate_blocks_from_duration(&self, duration: u64) -> u64 { duration / self.platform.avg_block_time }
+    fn estimate_blocks_from_duration(&self, duration: u64) -> u64 { duration / self.avg_blocktime() }
 
     async fn swap_payment_instructions(
         &self,

--- a/mm2src/coins/lightning/ln_conf.rs
+++ b/mm2src/coins/lightning/ln_conf.rs
@@ -12,7 +12,6 @@ pub struct PlatformCoinConfirmationTargets {
 pub struct LightningProtocolConf {
     pub platform_coin_ticker: String,
     pub network: BlockchainNetwork,
-    pub avg_block_time: u64,
     pub confirmation_targets: PlatformCoinConfirmationTargets,
 }
 

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2473,7 +2473,6 @@ pub enum CoinProtocol {
     LIGHTNING {
         platform: String,
         network: BlockchainNetwork,
-        avg_block_time: u64,
         confirmation_targets: PlatformCoinConfirmationTargets,
     },
     #[cfg(not(target_arch = "wasm32"))]

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -562,6 +562,8 @@ pub struct UtxoCoinConf {
     /// where the full `BIP44` address has the following structure:
     /// `m/purpose'/coin_type'/account'/change/address_index`.
     pub derivation_path: Option<StandardHDPathToCoin>,
+    /// The average time in seconds needed to mine a new block for this coin.
+    pub avg_blocktime: Option<u64>,
 }
 
 pub struct UtxoCoinFields {

--- a/mm2src/coins/utxo/utxo_builder/utxo_conf_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_conf_builder.rs
@@ -89,6 +89,7 @@ impl<'a> UtxoConfBuilder<'a> {
         let enable_spv_proof = self.enable_spv_proof();
         let block_headers_verification_params = self.block_headers_verification_params();
         let derivation_path = self.derivation_path()?;
+        let avg_blocktime = self.avg_blocktime();
 
         Ok(UtxoCoinConf {
             ticker: self.ticker.to_owned(),
@@ -123,6 +124,7 @@ impl<'a> UtxoConfBuilder<'a> {
             enable_spv_proof,
             block_headers_verification_params,
             derivation_path,
+            avg_blocktime,
         })
     }
 
@@ -293,4 +295,6 @@ impl<'a> UtxoConfBuilder<'a> {
         json::from_value(self.conf["derivation_path"].clone())
             .map_to_mm(|e| UtxoConfError::ErrorDeserializingDerivationPath(e.to_string()))
     }
+
+    fn avg_blocktime(&self) -> Option<u64> { self.conf["avg_blocktime"].as_u64() }
 }

--- a/mm2src/coins/utxo/utxo_common_tests.rs
+++ b/mm2src/coins/utxo/utxo_common_tests.rs
@@ -123,6 +123,7 @@ pub(super) fn utxo_coin_fields_for_test(
             enable_spv_proof: false,
             block_headers_verification_params: None,
             derivation_path: None,
+            avg_blocktime: None,
         },
         decimals: TEST_COIN_DECIMALS,
         dust_amount: UTXO_DUST_AMOUNT,

--- a/mm2src/coins_activation/src/l2/init_l2_error.rs
+++ b/mm2src/coins_activation/src/l2/init_l2_error.rs
@@ -36,6 +36,11 @@ pub enum InitL2Error {
         platform_coin_ticker: String,
         l2_ticker: String,
     },
+    #[display(fmt = "Invalid config for platform coin: {}, error: {}", platform_coin_ticker, err)]
+    InvalidPlatformConfiguration {
+        platform_coin_ticker: String,
+        err: String,
+    },
     #[display(fmt = "Layer 2 configuration parsing failed: {}", _0)]
     L2ConfigParseError(String),
     #[display(fmt = "Initialization task has timed out {:?}", duration)]
@@ -80,6 +85,7 @@ impl HttpStatusCode for InitL2Error {
             InitL2Error::TaskTimedOut { .. } => StatusCode::REQUEST_TIMEOUT,
             InitL2Error::L2ProtocolParseError { .. }
             | InitL2Error::UnsupportedPlatformCoin { .. }
+            | InitL2Error::InvalidPlatformConfiguration { .. }
             | InitL2Error::L2ConfigParseError(_)
             | InitL2Error::Transport(_)
             | InitL2Error::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/mm2src/mm2_main/tests/mm2_tests/lightning_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/lightning_tests.rs
@@ -13,6 +13,7 @@ use serde_json::{self as json, json, Value as Json};
 use std::env;
 use std::str::FromStr;
 
+const BTC_AVG_BLOCKTIME: u64 = 600;
 const T_BTC_ELECTRUMS: &[&str] = &[
     "electrum1.cipig.net:10068",
     "electrum2.cipig.net:10068",
@@ -61,7 +62,7 @@ fn start_lightning_nodes(enable_0_confs: bool) -> (MarketMakerIt, MarketMakerIt,
             "estimate_fee_mode": "ECONOMICAL",
             "mm2": 1,
             "required_confirmations": 0,
-            "avg_blocktime": 600,
+            "avg_blocktime": BTC_AVG_BLOCKTIME,
             "protocol": {
               "type": "UTXO"
             }
@@ -170,7 +171,7 @@ fn test_enable_lightning() {
             "estimate_fee_mode": "ECONOMICAL",
             "mm2": 1,
             "required_confirmations": 0,
-            "avg_blocktime": 600,
+            "avg_blocktime": BTC_AVG_BLOCKTIME,
             "protocol": {
               "type": "UTXO"
             }
@@ -744,7 +745,7 @@ fn test_sign_verify_message_lightning() {
         "estimate_fee_mode": "ECONOMICAL",
         "mm2": 1,
         "required_confirmations": 0,
-        "avg_blocktime": 600,
+        "avg_blocktime": BTC_AVG_BLOCKTIME,
         "protocol": {
           "type": "UTXO"
         }

--- a/mm2src/mm2_main/tests/mm2_tests/lightning_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/lightning_tests.rs
@@ -61,6 +61,7 @@ fn start_lightning_nodes(enable_0_confs: bool) -> (MarketMakerIt, MarketMakerIt,
             "estimate_fee_mode": "ECONOMICAL",
             "mm2": 1,
             "required_confirmations": 0,
+            "avg_blocktime": 600,
             "protocol": {
               "type": "UTXO"
             }
@@ -84,7 +85,6 @@ fn start_lightning_nodes(enable_0_confs: bool) -> (MarketMakerIt, MarketMakerIt,
               "protocol_data":{
                 "platform": "tBTC-TEST-segwit",
                 "network": "testnet",
-                "avg_block_time": 600,
                 "confirmation_targets": {
                   "background": 12,
                   "normal": 6,
@@ -170,6 +170,7 @@ fn test_enable_lightning() {
             "estimate_fee_mode": "ECONOMICAL",
             "mm2": 1,
             "required_confirmations": 0,
+            "avg_blocktime": 600,
             "protocol": {
               "type": "UTXO"
             }
@@ -183,7 +184,6 @@ fn test_enable_lightning() {
               "protocol_data":{
                 "platform": "tBTC-TEST-segwit",
                 "network": "testnet",
-                "avg_block_time": 600,
                 "confirmation_targets": {
                   "background": 12,
                   "normal": 6,
@@ -744,6 +744,7 @@ fn test_sign_verify_message_lightning() {
         "estimate_fee_mode": "ECONOMICAL",
         "mm2": 1,
         "required_confirmations": 0,
+        "avg_blocktime": 600,
         "protocol": {
           "type": "UTXO"
         }
@@ -758,7 +759,6 @@ fn test_sign_verify_message_lightning() {
           "protocol_data":{
             "platform": "tBTC-TEST-segwit",
             "network": "testnet",
-            "avg_block_time": 600,
             "confirmation_targets": {
               "background": 12,
               "normal": 6,


### PR DESCRIPTION
Since blocktimes in config will be in seconds after this PR https://github.com/KomodoPlatform/coins/pull/573 is merged, lightning can now use the platform coin blocktime for estimating the number of blocks swap payments are locked for.