### PR TITLE
[r2r] Fix server version negotiation race condition in Electrum client.

### DIFF
--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2499,6 +2499,8 @@ pub trait RpcTransportEventHandler {
     fn on_incoming_response(&self, data: &[u8]);
 
     fn on_connected(&self, address: String) -> Result<(), String>;
+
+    fn on_disconnected(&self, address: String) -> Result<(), String>;
 }
 
 impl fmt::Debug for dyn RpcTransportEventHandler + Send + Sync {
@@ -2513,6 +2515,8 @@ impl RpcTransportEventHandler for RpcTransportEventHandlerShared {
     fn on_incoming_response(&self, data: &[u8]) { self.as_ref().on_incoming_response(data) }
 
     fn on_connected(&self, address: String) -> Result<(), String> { self.as_ref().on_connected(address) }
+
+    fn on_disconnected(&self, address: String) -> Result<(), String> { self.as_ref().on_disconnected(address) }
 }
 
 impl<T: RpcTransportEventHandler> RpcTransportEventHandler for Vec<T> {
@@ -2536,6 +2540,13 @@ impl<T: RpcTransportEventHandler> RpcTransportEventHandler for Vec<T> {
     fn on_connected(&self, address: String) -> Result<(), String> {
         for handler in self {
             try_s!(handler.on_connected(address.clone()))
+        }
+        Ok(())
+    }
+
+    fn on_disconnected(&self, address: String) -> Result<(), String> {
+        for handler in self {
+            try_s!(handler.on_disconnected(address.clone()))
         }
         Ok(())
     }
@@ -2598,6 +2609,12 @@ impl RpcTransportEventHandler for CoinTransportMetrics {
 
     fn on_connected(&self, _address: String) -> Result<(), String> {
         // Handle a new connected endpoint if necessary.
+        // Now just return the Ok
+        Ok(())
+    }
+
+    fn on_disconnected(&self, _address: String) -> Result<(), String> {
+        // Handle disconnected endpoint if necessary.
         // Now just return the Ok
         Ok(())
     }

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -1304,10 +1304,15 @@ pub fn coin_daemon_data_dir(name: &str, is_asset_chain: bool) -> PathBuf {
     data_dir
 }
 
+enum ElectrumProtoVerifierEvent {
+    Connected(String),
+    Disconnected(String),
+}
+
 /// Electrum protocol version verifier.
 /// The structure is used to handle the `on_connected` event and notify `electrum_version_loop`.
 struct ElectrumProtoVerifier {
-    on_connect_tx: UnboundedSender<String>,
+    on_event_tx: UnboundedSender<ElectrumProtoVerifierEvent>,
 }
 
 impl ElectrumProtoVerifier {
@@ -1322,7 +1327,16 @@ impl RpcTransportEventHandler for ElectrumProtoVerifier {
     fn on_incoming_response(&self, _data: &[u8]) {}
 
     fn on_connected(&self, address: String) -> Result<(), String> {
-        try_s!(self.on_connect_tx.unbounded_send(address));
+        try_s!(self
+            .on_event_tx
+            .unbounded_send(ElectrumProtoVerifierEvent::Connected(address)));
+        Ok(())
+    }
+
+    fn on_disconnected(&self, address: String) -> Result<(), String> {
+        try_s!(self
+            .on_event_tx
+            .unbounded_send(ElectrumProtoVerifierEvent::Disconnected(address)));
         Ok(())
     }
 }

--- a/mm2src/coins/utxo/rpc_clients.rs
+++ b/mm2src/coins/utxo/rpc_clients.rs
@@ -1753,11 +1753,11 @@ impl ElectrumClientImpl {
     /// Check if the protocol version was checked for one of the spawned connections.
     pub async fn is_protocol_version_checked(&self) -> bool {
         for connection in self.connections.lock().await.iter() {
-            if connection.protocol_version.lock().await.is_some() {
-                return true;
+            if connection.protocol_version.lock().await.is_none() {
+                return false;
             }
         }
-        false
+        true
     }
 
     /// Set the protocol version for the specified server.
@@ -2578,12 +2578,16 @@ async fn connect_loop<Spawner: SpawnFuture>(
         let stream = try_loop!(connect_f.await, addr, delay);
         try_loop!(stream.as_ref().set_nodelay(true), addr, delay);
         info!("Electrum client connected to {}", addr);
-        try_loop!(event_handlers.on_connected(addr.clone()), addr, delay);
         let last_chunk = Arc::new(AtomicU64::new(now_ms()));
         let mut last_chunk_f = electrum_last_chunk_loop(last_chunk.clone()).boxed().fuse();
 
         let (tx, rx) = mpsc::channel(0);
         *connection_tx.lock().await = Some(tx);
+
+        if addr == "electrum1.cipig.net:10001" {
+            Timer::sleep(1.).await;
+        }
+        try_loop!(event_handlers.on_connected(addr.clone()), addr, delay);
         let rx = rx_to_stream(rx).inspect(|data| {
             // measure the length of each sent packet
             event_handlers.on_outgoing_request(data);

--- a/mm2src/coins/utxo/rpc_clients.rs
+++ b/mm2src/coins/utxo/rpc_clients.rs
@@ -13,6 +13,7 @@ use common::executor::{abortable_queue, abortable_queue::AbortableQueue, Abortab
 use common::jsonrpc_client::{JsonRpcBatchClient, JsonRpcBatchResponse, JsonRpcClient, JsonRpcError, JsonRpcErrorType,
                              JsonRpcId, JsonRpcMultiClient, JsonRpcRemoteAddr, JsonRpcRequest, JsonRpcRequestEnum,
                              JsonRpcResponse, JsonRpcResponseEnum, JsonRpcResponseFut, RpcRes};
+use common::log::LogOnError;
 use common::log::{error, info, warn};
 use common::{median, now_float, now_ms, OrdRange};
 use derive_more::Display;
@@ -1553,6 +1554,8 @@ impl ElectrumConnection {
     async fn is_connected(&self) -> bool { self.tx.lock().await.is_some() }
 
     async fn set_protocol_version(&self, version: f32) { self.protocol_version.lock().await.replace(version); }
+
+    async fn reset_protocol_version(&self) { *self.protocol_version.lock().await = None; }
 }
 
 #[derive(Debug)]
@@ -1629,6 +1632,7 @@ pub struct ElectrumClientImpl {
     ///
     /// Please also note that this abortable system is a subsystem of [`UtxoCoinFields::abortable_system`].
     abortable_system: AbortableQueue,
+    negotiate_version: bool,
 }
 
 async fn electrum_request_multi(
@@ -1638,6 +1642,10 @@ async fn electrum_request_multi(
     let mut futures = vec![];
     let connections = client.connections.lock().await;
     for (i, connection) in connections.iter().enumerate() {
+        if client.negotiate_version && connection.protocol_version.lock().await.is_none() {
+            continue;
+        }
+
         let connection_addr = connection.addr.clone();
         let json = json::to_string(&request).map_err(|e| JsonRpcErrorType::InvalidRequest(e.to_string()))?;
         if let Some(tx) = &*connection.tx.lock().await {
@@ -1753,11 +1761,11 @@ impl ElectrumClientImpl {
     /// Check if the protocol version was checked for one of the spawned connections.
     pub async fn is_protocol_version_checked(&self) -> bool {
         for connection in self.connections.lock().await.iter() {
-            if connection.protocol_version.lock().await.is_none() {
-                return false;
+            if connection.protocol_version.lock().await.is_some() {
+                return true;
             }
         }
-        true
+        false
     }
 
     /// Set the protocol version for the specified server.
@@ -1768,6 +1776,17 @@ impl ElectrumClientImpl {
             .find(|con| con.addr == server_addr)
             .ok_or(ERRL!("Unknown electrum address {}", server_addr))?;
         con.set_protocol_version(version).await;
+        Ok(())
+    }
+
+    /// Reset the protocol version for the specified server.
+    pub async fn reset_protocol_version(&self, server_addr: &str) -> Result<(), String> {
+        let connections = self.connections.lock().await;
+        let con = connections
+            .iter()
+            .find(|con| con.addr == server_addr)
+            .ok_or(ERRL!("Unknown electrum address {}", server_addr))?;
+        con.reset_protocol_version().await;
         Ok(())
     }
 
@@ -2315,6 +2334,7 @@ impl ElectrumClientImpl {
         event_handlers: Vec<RpcTransportEventHandlerShared>,
         block_headers_storage: BlockHeaderStorage,
         abortable_system: AbortableQueue,
+        negotiate_version: bool,
     ) -> ElectrumClientImpl {
         let protocol_version = OrdRange::new(1.2, 1.4).unwrap();
         ElectrumClientImpl {
@@ -2327,6 +2347,7 @@ impl ElectrumClientImpl {
             list_unspent_concurrent_map: ConcurrentRequestMap::new(),
             block_headers_storage,
             abortable_system,
+            negotiate_version,
         }
     }
 
@@ -2340,7 +2361,13 @@ impl ElectrumClientImpl {
     ) -> ElectrumClientImpl {
         ElectrumClientImpl {
             protocol_version,
-            ..ElectrumClientImpl::new(coin_ticker, event_handlers, block_headers_storage, abortable_system)
+            ..ElectrumClientImpl::new(
+                coin_ticker,
+                event_handlers,
+                block_headers_storage,
+                abortable_system,
+                false,
+            )
         }
     }
 }
@@ -2583,10 +2610,6 @@ async fn connect_loop<Spawner: SpawnFuture>(
 
         let (tx, rx) = mpsc::channel(0);
         *connection_tx.lock().await = Some(tx);
-
-        if addr == "electrum1.cipig.net:10001" {
-            Timer::sleep(1.).await;
-        }
         try_loop!(event_handlers.on_connected(addr.clone()), addr, delay);
         let rx = rx_to_stream(rx).inspect(|data| {
             // measure the length of each sent packet
@@ -2643,6 +2666,7 @@ async fn connect_loop<Spawner: SpawnFuture>(
         macro_rules! reset_tx_and_continue {
             () => {
                 info!("{} connection dropped", addr);
+                event_handlers.on_disconnected(addr.clone()).error_log();
                 *connection_tx.lock().await = None;
                 increase_delay(&delay);
                 continue;
@@ -2749,6 +2773,7 @@ async fn connect_loop<Spawner: SpawnFuture>(
             () => {
                 info!("{} connection dropped", addr);
                 *connection_tx.lock().await = None;
+                event_handlers.on_disconnected(addr.clone()).error_log();
                 increase_delay(&delay);
                 continue;
             };

--- a/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
@@ -488,8 +488,8 @@ pub trait UtxoCoinBuilderCommonOps {
             block_headers_storage.init().await?;
         }
 
-        let mut rng = small_rng();
-        servers.as_mut_slice().shuffle(&mut rng);
+        // let mut rng = small_rng();
+        // servers.as_mut_slice().shuffle(&mut rng);
 
         let client = ElectrumClientImpl::new(ticker, event_handlers, block_headers_storage, abortable_system);
         for server in servers.iter() {

--- a/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
@@ -5,9 +5,9 @@ use crate::utxo::rpc_clients::{ElectrumClient, ElectrumClientImpl, ElectrumRpcRe
 use crate::utxo::tx_cache::{UtxoVerboseCacheOps, UtxoVerboseCacheShared};
 use crate::utxo::utxo_block_header_storage::BlockHeaderStorage;
 use crate::utxo::utxo_builder::utxo_conf_builder::{UtxoConfBuilder, UtxoConfError};
-use crate::utxo::{output_script, utxo_common, ElectrumBuilderArgs, ElectrumProtoVerifier, RecentlySpentOutPoints,
-                  TxFee, UtxoCoinConf, UtxoCoinFields, UtxoHDAccount, UtxoHDWallet, UtxoRpcMode, UtxoSyncStatus,
-                  UtxoSyncStatusLoopHandle, DEFAULT_GAP_LIMIT, UTXO_DUST_AMOUNT};
+use crate::utxo::{output_script, utxo_common, ElectrumBuilderArgs, ElectrumProtoVerifier, ElectrumProtoVerifierEvent,
+                  RecentlySpentOutPoints, TxFee, UtxoCoinConf, UtxoCoinFields, UtxoHDAccount, UtxoHDWallet,
+                  UtxoRpcMode, UtxoSyncStatus, UtxoSyncStatusLoopHandle, DEFAULT_GAP_LIMIT, UTXO_DUST_AMOUNT};
 use crate::{BlockchainNetwork, CoinTransportMetrics, DerivationMethod, HistorySyncState, IguanaPrivKey,
             PrivKeyBuildPolicy, PrivKeyPolicy, PrivKeyPolicyNotAllowed, RpcClientType, UtxoActivationParams};
 use async_trait::async_trait;
@@ -15,7 +15,7 @@ use chain::TxHashAlgo;
 use common::custom_futures::repeatable::{Ready, Retry};
 use common::executor::{abortable_queue::AbortableQueue, AbortSettings, AbortableSystem, AbortedError, SpawnAbortable,
                        Timer};
-use common::log::{error, info};
+use common::log::{error, info, LogOnError};
 // use common::small_rng;
 use crypto::{Bip32DerPathError, CryptoCtx, CryptoCtxError, GlobalHDAccountArc, HwWalletType, Secp256k1Secret,
              StandardHDPathError, StandardHDPathToCoin};
@@ -467,7 +467,7 @@ pub trait UtxoCoinBuilderCommonOps {
         args: ElectrumBuilderArgs,
         servers: Vec<ElectrumRpcRequest>,
     ) -> UtxoCoinBuildResult<ElectrumClient> {
-        let (on_connect_tx, on_connect_rx) = unbounded();
+        let (on_event_tx, on_event_rx) = unbounded();
         let ticker = self.ticker().to_owned();
         let ctx = self.ctx();
         let mut event_handlers = vec![];
@@ -478,7 +478,7 @@ pub trait UtxoCoinBuilderCommonOps {
         }
 
         if args.negotiate_version {
-            event_handlers.push(ElectrumProtoVerifier { on_connect_tx }.into_shared());
+            event_handlers.push(ElectrumProtoVerifier { on_event_tx }.into_shared());
         }
 
         let storage_ticker = self.ticker().replace('-', "_");
@@ -491,7 +491,13 @@ pub trait UtxoCoinBuilderCommonOps {
         // let mut rng = small_rng();
         // servers.as_mut_slice().shuffle(&mut rng);
 
-        let client = ElectrumClientImpl::new(ticker, event_handlers, block_headers_storage, abortable_system);
+        let client = ElectrumClientImpl::new(
+            ticker,
+            event_handlers,
+            block_headers_storage,
+            abortable_system,
+            args.negotiate_version,
+        );
         for server in servers.iter() {
             match client.add_server(server).await {
                 Ok(_) => (),
@@ -518,7 +524,7 @@ pub trait UtxoCoinBuilderCommonOps {
         if args.negotiate_version {
             let weak_client = Arc::downgrade(&client);
             let client_name = format!("{} GUI/MM2 {}", ctx.gui().unwrap_or("UNKNOWN"), ctx.mm_version());
-            spawn_electrum_version_loop(&spawner, weak_client, on_connect_rx, client_name);
+            spawn_electrum_version_loop(&spawner, weak_client, on_event_rx, client_name);
 
             wait_for_protocol_version_checked(&client)
                 .await
@@ -736,8 +742,8 @@ fn spawn_electrum_ping_loop<Spawner: SpawnAbortable>(
         }
     };
 
-    let settigns = AbortSettings::info_on_any_stop(msg_on_stopped);
-    spawner.spawn_with_settings(fut, settigns);
+    let settings = AbortSettings::info_on_any_stop(msg_on_stopped);
+    spawner.spawn_with_settings(fut, settings);
 }
 
 /// Follow the `on_connect_rx` stream and verify the protocol version of each connected electrum server.
@@ -746,12 +752,21 @@ fn spawn_electrum_ping_loop<Spawner: SpawnAbortable>(
 fn spawn_electrum_version_loop<Spawner: SpawnAbortable>(
     spawner: &Spawner,
     weak_client: Weak<ElectrumClientImpl>,
-    mut on_connect_rx: UnboundedReceiver<String>,
+    mut on_event_rx: UnboundedReceiver<ElectrumProtoVerifierEvent>,
     client_name: String,
 ) {
     let fut = async move {
-        while let Some(electrum_addr) = on_connect_rx.next().await {
-            check_electrum_server_version(weak_client.clone(), client_name.clone(), electrum_addr).await;
+        while let Some(event) = on_event_rx.next().await {
+            match event {
+                ElectrumProtoVerifierEvent::Connected(electrum_addr) => {
+                    check_electrum_server_version(weak_client.clone(), client_name.clone(), electrum_addr).await
+                },
+                ElectrumProtoVerifierEvent::Disconnected(electrum_addr) => {
+                    if let Some(client) = weak_client.upgrade() {
+                        client.reset_protocol_version(&electrum_addr).await.error_log();
+                    }
+                },
+            }
         }
     };
     let settings = AbortSettings::info_on_any_stop("Electrum server.version loop stopped".to_string());

--- a/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
@@ -16,7 +16,7 @@ use common::custom_futures::repeatable::{Ready, Retry};
 use common::executor::{abortable_queue::AbortableQueue, AbortSettings, AbortableSystem, AbortedError, SpawnAbortable,
                        Timer};
 use common::log::{error, info};
-use common::small_rng;
+// use common::small_rng;
 use crypto::{Bip32DerPathError, CryptoCtx, CryptoCtxError, GlobalHDAccountArc, HwWalletType, Secp256k1Secret,
              StandardHDPathError, StandardHDPathToCoin};
 use derive_more::Display;
@@ -30,7 +30,7 @@ pub use keys::{Address, AddressFormat as UtxoAddressFormat, AddressHashEnum, Key
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
 use primitives::hash::H160;
-use rand::seq::SliceRandom;
+// use rand::seq::SliceRandom;
 use serde_json::{self as json, Value as Json};
 use spv_validation::storage::{BlockHeaderStorageError, BlockHeaderStorageOps};
 use std::sync::{Arc, Mutex, Weak};
@@ -465,7 +465,7 @@ pub trait UtxoCoinBuilderCommonOps {
         &self,
         abortable_system: AbortableQueue,
         args: ElectrumBuilderArgs,
-        mut servers: Vec<ElectrumRpcRequest>,
+        servers: Vec<ElectrumRpcRequest>,
     ) -> UtxoCoinBuildResult<ElectrumClient> {
         let (on_connect_tx, on_connect_rx) = unbounded();
         let ticker = self.ticker().to_owned();

--- a/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_coin_builder.rs
@@ -16,7 +16,7 @@ use common::custom_futures::repeatable::{Ready, Retry};
 use common::executor::{abortable_queue::AbortableQueue, AbortSettings, AbortableSystem, AbortedError, SpawnAbortable,
                        Timer};
 use common::log::{error, info, LogOnError};
-// use common::small_rng;
+use common::small_rng;
 use crypto::{Bip32DerPathError, CryptoCtx, CryptoCtxError, GlobalHDAccountArc, HwWalletType, Secp256k1Secret,
              StandardHDPathError, StandardHDPathToCoin};
 use derive_more::Display;
@@ -30,7 +30,7 @@ pub use keys::{Address, AddressFormat as UtxoAddressFormat, AddressHashEnum, Key
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
 use primitives::hash::H160;
-// use rand::seq::SliceRandom;
+use rand::seq::SliceRandom;
 use serde_json::{self as json, Value as Json};
 use spv_validation::storage::{BlockHeaderStorageError, BlockHeaderStorageOps};
 use std::sync::{Arc, Mutex, Weak};
@@ -465,7 +465,7 @@ pub trait UtxoCoinBuilderCommonOps {
         &self,
         abortable_system: AbortableQueue,
         args: ElectrumBuilderArgs,
-        servers: Vec<ElectrumRpcRequest>,
+        mut servers: Vec<ElectrumRpcRequest>,
     ) -> UtxoCoinBuildResult<ElectrumClient> {
         let (on_event_tx, on_event_rx) = unbounded();
         let ticker = self.ticker().to_owned();
@@ -488,8 +488,8 @@ pub trait UtxoCoinBuilderCommonOps {
             block_headers_storage.init().await?;
         }
 
-        // let mut rng = small_rng();
-        // servers.as_mut_slice().shuffle(&mut rng);
+        let mut rng = small_rng();
+        servers.as_mut_slice().shuffle(&mut rng);
 
         let client = ElectrumClientImpl::new(
             ticker,

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -4365,3 +4365,13 @@ fn test_block_header_utxo_loop() {
         panic!("Loop shouldn't stop")
     };
 }
+
+#[test]
+fn test_electrum_race_condition() {
+    let client = electrum_client_for_test(&["electrum1.cipig.net:10001", "electrum2.cipig.net:10001"]);
+    let result = client
+        .scripthash_get_balance("22ec5b5e5ca59d7329c85df18905d374a1d3fd916cf8c40e3e75502f4f153f2b")
+        .wait()
+        .unwrap();
+    println!("{:?}", result);
+}

--- a/mm2src/coins/utxo/utxo_wasm_tests.rs
+++ b/mm2src/coins/utxo/utxo_wasm_tests.rs
@@ -21,6 +21,7 @@ pub async fn electrum_client_for_test(servers: &[&str]) -> ElectrumClient {
         Default::default(),
         block_headers_storage,
         abortable_system,
+        false,
     );
     for server in servers {
         client

--- a/mm2src/coins/utxo/utxo_wasm_tests.rs
+++ b/mm2src/coins/utxo/utxo_wasm_tests.rs
@@ -1,9 +1,10 @@
-use super::rpc_clients::{ElectrumClient, ElectrumClientImpl, ElectrumProtocol};
+use super::rpc_clients::{ElectrumClient, UtxoRpcClientOps};
+use super::utxo_builder::{UtxoArcBuilder, UtxoCoinBuilderCommonOps};
+use super::utxo_standard::UtxoStandardCoin;
 use super::*;
-use crate::utxo::rpc_clients::UtxoRpcClientOps;
-use crate::utxo::utxo_block_header_storage::{BlockHeaderStorage, IndexedDBBlockHeadersStorage};
 use crate::utxo::utxo_common_tests;
-use common::executor::Timer;
+use crate::{IguanaPrivKey, PrivKeyBuildPolicy};
+use mm2_core::mm_ctx::MmCtxBuilder;
 use serialization::deserialize;
 use wasm_bindgen_test::*;
 
@@ -12,39 +13,34 @@ wasm_bindgen_test_configure!(run_in_browser);
 const TEST_COIN_NAME: &'static str = "RICK";
 
 pub async fn electrum_client_for_test(servers: &[&str]) -> ElectrumClient {
-    let block_headers_storage = BlockHeaderStorage {
-        inner: Box::new(IndexedDBBlockHeadersStorage {}),
-    };
-    let abortable_system = AbortableQueue::default();
-    let client = ElectrumClientImpl::new(
-        TEST_COIN_NAME.into(),
-        Default::default(),
-        block_headers_storage,
-        abortable_system,
-        false,
+    let ctx = MmCtxBuilder::default().into_mm_arc();
+    let servers: Vec<_> = servers
+        .iter()
+        .map(|server| json!({ "url": server, "protocol": "WSS" }))
+        .collect();
+    let req = json!({
+        "method": "electrum",
+        "servers": servers,
+    });
+    let params = UtxoActivationParams::from_legacy_req(&req).unwrap();
+    let priv_key_policy = PrivKeyBuildPolicy::IguanaPrivKey(IguanaPrivKey::default());
+    let builder = UtxoArcBuilder::new(
+        &ctx,
+        TEST_COIN_NAME,
+        &Json::Null,
+        &params,
+        priv_key_policy,
+        UtxoStandardCoin::from,
     );
-    for server in servers {
-        client
-            .add_server(&ElectrumRpcRequest {
-                url: server.to_string(),
-                protocol: ElectrumProtocol::WSS,
-                disable_cert_verification: false,
-            })
-            .await
-            .expect("!add_server");
-    }
+    let args = ElectrumBuilderArgs {
+        spawn_ping: false,
+        negotiate_version: true,
+        collect_metrics: false,
+    };
 
-    let mut attempts = 0;
-    while !client.is_connected().await {
-        if attempts >= 10 {
-            panic!("Failed to connect to at least 1 of {:?} in 5 seconds.", servers);
-        }
-
-        Timer::sleep(0.5).await;
-        attempts += 1;
-    }
-
-    ElectrumClient(Arc::new(client))
+    let servers = servers.into_iter().map(|s| json::from_value(s).unwrap()).collect();
+    let abortable_system = AbortableQueue::default();
+    builder.electrum_client(abortable_system, args, servers).await.unwrap()
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
#1613 
- Reset negotiated protocol version on disconnection.
- Do not use a connection for multi request if version negotiation is required, but it's not finished yet.
- Also fix `utxo_wasm_tests`.