### PR TITLE
[r2r] Hardware Wallet enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,7 @@ dependencies = [
  "common",
  "derive_more",
  "enum-primitive-derive",
+ "enum_from",
  "futures 0.3.15",
  "hex 0.4.2",
  "http 0.2.7",

--- a/deny.toml
+++ b/deny.toml
@@ -57,6 +57,8 @@ ignore = [
     "RUSTSEC-2022-0040",
     "RUSTSEC-2022-0055",
     "RUSTSEC-2023-0001",
+    "RUSTSEC-2022-0084",
+    "RUSTSEC-2023-0004",
     #"RUSTSEC-0000-0000",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
@@ -179,6 +181,7 @@ deny = [
 # The goal is to reduce this list as much as possible
 skip = [
     { name = "aes", version = "*" },
+    { name = "adler", version = "*" },
     { name = "ahash", version = "*" },
     { name = "arrayvec", version = "*" },
     { name = "autocfg", version = "*" },
@@ -274,6 +277,7 @@ skip = [
     { name = "subtle", version = "*" },
     { name = "syn", version = "*" },
     { name = "time", version = "*" },
+    { name = "time-macros", version = "*" },
     { name = "tiny-keccak", version = "*" },
     { name = "tokio-util", version = "*" },
     { name = "trie-root", version = "*" },
@@ -281,6 +285,7 @@ skip = [
     { name = "unicode-xid", version = "*" },
     { name = "unsigned-varint", version = "*" },
     { name = "url", version = "*" },
+    { name = "uuid", version = "*" },
     { name = "wasi", version = "*" },
     { name = "webpki", version = "*" },
     { name = "wyz", version = "*" },

--- a/mm2src/coins/coin_balance.rs
+++ b/mm2src/coins/coin_balance.rs
@@ -155,7 +155,7 @@ pub trait EnableCoinBalanceOps {
         params: EnabledCoinBalanceParams,
     ) -> MmResult<CoinBalanceReport, EnableCoinBalanceError>
     where
-        XPubExtractor: HDXPubExtractor + Sync;
+        XPubExtractor: HDXPubExtractor;
 }
 
 #[async_trait]
@@ -173,7 +173,7 @@ where
         params: EnabledCoinBalanceParams,
     ) -> MmResult<CoinBalanceReport, EnableCoinBalanceError>
     where
-        XPubExtractor: HDXPubExtractor + Sync,
+        XPubExtractor: HDXPubExtractor,
     {
         match self.derivation_method() {
             DerivationMethod::SingleAddress(my_address) => self
@@ -211,7 +211,7 @@ pub trait HDWalletBalanceOps: HDWalletCoinOps {
         params: EnabledCoinBalanceParams,
     ) -> MmResult<HDWalletBalance, EnableCoinBalanceError>
     where
-        XPubExtractor: HDXPubExtractor + Sync;
+        XPubExtractor: HDXPubExtractor;
 
     /// Scans for the new addresses of the specified `hd_account` using the given `address_scanner`.
     /// Returns balances of the new addresses.
@@ -387,7 +387,7 @@ pub mod common_impl {
     where
         Coin: HDWalletBalanceOps + MarketCoinOps + Sync,
         Coin::Address: fmt::Display,
-        XPubExtractor: HDXPubExtractor + Sync,
+        XPubExtractor: HDXPubExtractor,
     {
         let mut accounts = hd_wallet.get_accounts_mut().await;
         let address_scanner = coin.produce_hd_address_scanner().await?;

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -55,7 +55,7 @@ use sha3::{Digest, Keccak256};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ops::Deref;
-use std::path::PathBuf;
+#[cfg(not(target_arch = "wasm32"))] use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
@@ -484,7 +484,7 @@ impl EthCoinImpl {
         Box::new(self.web3.trace().filter(filter.build()).map_err(|e| ERRL!("{}", e)))
     }
 
-    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    #[cfg(not(target_arch = "wasm32"))]
     fn eth_traces_path(&self, ctx: &MmArc) -> PathBuf {
         ctx.dbdir()
             .join("TRANSACTIONS")
@@ -528,7 +528,7 @@ impl EthCoinImpl {
         unreachable!()
     }
 
-    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    #[cfg(not(target_arch = "wasm32"))]
     fn erc20_events_path(&self, ctx: &MmArc) -> PathBuf {
         ctx.dbdir()
             .join("TRANSACTIONS")

--- a/mm2src/coins/hd_confirm_address.rs
+++ b/mm2src/coins/hd_confirm_address.rs
@@ -1,0 +1,166 @@
+use async_trait::async_trait;
+use bip32::DerivationPath;
+use crypto::hw_rpc_task::{HwConnectStatuses, TrezorRpcTaskConnectProcessor};
+use crypto::trezor::trezor_rpc_task::{TrezorRequestStatuses, TrezorRpcTaskProcessor, TryIntoUserAction};
+use crypto::trezor::{ProcessTrezorResponse, TrezorError, TrezorProcessingError};
+use crypto::{CryptoCtx, CryptoCtxError, HardwareWalletArc, HwError, HwProcessingError};
+use mm2_core::mm_ctx::MmArc;
+use mm2_err_handle::prelude::*;
+use rpc_task::{RpcTask, RpcTaskError, RpcTaskHandle};
+
+const SHOW_ADDRESS_ON_DISPLAY: bool = true;
+
+pub enum HDConfirmAddressError {
+    HwContextNotInitialized,
+    CoinDoesntSupportTrezor,
+    RpcTaskError(RpcTaskError),
+    HardwareWalletError(HwError),
+    InvalidAddress { expected: String, found: String },
+    Internal(String),
+}
+
+impl From<CryptoCtxError> for HDConfirmAddressError {
+    fn from(e: CryptoCtxError) -> Self { HDConfirmAddressError::Internal(e.to_string()) }
+}
+
+impl From<TrezorError> for HDConfirmAddressError {
+    fn from(e: TrezorError) -> Self { HDConfirmAddressError::HardwareWalletError(HwError::from(e)) }
+}
+
+impl From<HwError> for HDConfirmAddressError {
+    fn from(e: HwError) -> Self { HDConfirmAddressError::HardwareWalletError(e) }
+}
+
+impl From<TrezorProcessingError<RpcTaskError>> for HDConfirmAddressError {
+    fn from(e: TrezorProcessingError<RpcTaskError>) -> Self {
+        match e {
+            TrezorProcessingError::TrezorError(trezor) => HDConfirmAddressError::from(HwError::from(trezor)),
+            TrezorProcessingError::ProcessorError(rpc) => HDConfirmAddressError::RpcTaskError(rpc),
+        }
+    }
+}
+
+impl From<HwProcessingError<RpcTaskError>> for HDConfirmAddressError {
+    fn from(e: HwProcessingError<RpcTaskError>) -> Self {
+        match e {
+            HwProcessingError::HwError(hw) => HDConfirmAddressError::from(hw),
+            HwProcessingError::ProcessorError(rpc) => HDConfirmAddressError::RpcTaskError(rpc),
+        }
+    }
+}
+
+/// An `InProgress` status constructor.
+pub trait ConfirmAddressStatus: Sized {
+    /// Returns an `InProgress` RPC status that will be used to ask the user
+    /// to confirm an `address` on his HW device.
+    fn confirm_addr_status(address: String) -> Self;
+}
+
+/// An address confirmation interface.
+#[async_trait]
+pub trait HDConfirmAddress: Sync {
+    /// Asks the user to confirm if the given `expected_address` is the same as on the HW display.
+    async fn confirm_utxo_address(
+        &self,
+        trezor_utxo_coin: String,
+        derivation_path: DerivationPath,
+        expected_address: String,
+    ) -> MmResult<(), HDConfirmAddressError>;
+}
+
+pub enum RpcTaskConfirmAddress<'task, Task: RpcTask> {
+    Trezor {
+        hw_ctx: HardwareWalletArc,
+        task_handle: &'task RpcTaskHandle<Task>,
+        statuses: HwConnectStatuses<Task::InProgressStatus, Task::AwaitingStatus>,
+    },
+}
+
+#[async_trait]
+impl<'task, Task> HDConfirmAddress for RpcTaskConfirmAddress<'task, Task>
+where
+    Task: RpcTask,
+    Task::InProgressStatus: ConfirmAddressStatus,
+    Task::UserAction: TryIntoUserAction + Send,
+{
+    async fn confirm_utxo_address(
+        &self,
+        trezor_utxo_coin: String,
+        derivation_path: DerivationPath,
+        expected_address: String,
+    ) -> MmResult<(), HDConfirmAddressError> {
+        match self {
+            RpcTaskConfirmAddress::Trezor {
+                hw_ctx,
+                task_handle,
+                statuses,
+            } => {
+                Self::confirm_utxo_address_with_trezor(
+                    hw_ctx,
+                    task_handle,
+                    statuses,
+                    trezor_utxo_coin,
+                    derivation_path,
+                    expected_address,
+                )
+                .await
+            },
+        }
+    }
+}
+
+impl<'task, Task> RpcTaskConfirmAddress<'task, Task>
+where
+    Task: RpcTask,
+    Task::InProgressStatus: ConfirmAddressStatus,
+    Task::UserAction: TryIntoUserAction + Send,
+{
+    pub fn new(
+        ctx: &MmArc,
+        task_handle: &'task RpcTaskHandle<Task>,
+        statuses: HwConnectStatuses<Task::InProgressStatus, Task::AwaitingStatus>,
+    ) -> MmResult<RpcTaskConfirmAddress<'task, Task>, HDConfirmAddressError> {
+        let crypto_ctx = CryptoCtx::from_ctx(ctx)?;
+        let hw_ctx = crypto_ctx
+            .hw_ctx()
+            .or_mm_err(|| HDConfirmAddressError::HwContextNotInitialized)?;
+        Ok(RpcTaskConfirmAddress::Trezor {
+            hw_ctx,
+            task_handle,
+            statuses,
+        })
+    }
+
+    async fn confirm_utxo_address_with_trezor(
+        hw_ctx: &HardwareWalletArc,
+        task_handle: &RpcTaskHandle<Task>,
+        connect_statuses: &HwConnectStatuses<Task::InProgressStatus, Task::AwaitingStatus>,
+        trezor_coin: String,
+        derivation_path: DerivationPath,
+        expected_address: String,
+    ) -> MmResult<(), HDConfirmAddressError> {
+        let connect_processor = TrezorRpcTaskConnectProcessor::new(task_handle, connect_statuses.clone());
+        let trezor = hw_ctx.trezor(&connect_processor).await?;
+        let mut trezor_session = trezor.session().await?;
+
+        let confirm_statuses = TrezorRequestStatuses {
+            on_button_request: Task::InProgressStatus::confirm_addr_status(expected_address.clone()),
+            ..connect_statuses.to_trezor_request_statuses()
+        };
+
+        let pubkey_processor = TrezorRpcTaskProcessor::new(task_handle, confirm_statuses);
+        let address = trezor_session
+            .get_utxo_address(derivation_path, trezor_coin, SHOW_ADDRESS_ON_DISPLAY)
+            .await?
+            .process(&pubkey_processor)
+            .await?;
+
+        if address != expected_address {
+            return MmError::err(HDConfirmAddressError::InvalidAddress {
+                expected: expected_address,
+                found: address,
+            });
+        }
+        Ok(())
+    }
+}

--- a/mm2src/coins/hd_confirm_address.rs
+++ b/mm2src/coins/hd_confirm_address.rs
@@ -4,30 +4,29 @@ use crypto::hw_rpc_task::HwConnectStatuses;
 use crypto::trezor::trezor_rpc_task::{TrezorRequestStatuses, TrezorRpcTaskProcessor, TryIntoUserAction};
 use crypto::trezor::{ProcessTrezorResponse, TrezorError, TrezorProcessingError};
 use crypto::{CryptoCtx, CryptoCtxError, HardwareWalletArc, HwError, HwProcessingError};
+use enum_from::{EnumFromInner, EnumFromStringify};
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
 use rpc_task::{RpcTask, RpcTaskError, RpcTaskHandle};
 
 const SHOW_ADDRESS_ON_DISPLAY: bool = true;
 
+#[derive(EnumFromInner, EnumFromStringify)]
 pub enum HDConfirmAddressError {
     HwContextNotInitialized,
     RpcTaskError(RpcTaskError),
+    #[from_inner]
     HardwareWalletError(HwError),
-    InvalidAddress { expected: String, found: String },
+    InvalidAddress {
+        expected: String,
+        found: String,
+    },
+    #[from_stringify("CryptoCtxError")]
     Internal(String),
-}
-
-impl From<CryptoCtxError> for HDConfirmAddressError {
-    fn from(e: CryptoCtxError) -> Self { HDConfirmAddressError::Internal(e.to_string()) }
 }
 
 impl From<TrezorError> for HDConfirmAddressError {
     fn from(e: TrezorError) -> Self { HDConfirmAddressError::HardwareWalletError(HwError::from(e)) }
-}
-
-impl From<HwError> for HDConfirmAddressError {
-    fn from(e: HwError) -> Self { HDConfirmAddressError::HardwareWalletError(e) }
 }
 
 impl From<TrezorProcessingError<RpcTaskError>> for HDConfirmAddressError {

--- a/mm2src/coins/hd_confirm_address.rs
+++ b/mm2src/coins/hd_confirm_address.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use bip32::DerivationPath;
-use crypto::hw_rpc_task::{HwConnectStatuses, TrezorRpcTaskConnectProcessor};
+use crypto::hw_rpc_task::HwConnectStatuses;
 use crypto::trezor::trezor_rpc_task::{TrezorRequestStatuses, TrezorRpcTaskProcessor, TryIntoUserAction};
 use crypto::trezor::{ProcessTrezorResponse, TrezorError, TrezorProcessingError};
 use crypto::{CryptoCtx, CryptoCtxError, HardwareWalletArc, HwError, HwProcessingError};
@@ -138,9 +138,7 @@ where
         derivation_path: DerivationPath,
         expected_address: String,
     ) -> MmResult<(), HDConfirmAddressError> {
-        let connect_processor = TrezorRpcTaskConnectProcessor::new(task_handle, connect_statuses.clone());
-        let trezor = hw_ctx.trezor(&connect_processor).await?;
-        let mut trezor_session = trezor.session().await?;
+        let mut trezor_session = hw_ctx.trezor().await?;
 
         let confirm_statuses = TrezorRequestStatuses {
             on_button_request: Task::InProgressStatus::confirm_addr_status(expected_address.clone()),

--- a/mm2src/coins/hd_confirm_address.rs
+++ b/mm2src/coins/hd_confirm_address.rs
@@ -12,7 +12,6 @@ const SHOW_ADDRESS_ON_DISPLAY: bool = true;
 
 pub enum HDConfirmAddressError {
     HwContextNotInitialized,
-    CoinDoesntSupportTrezor,
     RpcTaskError(RpcTaskError),
     HardwareWalletError(HwError),
     InvalidAddress { expected: String, found: String },
@@ -162,5 +161,27 @@ where
             });
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod for_tests {
+    use super::*;
+    use mocktopus::macros::mockable;
+
+    #[derive(Default)]
+    pub struct MockableConfirmAddress;
+
+    #[async_trait]
+    #[mockable]
+    impl HDConfirmAddress for MockableConfirmAddress {
+        async fn confirm_utxo_address(
+            &self,
+            _trezor_utxo_coin: String,
+            _derivation_path: DerivationPath,
+            _expected_address: String,
+        ) -> MmResult<(), HDConfirmAddressError> {
+            unimplemented!()
+        }
     }
 }

--- a/mm2src/coins/hd_pubkey.rs
+++ b/mm2src/coins/hd_pubkey.rs
@@ -81,11 +81,11 @@ pub trait ExtractExtendedPubkey {
         derivation_path: DerivationPath,
     ) -> MmResult<Self::ExtendedPublicKey, HDExtractPubkeyError>
     where
-        XPubExtractor: HDXPubExtractor + Sync;
+        XPubExtractor: HDXPubExtractor;
 }
 
 #[async_trait]
-pub trait HDXPubExtractor {
+pub trait HDXPubExtractor: Sync {
     async fn extract_utxo_xpub(
         &self,
         trezor_utxo_coin: String,

--- a/mm2src/coins/hd_pubkey.rs
+++ b/mm2src/coins/hd_pubkey.rs
@@ -1,6 +1,6 @@
 use crate::hd_wallet::NewAccountCreatingError;
 use async_trait::async_trait;
-use crypto::hw_rpc_task::{HwConnectStatuses, TrezorRpcTaskConnectProcessor};
+use crypto::hw_rpc_task::HwConnectStatuses;
 use crypto::trezor::trezor_rpc_task::{TrezorRpcTaskProcessor, TryIntoUserAction};
 use crypto::trezor::utxo::IGNORE_XPUB_MAGIC;
 use crypto::trezor::{ProcessTrezorResponse, TrezorError, TrezorProcessingError};
@@ -162,9 +162,7 @@ where
         trezor_coin: String,
         derivation_path: DerivationPath,
     ) -> MmResult<XPub, HDExtractPubkeyError> {
-        let connect_processor = TrezorRpcTaskConnectProcessor::new(task_handle, statuses.clone());
-        let trezor = hw_ctx.trezor(&connect_processor).await?;
-        let mut trezor_session = trezor.session().await?;
+        let mut trezor_session = hw_ctx.trezor().await?;
 
         let pubkey_processor = TrezorRpcTaskProcessor::new(task_handle, statuses.to_trezor_request_statuses());
         let xpub = trezor_session

--- a/mm2src/coins/hd_wallet.rs
+++ b/mm2src/coins/hd_wallet.rs
@@ -122,6 +122,12 @@ impl From<AccountUpdatingError> for NewAddressDeriveConfirmError {
     }
 }
 
+impl From<InvalidBip44ChainError> for NewAddressDeriveConfirmError {
+    fn from(e: InvalidBip44ChainError) -> Self {
+        NewAddressDeriveConfirmError::DeriveError(NewAddressDerivingError::from(e))
+    }
+}
+
 #[derive(Display)]
 pub enum NewAccountCreatingError {
     #[display(fmt = "Hardware Wallet context is not initialized")]

--- a/mm2src/coins/hd_wallet.rs
+++ b/mm2src/coins/hd_wallet.rs
@@ -1,3 +1,4 @@
+use crate::hd_confirm_address::{HDConfirmAddress, HDConfirmAddressError};
 use crate::hd_pubkey::HDXPubExtractor;
 use crate::hd_wallet_storage::HDWalletStorageError;
 use crate::{BalanceError, WithdrawError};
@@ -99,6 +100,25 @@ impl From<AccountUpdatingError> for NewAddressDerivingError {
             AccountUpdatingError::InvalidBip44Chain(e) => NewAddressDerivingError::from(e),
             AccountUpdatingError::WalletStorageError(storage) => NewAddressDerivingError::WalletStorageError(storage),
         }
+    }
+}
+
+pub enum NewAddressDeriveConfirmError {
+    DeriveError(NewAddressDerivingError),
+    ConfirmError(HDConfirmAddressError),
+}
+
+impl From<HDConfirmAddressError> for NewAddressDeriveConfirmError {
+    fn from(e: HDConfirmAddressError) -> Self { NewAddressDeriveConfirmError::ConfirmError(e) }
+}
+
+impl From<NewAddressDerivingError> for NewAddressDeriveConfirmError {
+    fn from(e: NewAddressDerivingError) -> Self { NewAddressDeriveConfirmError::DeriveError(e) }
+}
+
+impl From<AccountUpdatingError> for NewAddressDeriveConfirmError {
+    fn from(e: AccountUpdatingError) -> Self {
+        NewAddressDeriveConfirmError::DeriveError(NewAddressDerivingError::from(e))
     }
 }
 
@@ -259,18 +279,27 @@ pub trait HDWalletCoinOps {
         hd_account: &mut Self::HDAccount,
         chain: Bip44Chain,
     ) -> MmResult<HDAddress<Self::Address, Self::Pubkey>, NewAddressDerivingError> {
-        let known_addresses_number = hd_account.known_addresses_number(chain)?;
-        // Address IDs start from 0, so the `known_addresses_number = last_known_address_id + 1`.
-        let new_address_id = known_addresses_number;
-        let max_addresses_number = hd_wallet.address_limit();
-        if new_address_id >= max_addresses_number {
-            return MmError::err(NewAddressDerivingError::AddressLimitReached { max_addresses_number });
-        }
-        let new_address = self.derive_address(hd_account, chain, new_address_id).await?;
-        self.set_known_addresses_number(hd_wallet, hd_account, chain, known_addresses_number + 1)
+        let inner_impl::NewAddress {
+            address,
+            new_known_addresses_number,
+        } = inner_impl::generate_new_address_immutable(self, hd_wallet, hd_account, chain).await?;
+
+        self.set_known_addresses_number(hd_wallet, hd_account, chain, new_known_addresses_number)
             .await?;
-        Ok(new_address)
+        Ok(address)
     }
+
+    /// Generates a new address, requests the user to confirm if it's the same as on the HW device,
+    /// and then updates the corresponding number of used `hd_account` addresses.
+    async fn generate_and_confirm_new_address<ConfirmAddress>(
+        &self,
+        hd_wallet: &Self::HDWallet,
+        hd_account: &mut Self::HDAccount,
+        chain: Bip44Chain,
+        confirm_address: &ConfirmAddress,
+    ) -> MmResult<HDAddress<Self::Address, Self::Pubkey>, NewAddressDeriveConfirmError>
+    where
+        ConfirmAddress: HDConfirmAddress;
 
     /// Creates a new HD account, registers it within the given `hd_wallet`
     /// and returns a mutable reference to the registered account.
@@ -280,7 +309,7 @@ pub trait HDWalletCoinOps {
         xpub_extractor: &XPubExtractor,
     ) -> MmResult<HDAccountMut<'a, Self::HDAccount>, NewAccountCreatingError>
     where
-        XPubExtractor: HDXPubExtractor + Sync;
+        XPubExtractor: HDXPubExtractor;
 
     async fn set_known_addresses_number(
         &self,
@@ -363,5 +392,38 @@ pub trait HDAccountOps: Send + Sync {
     fn is_address_activated(&self, chain: Bip44Chain, address_id: u32) -> MmResult<bool, InvalidBip44ChainError> {
         let is_activated = address_id < self.known_addresses_number(chain)?;
         Ok(is_activated)
+    }
+}
+
+pub(crate) mod inner_impl {
+    use super::*;
+
+    pub struct NewAddress<Address, Pubkey> {
+        pub address: HDAddress<Address, Pubkey>,
+        pub new_known_addresses_number: u32,
+    }
+
+    /// Generates a new address without updating a corresponding number of used `hd_account` addresses.
+    pub async fn generate_new_address_immutable<Coin>(
+        coin: &Coin,
+        hd_wallet: &Coin::HDWallet,
+        hd_account: &Coin::HDAccount,
+        chain: Bip44Chain,
+    ) -> MmResult<NewAddress<Coin::Address, Coin::Pubkey>, NewAddressDerivingError>
+    where
+        Coin: HDWalletCoinOps + ?Sized + Sync,
+    {
+        let known_addresses_number = hd_account.known_addresses_number(chain)?;
+        // Address IDs start from 0, so the `known_addresses_number = last_known_address_id + 1`.
+        let new_address_id = known_addresses_number;
+        let max_addresses_number = hd_wallet.address_limit();
+        if new_address_id >= max_addresses_number {
+            return MmError::err(NewAddressDerivingError::AddressLimitReached { max_addresses_number });
+        }
+        let address = coin.derive_address(hd_account, chain, new_address_id).await?;
+        Ok(NewAddress {
+            address,
+            new_known_addresses_number: known_addresses_number + 1,
+        })
     }
 }

--- a/mm2src/coins/hd_wallet_storage/mod.rs
+++ b/mm2src/coins/hd_wallet_storage/mod.rs
@@ -360,7 +360,7 @@ mod tests {
             .expect("!HDWalletCoinStorage::upload_new_account: MORTY device=0 account=0");
 
         // All accounts must be in the only one database.
-        // Rows in the database must differ by only `coin`, `mm2_rmd160`, `hd_wallet_rmd160` and `account_id` values.
+        // Rows in the database must differ by only `coin`, `hd_wallet_rmd160` and `account_id` values.
         let all_accounts: Vec<_> = get_all_storage_items(&ctx)
             .await
             .into_iter()
@@ -457,7 +457,7 @@ mod tests {
             .expect("HDWalletCoinStorage::clear_accounts: RICK wallet=0");
 
         // All accounts must be in the only one database.
-        // Rows in the database must differ by only `coin`, `mm2_rmd160`, `hd_wallet_rmd160` and `account_id` values.
+        // Rows in the database must differ by only `coin`, `hd_wallet_rmd160` and `account_id` values.
         let all_accounts: Vec<_> = get_all_storage_items(&ctx)
             .await
             .into_iter()

--- a/mm2src/coins/hd_wallet_storage/wasm_storage.rs
+++ b/mm2src/coins/hd_wallet_storage/wasm_storage.rs
@@ -14,12 +14,10 @@ const DB_NAME: &str = "hd_wallet";
 const DB_VERSION: u32 = 1;
 /// An index of the `HDAccountTable` table that consists of the following properties:
 /// * coin - coin ticker
-/// * mm2_rmd160 - RIPEMD160(SHA256(x)) where x is a pubkey with which mm2 is launched
 /// * hd_wallet_rmd160 - RIPEMD160(SHA256(x)) where x is a pubkey extracted from a Hardware Wallet device or passphrase.
 const WALLET_ID_INDEX: &str = "wallet_id";
 /// A **unique** index of the `HDAccountTable` table that consists of the following properties:
 /// * coin - coin ticker
-/// * mm2_rmd160 - RIPEMD160(SHA256(x)) where x is a pubkey with which mm2 is launched
 /// * hd_wallet_rmd160 - RIPEMD160(SHA256(x)) where x is a pubkey extracted from a Hardware Wallet device or passphrase.
 /// * account_id - HD account id
 const WALLET_ACCOUNT_ID_INDEX: &str = "wallet_account_id";
@@ -75,8 +73,8 @@ impl From<InitDbError> for HDWalletStorageError {
     fn from(e: InitDbError) -> Self { HDWalletStorageError::Internal(e.to_string()) }
 }
 
-/// The table has the following individually non-unique indexes: `coin`, `mm2_rmd160`, `hd_wallet_rmd160`, `account_id`,
-/// one non-unique multi-index `wallet_id` that consists of `coin`, `mm2_rmd160`, `hd_wallet_rmd160`,
+/// The table has the following individually non-unique indexes: `coin`, `hd_wallet_rmd160`, `account_id`,
+/// one non-unique multi-index `wallet_id` that consists of `coin`, `hd_wallet_rmd160`,
 /// and one unique multi-index `wallet_account_id` that consists of these four indexes in a row.
 /// See [`HDAccountTable::on_update_needed`].
 #[derive(Deserialize, Serialize)]
@@ -84,9 +82,6 @@ pub struct HDAccountTable {
     /// [`HDWalletId::coin`].
     /// Non-unique index that is used to fetch/remove items from the storage.
     coin: String,
-    /// [`HDWalletId::mm2_rmd160`].
-    /// Non-unique index that is used to fetch/remove items from the storage.
-    mm2_rmd160: String,
     /// [`HDWalletId::hd_wallet_rmd160`].
     /// Non-unique index that is used to fetch/remove items from the storage.
     hd_wallet_rmd160: String,
@@ -106,10 +101,10 @@ impl TableSignature for HDAccountTable {
         match (old_version, new_version) {
             (0, 1) => {
                 let table = upgrader.create_table(Self::table_name())?;
-                table.create_multi_index(WALLET_ID_INDEX, &["coin", "mm2_rmd160", "hd_wallet_rmd160"], false)?;
+                table.create_multi_index(WALLET_ID_INDEX, &["coin", "hd_wallet_rmd160"], false)?;
                 table.create_multi_index(
                     WALLET_ACCOUNT_ID_INDEX,
-                    &["coin", "mm2_rmd160", "hd_wallet_rmd160", "account_id"],
+                    &["coin", "hd_wallet_rmd160", "account_id"],
                     true,
                 )?;
             },
@@ -123,7 +118,6 @@ impl HDAccountTable {
     fn new(wallet_id: HDWalletId, account_info: HDAccountStorageItem) -> HDAccountTable {
         HDAccountTable {
             coin: wallet_id.coin,
-            mm2_rmd160: wallet_id.mm2_rmd160,
             hd_wallet_rmd160: wallet_id.hd_wallet_rmd160,
             account_id: account_info.account_id,
             account_xpub: account_info.account_xpub,
@@ -187,7 +181,6 @@ impl HDWalletStorageInternalOps for HDWalletIndexedDbStorage {
 
         let index_keys = MultiIndex::new(WALLET_ID_INDEX)
             .with_value(wallet_id.coin)?
-            .with_value(wallet_id.mm2_rmd160)?
             .with_value(wallet_id.hd_wallet_rmd160)?;
         Ok(table
             .get_items_by_multi_index(index_keys)
@@ -267,7 +260,6 @@ impl HDWalletStorageInternalOps for HDWalletIndexedDbStorage {
 
         let index_keys = MultiIndex::new(WALLET_ID_INDEX)
             .with_value(wallet_id.coin)?
-            .with_value(wallet_id.mm2_rmd160)?
             .with_value(wallet_id.hd_wallet_rmd160)?;
         table.delete_items_by_multi_index(index_keys).await?;
         Ok(())
@@ -292,7 +284,6 @@ impl HDWalletIndexedDbStorage {
     ) -> HDWalletStorageResult<Option<(ItemId, HDAccountTable)>> {
         let index_keys = MultiIndex::new(WALLET_ACCOUNT_ID_INDEX)
             .with_value(wallet_id.coin)?
-            .with_value(wallet_id.mm2_rmd160)?
             .with_value(wallet_id.hd_wallet_rmd160)?
             .with_value(account_id)?;
         table

--- a/mm2src/coins/lightning/ln_sql.rs
+++ b/mm2src/coins/lightning/ln_sql.rs
@@ -4,7 +4,6 @@ use crate::lightning::ln_db::{ChannelType, ChannelVisibility, ClosedChannelsFilt
 use async_trait::async_trait;
 use common::{async_blocking, PagingOptionsEnum};
 use db_common::owned_named_params;
-use db_common::sqlite::rusqlite::types::Value;
 use db_common::sqlite::rusqlite::{params, Error as SqlError, Row, ToSql, NO_PARAMS};
 use db_common::sqlite::sql_builder::SqlBuilder;
 use db_common::sqlite::{h256_option_slice_from_row, h256_slice_from_row, offset_by_id, query_single_row,

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2234,9 +2234,9 @@ impl CoinsContext {
                 create_account_manager: CreateAccountTaskManager::new_shared(),
                 scan_addresses_manager: ScanAddressesTaskManager::new_shared(),
                 #[cfg(target_arch = "wasm32")]
-                tx_history_db: ConstructibleDb::new_shared(ctx),
+                tx_history_db: ConstructibleDb::new(ctx).into_shared(),
                 #[cfg(target_arch = "wasm32")]
-                hd_wallet_db: ConstructibleDb::new_shared(ctx),
+                hd_wallet_db: ConstructibleDb::new_shared_db(ctx).into_shared(),
             })
         })))
     }

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -216,7 +216,8 @@ pub mod qrc20;
 use qrc20::{qrc20_coin_with_policy, Qrc20ActivationParams, Qrc20Coin, Qrc20FeeDetails};
 
 pub mod rpc_command;
-use rpc_command::{init_account_balance::{AccountBalanceTaskManager, AccountBalanceTaskManagerShared},
+use rpc_command::{get_new_address::{GetNewAddressTaskManager, GetNewAddressTaskManagerShared},
+                  init_account_balance::{AccountBalanceTaskManager, AccountBalanceTaskManagerShared},
                   init_create_account::{CreateAccountTaskManager, CreateAccountTaskManagerShared},
                   init_scan_for_new_addresses::{ScanAddressesTaskManager, ScanAddressesTaskManagerShared},
                   init_withdraw::{WithdrawTaskManager, WithdrawTaskManagerShared}};
@@ -2229,6 +2230,7 @@ pub struct CoinsContext {
     balance_update_handlers: AsyncMutex<Vec<Box<dyn BalanceTradeFeeUpdatedHandler + Send + Sync>>>,
     account_balance_task_manager: AccountBalanceTaskManagerShared,
     create_account_manager: CreateAccountTaskManagerShared,
+    get_new_address_manager: GetNewAddressTaskManagerShared,
     platform_coin_tokens: PaMutex<HashMap<String, HashSet<String>>>,
     scan_addresses_manager: ScanAddressesTaskManagerShared,
     withdraw_task_manager: WithdrawTaskManagerShared,
@@ -2252,9 +2254,10 @@ impl CoinsContext {
                 coins: AsyncMutex::new(HashMap::new()),
                 balance_update_handlers: AsyncMutex::new(vec![]),
                 account_balance_task_manager: AccountBalanceTaskManager::new_shared(),
-                withdraw_task_manager: WithdrawTaskManager::new_shared(),
                 create_account_manager: CreateAccountTaskManager::new_shared(),
+                get_new_address_manager: GetNewAddressTaskManager::new_shared(),
                 scan_addresses_manager: ScanAddressesTaskManager::new_shared(),
+                withdraw_task_manager: WithdrawTaskManager::new_shared(),
                 #[cfg(target_arch = "wasm32")]
                 tx_history_db: ConstructibleDb::new(ctx).into_shared(),
                 #[cfg(target_arch = "wasm32")]

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -66,7 +66,6 @@ use std::fmt;
 use std::future::Future as Future03;
 use std::num::NonZeroUsize;
 use std::ops::{Add, Deref};
-use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -80,6 +79,7 @@ cfg_native! {
     use futures::AsyncWriteExt;
     use lightning_invoice::{Invoice, ParseOrSemanticError};
     use std::io;
+    use std::path::PathBuf;
     use zcash_primitives::transaction::Transaction as ZTransaction;
     use z_coin::ZcoinProtocolInfo;
 }
@@ -1962,6 +1962,7 @@ pub trait MmCoin:
     fn process_history_loop(&self, ctx: MmArc) -> Box<dyn Future<Item = (), Error = ()> + Send>;
 
     /// Path to tx history file
+    #[cfg(not(target_arch = "wasm32"))]
     fn tx_history_path(&self, ctx: &MmArc) -> PathBuf {
         let my_address = self.my_address().unwrap_or_default();
         // BCH cash address format has colon after prefix, e.g. bitcoincash:
@@ -1973,6 +1974,7 @@ pub trait MmCoin:
     }
 
     /// Path to tx history migration file
+    #[cfg(not(target_arch = "wasm32"))]
     fn tx_migration_path(&self, ctx: &MmArc) -> PathBuf {
         let my_address = self.my_address().unwrap_or_default();
         // BCH cash address format has colon after prefix, e.g. bitcoincash:

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -201,6 +201,7 @@ pub mod coins_tests;
 pub mod eth;
 use eth::{eth_coin_from_conf_and_request, EthCoin, EthTxFeeDetails, SignedEthTx};
 
+pub mod hd_confirm_address;
 pub mod hd_pubkey;
 
 pub mod hd_wallet;

--- a/mm2src/coins/rpc_command/get_new_address.rs
+++ b/mm2src/coins/rpc_command/get_new_address.rs
@@ -271,7 +271,8 @@ impl RpcTaskTypes for InitGetNewAddressTask {
 impl RpcTask for InitGetNewAddressTask {
     fn initial_status(&self) -> Self::InProgressStatus { GetNewAddressInProgressStatus::Preparing }
 
-    async fn cancel(self) { todo!() }
+    // Do nothing if the task has been cancelled.
+    async fn cancel(self) {}
 
     async fn run(&mut self, task_handle: &RpcTaskHandle<Self>) -> Result<Self::Item, MmError<Self::Error>> {
         async fn get_new_address_helper<Coin>(

--- a/mm2src/coins/rpc_command/get_new_address.rs
+++ b/mm2src/coins/rpc_command/get_new_address.rs
@@ -1,38 +1,68 @@
 use crate::coin_balance::HDAddressBalance;
-use crate::hd_wallet::{AddressDerivingError, InvalidBip44ChainError, NewAddressDerivingError};
-use crate::{lp_coinfind_or_err, BalanceError, CoinFindError, MmCoinEnum, UnexpectedDerivationMethod};
+use crate::hd_confirm_address::{ConfirmAddressStatus, HDConfirmAddress, HDConfirmAddressError, RpcTaskConfirmAddress};
+use crate::hd_wallet::{AddressDerivingError, InvalidBip44ChainError, NewAddressDeriveConfirmError,
+                       NewAddressDerivingError};
+use crate::{lp_coinfind_or_err, BalanceError, CoinFindError, CoinsContext, MmCoinEnum, UnexpectedDerivationMethod};
 use async_trait::async_trait;
-use common::HttpStatusCode;
-use crypto::Bip44Chain;
+use common::{HttpStatusCode, SuccessResponse};
+use crypto::hw_rpc_task::{HwConnectStatuses, HwRpcTaskAwaitingStatus, HwRpcTaskUserAction, HwRpcTaskUserActionRequest};
+use crypto::{from_hw_error, Bip44Chain, HwError, HwRpcError, WithHwRpcError};
 use derive_more::Display;
+use enum_from::EnumFromTrait;
 use http::StatusCode;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
+use rpc_task::rpc_common::{CancelRpcTaskError, CancelRpcTaskRequest, InitRpcTaskResponse, RpcTaskStatusError,
+                           RpcTaskStatusRequest, RpcTaskUserActionError};
+use rpc_task::{RpcTask, RpcTaskError, RpcTaskHandle, RpcTaskManager, RpcTaskManagerShared, RpcTaskStatus, RpcTaskTypes};
+use std::time::Duration;
 
-#[derive(Clone, Debug, Display, PartialEq, Serialize, SerializeErrorType)]
+pub type GetNewAddressUserAction = HwRpcTaskUserAction;
+pub type GetNewAddressAwaitingStatus = HwRpcTaskAwaitingStatus;
+pub type GetNewAddressTaskManager = RpcTaskManager<InitGetNewAddressTask>;
+pub type GetNewAddressTaskManagerShared = RpcTaskManagerShared<InitGetNewAddressTask>;
+pub type GetNewAddressTaskHandle = RpcTaskHandle<InitGetNewAddressTask>;
+pub type GetNewAddressRpcTaskStatus = RpcTaskStatus<
+    GetNewAddressResponse,
+    GetNewAddressRpcError,
+    GetNewAddressInProgressStatus,
+    GetNewAddressAwaitingStatus,
+>;
+
+#[derive(Clone, Debug, Display, EnumFromTrait, PartialEq, Serialize, SerializeErrorType)]
 #[serde(tag = "error_type", content = "error_data")]
 pub enum GetNewAddressRpcError {
-    #[display(fmt = "No such coin {}", coin)]
+    #[display(fmt = "Hardware Wallet context is not initialized")]
+    HwContextNotInitialized,
+    #[display(fmt = "No such coin {coin}")]
     NoSuchCoin { coin: String },
+    #[display(fmt = "RPC 'task' is awaiting '{expected}' user action")]
+    UnexpectedUserAction { expected: String },
     #[display(fmt = "Coin is expected to be activated with the HD wallet derivation method")]
     CoinIsActivatedNotWithHDWallet,
-    #[display(fmt = "HD account '{}' is not activated", account_id)]
+    #[display(fmt = "HD account '{account_id}' is not activated")]
     UnknownAccount { account_id: u32 },
-    #[display(fmt = "Coin doesn't support the given BIP44 chain: {:?}", chain)]
+    #[display(fmt = "Coin doesn't support the given BIP44 chain: {chain:?}")]
     InvalidBip44Chain { chain: Bip44Chain },
-    #[display(fmt = "Error deriving an address: {}", _0)]
+    #[display(fmt = "Error deriving an address: {_0}")]
     ErrorDerivingAddress(String),
-    #[display(fmt = "Addresses limit reached. Max number of addresses: {}", max_addresses_number)]
+    #[display(fmt = "Addresses limit reached. Max number of addresses: {max_addresses_number}")]
     AddressLimitReached { max_addresses_number: u32 },
-    #[display(fmt = "Empty addresses limit reached. Gap limit: {}", gap_limit)]
+    #[display(fmt = "Empty addresses limit reached. Gap limit: {gap_limit}")]
     EmptyAddressesLimitReached { gap_limit: u32 },
-    #[display(fmt = "Electrum/Native RPC invalid response: {}", _0)]
+    #[display(fmt = "Electrum/Native RPC invalid response: {_0}")]
     RpcInvalidResponse(String),
-    #[display(fmt = "HD wallet storage error: {}", _0)]
+    #[display(fmt = "HD wallet storage error: {_0}")]
     WalletStorageError(String),
-    #[display(fmt = "Transport: {}", _0)]
+    #[from_trait(WithTimeout::timeout)]
+    #[display(fmt = "RPC timed out {_0:?}")]
+    Timeout(Duration),
+    #[from_trait(WithHwRpcError::hw_rpc_error)]
+    HwError(HwRpcError),
+    #[display(fmt = "Transport: {_0}")]
     Transport(String),
-    #[display(fmt = "Internal: {}", _0)]
+    #[from_trait(WithInternal::internal)]
+    #[display(fmt = "Internal: {_0}")]
     Internal(String),
 }
 
@@ -96,10 +126,54 @@ impl From<AddressDerivingError> for GetNewAddressRpcError {
     }
 }
 
+impl From<NewAddressDeriveConfirmError> for GetNewAddressRpcError {
+    fn from(e: NewAddressDeriveConfirmError) -> Self {
+        match e {
+            NewAddressDeriveConfirmError::DeriveError(derive) => GetNewAddressRpcError::from(derive),
+            NewAddressDeriveConfirmError::ConfirmError(confirm) => GetNewAddressRpcError::from(confirm),
+        }
+    }
+}
+
+impl From<HDConfirmAddressError> for GetNewAddressRpcError {
+    fn from(e: HDConfirmAddressError) -> Self {
+        match e {
+            HDConfirmAddressError::HwContextNotInitialized => GetNewAddressRpcError::HwContextNotInitialized,
+            HDConfirmAddressError::RpcTaskError(rpc) => GetNewAddressRpcError::from(rpc),
+            HDConfirmAddressError::HardwareWalletError(hw) => GetNewAddressRpcError::from(hw),
+            HDConfirmAddressError::InvalidAddress { expected, found } => GetNewAddressRpcError::Internal(format!(
+                "Confirmation address mismatched: expected '{expected}, found '{found}''"
+            )),
+            HDConfirmAddressError::Internal(internal) => GetNewAddressRpcError::Internal(internal),
+        }
+    }
+}
+
+impl From<HwError> for GetNewAddressRpcError {
+    fn from(e: HwError) -> Self { from_hw_error(e) }
+}
+
+impl From<RpcTaskError> for GetNewAddressRpcError {
+    fn from(e: RpcTaskError) -> Self {
+        let error = e.to_string();
+        match e {
+            RpcTaskError::Cancelled => GetNewAddressRpcError::Internal("Cancelled".to_owned()),
+            RpcTaskError::Timeout(timeout) => GetNewAddressRpcError::Timeout(timeout),
+            RpcTaskError::NoSuchTask(_) | RpcTaskError::UnexpectedTaskStatus { .. } => {
+                GetNewAddressRpcError::Internal(error)
+            },
+            RpcTaskError::UnexpectedUserAction { expected } => GetNewAddressRpcError::UnexpectedUserAction { expected },
+            RpcTaskError::Internal(internal) => GetNewAddressRpcError::Internal(internal),
+        }
+    }
+}
+
 impl HttpStatusCode for GetNewAddressRpcError {
     fn status_code(&self) -> StatusCode {
         match self {
-            GetNewAddressRpcError::NoSuchCoin { .. }
+            GetNewAddressRpcError::HwContextNotInitialized
+            | GetNewAddressRpcError::NoSuchCoin { .. }
+            | GetNewAddressRpcError::UnexpectedUserAction { .. }
             | GetNewAddressRpcError::CoinIsActivatedNotWithHDWallet
             | GetNewAddressRpcError::UnknownAccount { .. }
             | GetNewAddressRpcError::InvalidBip44Chain { .. }
@@ -109,7 +183,9 @@ impl HttpStatusCode for GetNewAddressRpcError {
             GetNewAddressRpcError::Transport(_)
             | GetNewAddressRpcError::RpcInvalidResponse(_)
             | GetNewAddressRpcError::WalletStorageError(_)
+            | GetNewAddressRpcError::HwError(_)
             | GetNewAddressRpcError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            GetNewAddressRpcError::Timeout(_) => StatusCode::REQUEST_TIMEOUT,
         }
     }
 }
@@ -121,7 +197,7 @@ pub struct GetNewAddressRequest {
     params: GetNewAddressParams,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct GetNewAddressParams {
     pub(crate) account_id: u32,
     pub(crate) chain: Option<Bip44Chain>,
@@ -131,33 +207,197 @@ pub struct GetNewAddressParams {
     pub(crate) gap_limit: Option<u32>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct GetNewAddressResponse {
     new_address: HDAddressBalance,
 }
 
+#[derive(Clone, Serialize)]
+pub enum GetNewAddressInProgressStatus {
+    Preparing,
+    RequestingAccountBalance,
+    Finishing,
+    /// The following statuses don't require the user to send `UserAction`,
+    /// but they tell the user that he should confirm/decline the operation on his device.
+    WaitingForTrezorToConnect,
+    FollowHwDeviceInstructions,
+    ConfirmAddress {
+        expected_address: String,
+    },
+}
+
+impl ConfirmAddressStatus for GetNewAddressInProgressStatus {
+    fn confirm_addr_status(expected_address: String) -> Self {
+        GetNewAddressInProgressStatus::ConfirmAddress { expected_address }
+    }
+}
+
 #[async_trait]
 pub trait GetNewAddressRpcOps {
-    async fn get_new_address_rpc(
+    /// Generates a new address.
+    /// TODO remove once GUI integrates `task::get_new_address::init`.
+    async fn get_new_address_rpc_without_conf(
         &self,
         params: GetNewAddressParams,
     ) -> MmResult<GetNewAddressResponse, GetNewAddressRpcError>;
+
+    /// Generates and asks the user to confirm a new address.
+    async fn get_new_address_rpc<ConfirmAddress>(
+        &self,
+        params: GetNewAddressParams,
+        confirm_address: &ConfirmAddress,
+    ) -> MmResult<GetNewAddressResponse, GetNewAddressRpcError>
+    where
+        ConfirmAddress: HDConfirmAddress;
+}
+
+pub struct InitGetNewAddressTask {
+    ctx: MmArc,
+    coin: MmCoinEnum,
+    req: GetNewAddressRequest,
+    // The state of the account creation. It's used to revert changes if the task has been cancelled.
+    // task_state: CreateAccountState,
+}
+
+impl RpcTaskTypes for InitGetNewAddressTask {
+    type Item = GetNewAddressResponse;
+    type Error = GetNewAddressRpcError;
+    type InProgressStatus = GetNewAddressInProgressStatus;
+    type AwaitingStatus = GetNewAddressAwaitingStatus;
+    type UserAction = GetNewAddressUserAction;
+}
+
+#[async_trait]
+impl RpcTask for InitGetNewAddressTask {
+    fn initial_status(&self) -> Self::InProgressStatus { GetNewAddressInProgressStatus::Preparing }
+
+    async fn cancel(self) { todo!() }
+
+    async fn run(&mut self, task_handle: &RpcTaskHandle<Self>) -> Result<Self::Item, MmError<Self::Error>> {
+        async fn get_new_address_helper<Coin>(
+            ctx: &MmArc,
+            coin: &Coin,
+            params: GetNewAddressParams,
+            // state: CreateAccountState,
+            task_handle: &GetNewAddressTaskHandle,
+        ) -> MmResult<GetNewAddressResponse, GetNewAddressRpcError>
+        where
+            Coin: GetNewAddressRpcOps + Send + Sync,
+        {
+            let hw_statuses = HwConnectStatuses {
+                on_connect: GetNewAddressInProgressStatus::WaitingForTrezorToConnect,
+                on_connected: GetNewAddressInProgressStatus::Preparing,
+                on_connection_failed: GetNewAddressInProgressStatus::Finishing,
+                on_button_request: GetNewAddressInProgressStatus::FollowHwDeviceInstructions,
+                on_pin_request: GetNewAddressAwaitingStatus::EnterTrezorPin,
+                on_passphrase_request: GetNewAddressAwaitingStatus::EnterTrezorPassphrase,
+                on_ready: GetNewAddressInProgressStatus::RequestingAccountBalance,
+            };
+            let confirm_address: RpcTaskConfirmAddress<'_, InitGetNewAddressTask> =
+                RpcTaskConfirmAddress::new(ctx, task_handle, hw_statuses)?;
+            coin.get_new_address_rpc(params, &confirm_address).await
+        }
+
+        match self.coin {
+            MmCoinEnum::UtxoCoin(ref utxo) => {
+                get_new_address_helper(
+                    &self.ctx,
+                    utxo,
+                    self.req.params.clone(),
+                    // self.task_state.clone(),
+                    task_handle,
+                )
+                .await
+            },
+            MmCoinEnum::QtumCoin(ref qtum) => {
+                get_new_address_helper(
+                    &self.ctx,
+                    qtum,
+                    self.req.params.clone(),
+                    // self.task_state.clone(),
+                    task_handle,
+                )
+                .await
+            },
+            _ => MmError::err(GetNewAddressRpcError::CoinIsActivatedNotWithHDWallet),
+        }
+    }
 }
 
 /// Generates a new address.
+/// TODO remove once GUI integrates `task::get_new_address::init`.
 pub async fn get_new_address(
     ctx: MmArc,
     req: GetNewAddressRequest,
 ) -> MmResult<GetNewAddressResponse, GetNewAddressRpcError> {
     let coin = lp_coinfind_or_err(&ctx, &req.coin).await?;
     match coin {
-        MmCoinEnum::UtxoCoin(utxo) => utxo.get_new_address_rpc(req.params).await,
-        MmCoinEnum::QtumCoin(qtum) => qtum.get_new_address_rpc(req.params).await,
+        MmCoinEnum::UtxoCoin(utxo) => utxo.get_new_address_rpc_without_conf(req.params).await,
+        MmCoinEnum::QtumCoin(qtum) => qtum.get_new_address_rpc_without_conf(req.params).await,
         _ => MmError::err(GetNewAddressRpcError::CoinIsActivatedNotWithHDWallet),
     }
 }
 
-pub mod common_impl {
+/// Generates a new address.
+/// TODO remove once GUI integrates `task::get_new_address::init`.
+pub async fn init_get_new_address(
+    ctx: MmArc,
+    req: GetNewAddressRequest,
+) -> MmResult<InitRpcTaskResponse, GetNewAddressRpcError> {
+    let coin = lp_coinfind_or_err(&ctx, &req.coin).await?;
+    let coins_ctx = CoinsContext::from_ctx(&ctx).map_to_mm(GetNewAddressRpcError::Internal)?;
+    let spawner = coin.spawner();
+    let task = InitGetNewAddressTask {
+        ctx,
+        coin,
+        req,
+        // task_state: CreateAccountState::default(),
+    };
+    let task_id = GetNewAddressTaskManager::spawn_rpc_task(&coins_ctx.get_new_address_manager, &spawner, task)?;
+    Ok(InitRpcTaskResponse { task_id })
+}
+
+pub async fn init_get_new_address_status(
+    ctx: MmArc,
+    req: RpcTaskStatusRequest,
+) -> MmResult<GetNewAddressRpcTaskStatus, RpcTaskStatusError> {
+    let coins_ctx = CoinsContext::from_ctx(&ctx).map_to_mm(RpcTaskStatusError::Internal)?;
+    let mut task_manager = coins_ctx
+        .get_new_address_manager
+        .lock()
+        .map_to_mm(|e| RpcTaskStatusError::Internal(e.to_string()))?;
+    task_manager
+        .task_status(req.task_id, req.forget_if_finished)
+        .or_mm_err(|| RpcTaskStatusError::NoSuchTask(req.task_id))
+}
+
+pub async fn init_get_new_address_user_action(
+    ctx: MmArc,
+    req: HwRpcTaskUserActionRequest,
+) -> MmResult<SuccessResponse, RpcTaskUserActionError> {
+    let coins_ctx = CoinsContext::from_ctx(&ctx).map_to_mm(RpcTaskUserActionError::Internal)?;
+    let mut task_manager = coins_ctx
+        .get_new_address_manager
+        .lock()
+        .map_to_mm(|e| RpcTaskUserActionError::Internal(e.to_string()))?;
+    task_manager.on_user_action(req.task_id, req.user_action)?;
+    Ok(SuccessResponse::new())
+}
+
+pub async fn cancel_get_new_address(
+    ctx: MmArc,
+    req: CancelRpcTaskRequest,
+) -> MmResult<SuccessResponse, CancelRpcTaskError> {
+    let coins_ctx = CoinsContext::from_ctx(&ctx).map_to_mm(CancelRpcTaskError::Internal)?;
+    let mut task_manager = coins_ctx
+        .get_new_address_manager
+        .lock()
+        .map_to_mm(|e| CancelRpcTaskError::Internal(e.to_string()))?;
+    task_manager.cancel_task(req.task_id)?;
+    Ok(SuccessResponse::new())
+}
+
+pub(crate) mod common_impl {
     use super::*;
     use crate::coin_balance::{HDAddressBalanceScanner, HDWalletBalanceOps};
     use crate::hd_wallet::{HDAccountOps, HDWalletCoinOps, HDWalletOps};
@@ -166,7 +406,8 @@ pub mod common_impl {
     use std::fmt;
     use std::ops::DerefMut;
 
-    pub async fn get_new_address_rpc<Coin>(
+    /// TODO remove once GUI integrates `task::get_new_address::init`.
+    pub async fn get_new_address_rpc_without_conf<Coin>(
         coin: &Coin,
         params: GetNewAddressParams,
     ) -> MmResult<GetNewAddressResponse, GetNewAddressRpcError>
@@ -198,6 +439,50 @@ pub mod common_impl {
             .await?;
         let balance = coin.known_address_balance(&address).await?;
 
+        Ok(GetNewAddressResponse {
+            new_address: HDAddressBalance {
+                address: address.to_string(),
+                derivation_path: RpcDerivationPath(derivation_path),
+                chain,
+                balance,
+            },
+        })
+    }
+
+    pub async fn get_new_address_rpc<'a, Coin, ConfirmAddress>(
+        coin: &Coin,
+        params: GetNewAddressParams,
+        confirm_address: &ConfirmAddress,
+    ) -> MmResult<GetNewAddressResponse, GetNewAddressRpcError>
+    where
+        ConfirmAddress: HDConfirmAddress,
+        Coin:
+            HDWalletBalanceOps + CoinWithDerivationMethod<HDWallet = <Coin as HDWalletCoinOps>::HDWallet> + Send + Sync,
+        <Coin as HDWalletCoinOps>::Address: fmt::Display,
+    {
+        let hd_wallet = coin.derivation_method().hd_wallet_or_err()?;
+
+        let account_id = params.account_id;
+        let mut hd_account = hd_wallet
+            .get_account_mut(account_id)
+            .await
+            .or_mm_err(|| GetNewAddressRpcError::UnknownAccount { account_id })?;
+
+        let chain = params.chain.unwrap_or_else(|| hd_wallet.default_receiver_chain());
+        let gap_limit = params.gap_limit.unwrap_or_else(|| hd_wallet.gap_limit());
+
+        // Check if we can generate new address.
+        check_if_can_get_new_address(coin, hd_wallet, &hd_account, chain, gap_limit).await?;
+
+        let HDAddress {
+            address,
+            derivation_path,
+            ..
+        } = coin
+            .generate_and_confirm_new_address(hd_wallet, &mut hd_account, chain, confirm_address)
+            .await?;
+
+        let balance = coin.known_address_balance(&address).await?;
         Ok(GetNewAddressResponse {
             new_address: HDAddressBalance {
                 address: address.to_string(),

--- a/mm2src/coins/rpc_command/init_create_account.rs
+++ b/mm2src/coins/rpc_command/init_create_account.rs
@@ -205,7 +205,7 @@ pub trait InitCreateAccountRpcOps {
         xpub_extractor: &XPubExtractor,
     ) -> MmResult<HDAccountBalance, CreateAccountRpcError>
     where
-        XPubExtractor: HDXPubExtractor + Sync;
+        XPubExtractor: HDXPubExtractor;
 
     async fn revert_creating_account(&self, account_id: u32);
 }
@@ -362,7 +362,7 @@ pub(crate) mod common_impl {
     where
         Coin:
             HDWalletBalanceOps + CoinWithDerivationMethod<HDWallet = <Coin as HDWalletCoinOps>::HDWallet> + Send + Sync,
-        XPubExtractor: HDXPubExtractor + Sync,
+        XPubExtractor: HDXPubExtractor,
     {
         let hd_wallet = coin.derivation_method().hd_wallet_or_err()?;
 

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -1202,11 +1202,22 @@ impl HDWalletCoinWithStorageOps for QtumCoin {
 
 #[async_trait]
 impl GetNewAddressRpcOps for QtumCoin {
-    async fn get_new_address_rpc(
+    async fn get_new_address_rpc_without_conf(
         &self,
         params: GetNewAddressParams,
     ) -> MmResult<GetNewAddressResponse, GetNewAddressRpcError> {
-        get_new_address::common_impl::get_new_address_rpc(self, params).await
+        get_new_address::common_impl::get_new_address_rpc_without_conf(self, params).await
+    }
+
+    async fn get_new_address_rpc<ConfirmAddress>(
+        &self,
+        params: GetNewAddressParams,
+        confirm_address: &ConfirmAddress,
+    ) -> MmResult<GetNewAddressResponse, GetNewAddressRpcError>
+    where
+        ConfirmAddress: HDConfirmAddress,
+    {
+        get_new_address::common_impl::get_new_address_rpc(self, params, confirm_address).await
     }
 }
 

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -2,8 +2,10 @@ use super::*;
 use crate::coin_balance::{self, EnableCoinBalanceError, EnabledCoinBalanceParams, HDAccountBalance, HDAddressBalance,
                           HDWalletBalance, HDWalletBalanceOps};
 use crate::coin_errors::MyAddressError;
+use crate::hd_confirm_address::HDConfirmAddress;
 use crate::hd_pubkey::{ExtractExtendedPubkey, HDExtractPubkeyError, HDXPubExtractor};
-use crate::hd_wallet::{AccountUpdatingError, AddressDerivingResult, HDAccountMut, NewAccountCreatingError};
+use crate::hd_wallet::{AccountUpdatingError, AddressDerivingResult, HDAccountMut, NewAccountCreatingError,
+                       NewAddressDeriveConfirmError};
 use crate::hd_wallet_storage::HDWalletCoinWithStorageOps;
 use crate::my_tx_history_v2::{CoinWithTxHistoryV2, MyTxHistoryErrorV2, MyTxHistoryTarget, TxHistoryStorage};
 use crate::rpc_command::account_balance::{self, AccountBalanceParams, AccountBalanceRpcOps, HDAccountBalanceResponse};
@@ -1087,7 +1089,7 @@ impl ExtractExtendedPubkey for QtumCoin {
         derivation_path: DerivationPath,
     ) -> MmResult<Self::ExtendedPublicKey, HDExtractPubkeyError>
     where
-        XPubExtractor: HDXPubExtractor + Sync,
+        XPubExtractor: HDXPubExtractor,
     {
         utxo_common::extract_extended_pubkey(&self.utxo_arc.conf, xpub_extractor, derivation_path).await
     }
@@ -1111,13 +1113,26 @@ impl HDWalletCoinOps for QtumCoin {
         utxo_common::derive_addresses(self, hd_account, address_ids).await
     }
 
+    async fn generate_and_confirm_new_address<ConfirmAddress>(
+        &self,
+        hd_wallet: &Self::HDWallet,
+        hd_account: &mut Self::HDAccount,
+        chain: Bip44Chain,
+        confirm_address: &ConfirmAddress,
+    ) -> MmResult<HDAddress<Self::Address, Self::Pubkey>, NewAddressDeriveConfirmError>
+    where
+        ConfirmAddress: HDConfirmAddress,
+    {
+        utxo_common::generate_and_confirm_new_address(self, hd_wallet, hd_account, chain, confirm_address).await
+    }
+
     async fn create_new_account<'a, XPubExtractor>(
         &self,
         hd_wallet: &'a Self::HDWallet,
         xpub_extractor: &XPubExtractor,
     ) -> MmResult<HDAccountMut<'a, Self::HDAccount>, NewAccountCreatingError>
     where
-        XPubExtractor: HDXPubExtractor + Sync,
+        XPubExtractor: HDXPubExtractor,
     {
         utxo_common::create_new_account(self, hd_wallet, xpub_extractor).await
     }
@@ -1148,7 +1163,7 @@ impl HDWalletBalanceOps for QtumCoin {
         params: EnabledCoinBalanceParams,
     ) -> MmResult<HDWalletBalance, EnableCoinBalanceError>
     where
-        XPubExtractor: HDXPubExtractor + Sync,
+        XPubExtractor: HDXPubExtractor,
     {
         coin_balance::common_impl::enable_hd_wallet(self, hd_wallet, xpub_extractor, params).await
     }
@@ -1234,7 +1249,7 @@ impl InitCreateAccountRpcOps for QtumCoin {
         xpub_extractor: &XPubExtractor,
     ) -> MmResult<HDAccountBalance, CreateAccountRpcError>
     where
-        XPubExtractor: HDXPubExtractor + Sync,
+        XPubExtractor: HDXPubExtractor,
     {
         init_create_account::common_impl::init_create_new_account_rpc(self, params, state, xpub_extractor).await
     }

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -229,10 +229,14 @@ where
         .confirm_utxo_address(trezor_coin, address.derivation_path.clone(), expected_address)
         .await?;
 
-    // We can update the corresponding number of used `hd_account` addresses
-    // since the user confirmed the new address.
-    coin.set_known_addresses_number(hd_wallet, hd_account, chain, new_known_addresses_number)
-        .await?;
+    let actual_known_addresses_number = hd_account.known_addresses_number(chain)?;
+    // Check if the actual `known_addresses_number` hasn't been changed while we waited for the user confirmation.
+    // If the actual value is greater than the new one, we don't need to update.
+    if actual_known_addresses_number < new_known_addresses_number {
+        coin.set_known_addresses_number(hd_wallet, hd_account, chain, new_known_addresses_number)
+            .await?;
+    }
+
     Ok(address)
 }
 

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -914,11 +914,22 @@ impl HDWalletCoinOps for UtxoStandardCoin {
 
 #[async_trait]
 impl GetNewAddressRpcOps for UtxoStandardCoin {
-    async fn get_new_address_rpc(
+    async fn get_new_address_rpc_without_conf(
         &self,
         params: GetNewAddressParams,
     ) -> MmResult<GetNewAddressResponse, GetNewAddressRpcError> {
-        get_new_address::common_impl::get_new_address_rpc(self, params).await
+        get_new_address::common_impl::get_new_address_rpc_without_conf(self, params).await
+    }
+
+    async fn get_new_address_rpc<ConfirmAddress>(
+        &self,
+        params: GetNewAddressParams,
+        confirm_address: &ConfirmAddress,
+    ) -> MmResult<GetNewAddressResponse, GetNewAddressRpcError>
+    where
+        ConfirmAddress: HDConfirmAddress,
+    {
+        get_new_address::common_impl::get_new_address_rpc(self, params, confirm_address).await
     }
 }
 

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -2,8 +2,10 @@ use super::*;
 use crate::coin_balance::{self, EnableCoinBalanceError, EnabledCoinBalanceParams, HDAccountBalance, HDAddressBalance,
                           HDWalletBalance, HDWalletBalanceOps};
 use crate::coin_errors::MyAddressError;
+use crate::hd_confirm_address::HDConfirmAddress;
 use crate::hd_pubkey::{ExtractExtendedPubkey, HDExtractPubkeyError, HDXPubExtractor};
-use crate::hd_wallet::{AccountUpdatingError, AddressDerivingResult, HDAccountMut, NewAccountCreatingError};
+use crate::hd_wallet::{AccountUpdatingError, AddressDerivingResult, HDAccountMut, NewAccountCreatingError,
+                       NewAddressDeriveConfirmError};
 use crate::hd_wallet_storage::HDWalletCoinWithStorageOps;
 use crate::my_tx_history_v2::{CoinWithTxHistoryV2, MyTxHistoryErrorV2, MyTxHistoryTarget, TxHistoryStorage};
 use crate::rpc_command::account_balance::{self, AccountBalanceParams, AccountBalanceRpcOps, HDAccountBalanceResponse};
@@ -851,7 +853,7 @@ impl ExtractExtendedPubkey for UtxoStandardCoin {
         derivation_path: DerivationPath,
     ) -> MmResult<Self::ExtendedPublicKey, HDExtractPubkeyError>
     where
-        XPubExtractor: HDXPubExtractor + Sync,
+        XPubExtractor: HDXPubExtractor,
     {
         utxo_common::extract_extended_pubkey(&self.utxo_arc.conf, xpub_extractor, derivation_path).await
     }
@@ -875,13 +877,26 @@ impl HDWalletCoinOps for UtxoStandardCoin {
         utxo_common::derive_addresses(self, hd_account, address_ids).await
     }
 
+    async fn generate_and_confirm_new_address<ConfirmAddress>(
+        &self,
+        hd_wallet: &Self::HDWallet,
+        hd_account: &mut Self::HDAccount,
+        chain: Bip44Chain,
+        confirm_address: &ConfirmAddress,
+    ) -> MmResult<HDAddress<Self::Address, Self::Pubkey>, NewAddressDeriveConfirmError>
+    where
+        ConfirmAddress: HDConfirmAddress,
+    {
+        utxo_common::generate_and_confirm_new_address(self, hd_wallet, hd_account, chain, confirm_address).await
+    }
+
     async fn create_new_account<'a, XPubExtractor>(
         &self,
         hd_wallet: &'a Self::HDWallet,
         xpub_extractor: &XPubExtractor,
     ) -> MmResult<HDAccountMut<'a, Self::HDAccount>, NewAccountCreatingError>
     where
-        XPubExtractor: HDXPubExtractor + Sync,
+        XPubExtractor: HDXPubExtractor,
     {
         utxo_common::create_new_account(self, hd_wallet, xpub_extractor).await
     }
@@ -922,7 +937,7 @@ impl HDWalletBalanceOps for UtxoStandardCoin {
         params: EnabledCoinBalanceParams,
     ) -> MmResult<HDWalletBalance, EnableCoinBalanceError>
     where
-        XPubExtractor: HDXPubExtractor + Sync,
+        XPubExtractor: HDXPubExtractor,
     {
         coin_balance::common_impl::enable_hd_wallet(self, hd_wallet, xpub_extractor, params).await
     }
@@ -998,7 +1013,7 @@ impl InitCreateAccountRpcOps for UtxoStandardCoin {
         xpub_extractor: &XPubExtractor,
     ) -> MmResult<HDAccountBalance, CreateAccountRpcError>
     where
-        XPubExtractor: HDXPubExtractor + Sync,
+        XPubExtractor: HDXPubExtractor,
     {
         init_create_account::common_impl::init_create_new_account_rpc(self, params, state, xpub_extractor).await
     }

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::coin_balance::HDAddressBalance;
+use crate::hd_confirm_address::for_tests::MockableConfirmAddress;
+use crate::hd_confirm_address::{HDConfirmAddress, HDConfirmAddressError};
 use crate::hd_wallet::HDAccountsMap;
 use crate::hd_wallet_storage::{HDWalletMockStorage, HDWalletStorageInternalOps};
 use crate::my_tx_history_v2::for_tests::init_storage_for;
@@ -3924,6 +3926,9 @@ fn test_get_new_address() {
         }
     });
 
+    MockableConfirmAddress::confirm_utxo_address
+        .mock_safe(move |_, _, _, _| MockResult::Return(Box::pin(futures::future::ok(()))));
+
     // This mock is required just not to fail on [`UtxoAddressScanner::init`].
     NativeClient::list_all_transactions
         .mock_safe(move |_, _| MockResult::Return(Box::new(futures01::future::ok(Vec::new()))));
@@ -3953,9 +3958,12 @@ fn test_get_new_address() {
         accounts: HDAccountsMutex::new(hd_accounts),
         gap_limit: 2,
     });
+    fields.conf.trezor_coin = Some("Komodo".to_string());
     let coin = utxo_coin_from_fields(fields);
 
     // =======
+
+    let confirm_address = MockableConfirmAddress::default();
 
     expected_checked_addresses!["m/44'/141'/0'/0/3", "RU1gRFXWXNx7uPRAEJ7wdZAW1RZ4TE6Vv1"];
     non_empty_addresses!["m/44'/141'/0'/0/3", "RU1gRFXWXNx7uPRAEJ7wdZAW1RZ4TE6Vv1"];
@@ -3964,7 +3972,7 @@ fn test_get_new_address() {
         chain: Some(Bip44Chain::External),
         gap_limit: None, // Will be used 2 from `UtxoHDWallet` by default.
     };
-    block_on(coin.get_new_address_rpc(params)).unwrap();
+    block_on(coin.get_new_address_rpc(params, &confirm_address)).unwrap();
     unsafe { assert_eq!(CHECKED_ADDRESSES, EXPECTED_CHECKED_ADDRESSES) };
 
     // `m/44'/141'/1'/0/3` is empty, so `m/44'/141'/1'/0/2` will be checked.
@@ -3976,8 +3984,8 @@ fn test_get_new_address() {
         chain: Some(Bip44Chain::External),
         gap_limit: Some(1),
     };
-    let err = block_on(coin.get_new_address_rpc(params))
-        .expect_err("check_if_can_get_new_address should have failed with 'EmptyAddressesLimitReached' error");
+    let err = block_on(coin.get_new_address_rpc(params, &confirm_address))
+        .expect_err("get_new_address_rpc should have failed with 'EmptyAddressesLimitReached' error");
     let expected = GetNewAddressRpcError::EmptyAddressesLimitReached { gap_limit: 1 };
     assert_eq!(err.into_inner(), expected);
     unsafe { assert_eq!(CHECKED_ADDRESSES, EXPECTED_CHECKED_ADDRESSES) };
@@ -3994,7 +4002,7 @@ fn test_get_new_address() {
         chain: Some(Bip44Chain::External),
         gap_limit: Some(2),
     };
-    block_on(coin.get_new_address_rpc(params)).unwrap();
+    block_on(coin.get_new_address_rpc(params, &confirm_address)).unwrap();
     unsafe { assert_eq!(CHECKED_ADDRESSES, EXPECTED_CHECKED_ADDRESSES) };
 
     // `m/44'/141'/2'/0/3` and `m/44'/141'/2'/0/2` are empty.
@@ -4009,8 +4017,8 @@ fn test_get_new_address() {
         chain: Some(Bip44Chain::External),
         gap_limit: Some(2),
     };
-    let err = block_on(coin.get_new_address_rpc(params))
-        .expect_err("check_if_can_get_new_address should have failed with 'EmptyAddressesLimitReached' error");
+    let err = block_on(coin.get_new_address_rpc(params, &confirm_address))
+        .expect_err("get_new_address_rpc should have failed with 'EmptyAddressesLimitReached' error");
     let expected = GetNewAddressRpcError::EmptyAddressesLimitReached { gap_limit: 2 };
     assert_eq!(err.into_inner(), expected);
     unsafe { assert_eq!(CHECKED_ADDRESSES, EXPECTED_CHECKED_ADDRESSES) };
@@ -4024,8 +4032,8 @@ fn test_get_new_address() {
         chain: Some(Bip44Chain::External),
         gap_limit: Some(0),
     };
-    let err = block_on(coin.get_new_address_rpc(params))
-        .expect_err("!check_if_can_get_new_address should have failed with 'EmptyAddressesLimitReached' error");
+    let err = block_on(coin.get_new_address_rpc(params, &confirm_address))
+        .expect_err("!get_new_address_rpc should have failed with 'EmptyAddressesLimitReached' error");
     let expected = GetNewAddressRpcError::EmptyAddressesLimitReached { gap_limit: 0 };
     assert_eq!(err.into_inner(), expected);
     unsafe { assert_eq!(CHECKED_ADDRESSES, EXPECTED_CHECKED_ADDRESSES) };
@@ -4039,7 +4047,7 @@ fn test_get_new_address() {
         chain: Some(Bip44Chain::External),
         gap_limit: Some(5),
     };
-    block_on(coin.get_new_address_rpc(params)).unwrap();
+    block_on(coin.get_new_address_rpc(params, &confirm_address)).unwrap();
     unsafe { assert_eq!(CHECKED_ADDRESSES, EXPECTED_CHECKED_ADDRESSES) };
 
     // `known_addresses_number=0`, always allow.
@@ -4051,8 +4059,27 @@ fn test_get_new_address() {
         chain: Some(Bip44Chain::Internal),
         gap_limit: Some(0),
     };
-    block_on(coin.get_new_address_rpc(params)).unwrap();
+    block_on(coin.get_new_address_rpc(params, &confirm_address)).unwrap();
     unsafe { assert_eq!(CHECKED_ADDRESSES, EXPECTED_CHECKED_ADDRESSES) };
+
+    // Check if `get_new_address_rpc` fails if `HDAddressConfirm::confirm_utxo_address` fails.
+
+    MockableConfirmAddress::confirm_utxo_address.mock_safe(move |_, _, _, _| {
+        MockResult::Return(Box::pin(futures::future::ready(MmError::err(
+            HDConfirmAddressError::HwContextNotInitialized,
+        ))))
+    });
+
+    expected_checked_addresses![];
+    non_empty_addresses![];
+    let params = GetNewAddressParams {
+        account_id: 0,
+        chain: Some(Bip44Chain::Internal),
+        gap_limit: Some(2),
+    };
+    let err = block_on(coin.get_new_address_rpc(params, &confirm_address))
+        .expect_err("!get_new_address_rpc should have failed with 'HwContextNotInitialized' error");
+    assert_eq!(err.into_inner(), GetNewAddressRpcError::HwContextNotInitialized);
 }
 
 /// https://github.com/KomodoPlatform/atomicDEX-API/issues/1196

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -4062,7 +4062,7 @@ fn test_get_new_address() {
     block_on(coin.get_new_address_rpc(params, &confirm_address)).unwrap();
     unsafe { assert_eq!(CHECKED_ADDRESSES, EXPECTED_CHECKED_ADDRESSES) };
 
-    // Check if `get_new_address_rpc` fails if `HDAddressConfirm::confirm_utxo_address` fails.
+    // Check if `get_new_address_rpc` fails on the `HDAddressConfirm::confirm_utxo_address` error.
 
     MockableConfirmAddress::confirm_utxo_address.mock_safe(move |_, _, _, _| {
         MockResult::Return(Box::pin(futures::future::ready(MmError::err(

--- a/mm2src/coins/utxo_signer/src/lib.rs
+++ b/mm2src/coins/utxo_signer/src/lib.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use chain::Transaction as UtxoTx;
-use crypto::trezor::client::TrezorClient;
-use crypto::trezor::TrezorError;
+use crypto::trezor::{TrezorError, TrezorSession};
 use derive_more::Display;
 use keys::bytes::Bytes;
 use keys::KeyPair;
@@ -111,7 +110,7 @@ pub trait TxProvider {
 }
 
 pub enum SignPolicy<'a> {
-    WithTrezor(TrezorClient),
+    WithTrezor(TrezorSession<'a>),
     WithKeyPair(&'a KeyPair),
 }
 

--- a/mm2src/coins_activation/src/utxo_activation/init_utxo_standard_activation_error.rs
+++ b/mm2src/coins_activation/src/utxo_activation/init_utxo_standard_activation_error.rs
@@ -114,7 +114,7 @@ impl InitUtxoStandardError {
             },
             HwError::CannotChooseDevice { .. } => InitUtxoStandardError::HwError(HwRpcError::FoundMultipleDevices),
             HwError::ConnectionTimedOut { timeout } => InitUtxoStandardError::TaskTimedOut { duration: timeout },
-            HwError::FoundUnexpectedDevice { .. } => InitUtxoStandardError::HwError(HwRpcError::FoundUnexpectedDevice),
+            HwError::FoundUnexpectedDevice => InitUtxoStandardError::HwError(HwRpcError::FoundUnexpectedDevice),
             HwError::Failure(error) => InitUtxoStandardError::CoinCreationError { ticker, error },
             other => InitUtxoStandardError::Internal(other.to_string()),
         }

--- a/mm2src/crypto/Cargo.toml
+++ b/mm2src/crypto/Cargo.toml
@@ -14,6 +14,7 @@ bitcrypto = { path = "../mm2_bitcoin/crypto" }
 bs58 = "0.4.0"
 common = { path = "../common" }
 derive_more = "0.99"
+enum_from = { path = "../derives/enum_from" }
 enum-primitive-derive = "0.2"
 futures = "0.3"
 hex = "0.4.2"

--- a/mm2src/crypto/src/crypto_ctx.rs
+++ b/mm2src/crypto/src/crypto_ctx.rs
@@ -25,8 +25,8 @@ pub type CryptoInitResult<T> = Result<T, MmError<CryptoInitError>>;
 pub enum CryptoInitError {
     NotInitialized,
     InitializedAlready,
-    #[display(fmt = "jeezy says we cant use the nullstring as passphrase and I agree")]
-    NullStringPassphrase,
+    #[display(fmt = "Passphrase cannot be an empty string")]
+    EmptyPassphrase,
     #[display(fmt = "Invalid passphrase: '{}'", _0)]
     InvalidPassphrase(PrivKeyError),
     #[display(fmt = "Invalid 'hd_account_id' = {}: {}", hd_account_id, error)]
@@ -44,7 +44,7 @@ impl From<PrivKeyError> for CryptoInitError {
 impl From<SharedDbIdError> for CryptoInitError {
     fn from(e: SharedDbIdError) -> Self {
         match e {
-            SharedDbIdError::NullStringPassphrase => CryptoInitError::NullStringPassphrase,
+            SharedDbIdError::EmptyPassphrase => CryptoInitError::EmptyPassphrase,
             SharedDbIdError::Internal(internal) => CryptoInitError::Internal(internal),
         }
     }
@@ -303,7 +303,7 @@ impl CryptoCtx {
         }
 
         if passphrase.is_empty() {
-            return MmError::err(CryptoInitError::NullStringPassphrase);
+            return MmError::err(CryptoInitError::EmptyPassphrase);
         }
 
         let (secp256k1_key_pair, key_pair_policy) = policy_builder.build(passphrase)?;

--- a/mm2src/crypto/src/crypto_ctx.rs
+++ b/mm2src/crypto/src/crypto_ctx.rs
@@ -5,8 +5,10 @@ use crate::hw_error::HwError;
 #[cfg(target_arch = "wasm32")]
 use crate::metamask_ctx::{MetamaskArc, MetamaskCtx, MetamaskError};
 use crate::privkey::{key_pair_from_seed, PrivKeyError};
+use crate::shared_db_id::{shared_db_id_from_seed, SharedDbIdError};
 use arrayref::array_ref;
 use common::bits256;
+use common::log::info;
 use derive_more::Display;
 use keys::{KeyPair, Public as PublicKey, Secret as Secp256k1Secret};
 use mm2_core::mm_ctx::MmArc;
@@ -37,6 +39,15 @@ pub enum CryptoInitError {
 
 impl From<PrivKeyError> for CryptoInitError {
     fn from(e: PrivKeyError) -> Self { CryptoInitError::InvalidPassphrase(e) }
+}
+
+impl From<SharedDbIdError> for CryptoInitError {
+    fn from(e: SharedDbIdError) -> Self {
+        match e {
+            SharedDbIdError::NullStringPassphrase => CryptoInitError::NullStringPassphrase,
+            SharedDbIdError::Internal(internal) => CryptoInitError::Internal(internal),
+        }
+    }
 }
 
 #[derive(Debug, Display)]
@@ -297,6 +308,7 @@ impl CryptoCtx {
 
         let (secp256k1_key_pair, key_pair_policy) = policy_builder.build(passphrase)?;
         let rmd160 = secp256k1_key_pair.public().address_hash();
+        let shared_db_id = shared_db_id_from_seed(passphrase)?;
 
         let crypto_ctx = CryptoCtx {
             secp256k1_key_pair,
@@ -311,7 +323,12 @@ impl CryptoCtx {
         drop(ctx_field);
 
         ctx.rmd160.pin(rmd160).map_to_mm(CryptoInitError::Internal)?;
+        ctx.shared_db_id
+            .pin(shared_db_id)
+            .map_to_mm(CryptoInitError::Internal)?;
 
+        info!("Public key hash: {rmd160}");
+        info!("Shared Database ID: {shared_db_id}");
         Ok(result)
     }
 }

--- a/mm2src/crypto/src/hw_client.rs
+++ b/mm2src/crypto/src/hw_client.rs
@@ -52,6 +52,14 @@ pub enum HwDeviceInfo {
     Trezor(TrezorDeviceInfo),
 }
 
+#[derive(Debug, Serialize)]
+pub enum HwConnectionStatus {
+    Connected,
+    /// `Unreachable` means that the device is either disconnected or is in an incorrect state,
+    /// so it should be reinitialized.
+    Unreachable,
+}
+
 #[async_trait]
 pub trait TrezorConnectProcessor: TrezorRequestProcessor {
     async fn on_connect(&self) -> MmResult<Duration, HwProcessingError<Self::Error>>;

--- a/mm2src/crypto/src/hw_ctx.rs
+++ b/mm2src/crypto/src/hw_ctx.rs
@@ -1,19 +1,19 @@
-use crate::hw_client::{HwClient, HwDeviceInfo, HwProcessingError, HwPubkey, TrezorConnectProcessor};
+use crate::hw_client::{HwClient, HwConnectionStatus, HwDeviceInfo, HwProcessingError, HwPubkey, TrezorConnectProcessor};
 use crate::hw_error::HwError;
 use crate::trezor::TrezorSession;
 use crate::{mm2_internal_der_path, HwWalletType};
 use bip32::ChildNumber;
 use bitcrypto::dhash160;
 use common::log::warn;
-use futures::lock::Mutex as AsyncMutex;
 use hw_common::primitives::{EcdsaCurve, Secp256k1ExtendedPublicKey};
 use keys::Public as PublicKey;
 use mm2_err_handle::prelude::*;
 use primitives::hash::{H160, H264};
+use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use trezor::client::TrezorClient;
 use trezor::utxo::IGNORE_XPUB_MAGIC;
 use trezor::{ProcessTrezorResponse, TrezorRequestProcessor};
 
@@ -42,7 +42,9 @@ pub struct HardwareWalletCtx {
     /// The mutex hasn't to be locked while the client is used
     /// because every variant of `HwClient` uses an internal mutex to operate with the device.
     /// But it has to be locked while the client is initialized.
-    pub(crate) hw_wallet: AsyncMutex<Option<HwClient>>,
+    pub(crate) hw_wallet: HwClient,
+    /// Whether the Hardware Wallet is connected.
+    pub(crate) hw_wallet_connected: AtomicBool,
 }
 
 impl HardwareWalletCtx {
@@ -55,48 +57,91 @@ impl HardwareWalletCtx {
         let trezor = HwClient::trezor(processor).await?;
 
         let (hw_device_info, hw_internal_pubkey) = {
-            let (device_info, mut session) = trezor.new_session().await?;
+            let (device_info, mut session) = trezor.init_new_session().await?;
             let hw_internal_pubkey = HardwareWalletCtx::trezor_mm_internal_pubkey(&mut session, processor).await?;
             (HwDeviceInfo::Trezor(device_info), hw_internal_pubkey)
         };
 
-        let hw_client = HwClient::Trezor(trezor);
+        let hw_wallet = HwClient::Trezor(trezor);
         let hw_ctx = HardwareWalletArc::new(HardwareWalletCtx {
             hw_internal_pubkey,
-            hw_wallet_type: hw_client.hw_wallet_type(),
-            hw_wallet: AsyncMutex::new(Some(hw_client)),
+            hw_wallet_type: hw_wallet.hw_wallet_type(),
+            hw_wallet,
+            hw_wallet_connected: AtomicBool::new(true),
         });
         Ok((hw_device_info, hw_ctx))
     }
 
     pub fn hw_wallet_type(&self) -> HwWalletType { self.hw_wallet_type }
 
-    /// Connects to a Trezor device and checks if MM was initialized from this particular device.
-    pub async fn trezor<Processor>(
-        &self,
-        processor: &Processor,
-    ) -> MmResult<TrezorClient, HwProcessingError<Processor::Error>>
-    where
-        Processor: TrezorConnectProcessor + Sync,
-        Processor::Error: std::fmt::Display,
-    {
-        let mut hw_client = self.hw_wallet.lock().await;
-        if let Some(HwClient::Trezor(connected_trezor)) = hw_client.deref() {
-            match self.check_trezor(connected_trezor, processor).await {
-                Ok(()) => return Ok(connected_trezor.clone()),
-                // The device could be unplugged. We should try to reconnect to the device.
-                Err(e) => warn!("Error checking hardware wallet device: '{}'. Trying to reconnect...", e),
-            }
+    /// Returns a Trezor session.
+    pub async fn trezor(&self) -> MmResult<TrezorSession<'_>, HwError> {
+        if !self.hw_wallet_connected.load(Ordering::Relaxed) {
+            return MmError::err(HwError::DeviceDisconnected);
         }
-        // Connect to a device.
-        let trezor = HwClient::trezor(processor).await?;
-        // Check if the connected device has the same public key as we used to initialize the app.
-        self.check_trezor(&trezor, processor).await?;
 
-        // Reinitialize the field to avoid reconnecting next time.
-        *hw_client = Some(HwClient::Trezor(trezor.clone()));
+        let HwClient::Trezor(ref trezor) = self.hw_wallet;
+        match trezor.init_new_session().await {
+            Ok((_device, session)) => Ok(session),
+            Err(e) => {
+                self.handle_hw_error(&e);
+                Err(e.map(HwError::from))
+            },
+        }
+    }
 
-        Ok(trezor)
+    #[cfg(target_arch = "wasm32")]
+    pub async fn trezor_connection_status(&self) -> HwConnectionStatus {
+        if !self.hw_wallet_connected.load(Ordering::Relaxed) {
+            return HwConnectionStatus::Unreachable;
+        }
+
+        let HwClient::Trezor(ref trezor) = self.hw_wallet;
+        let mut session = match trezor.try_session_if_not_occupied() {
+            Some(session) => session,
+            // If we got `None`, the session mutex is occupied by another task,
+            // so for now we can consider the Trezor device as connected.
+            None => return HwConnectionStatus::Connected,
+        };
+
+        #[cfg(target_arch = "wasm32")]
+        match session.is_connected().await {
+            Ok(true) => HwConnectionStatus::Connected,
+            Ok(false) => {
+                self.handle_hw_error(&"Device has been disconnected");
+                HwConnectionStatus::Unreachable
+            },
+            Err(e) => {
+                self.handle_hw_error(&e);
+                HwConnectionStatus::Unreachable
+            },
+        }
+    }
+
+    /// Currently, we use the heavy [`TrezorClient::try_init_new_session_if_not_occupied`] method.
+    ///
+    /// Please note that we can't use [`TrezorSession::ping`] as it may request a Button/PIN press
+    /// if the device is **locked**.  So even if we cancel the Button/PIN request,
+    /// the display will have time to draw something, that is, blink.
+    ///
+    /// TODO figure out how to implement [`Transport::is_connected`] for the native `UsbTransport`.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn trezor_connection_status(&self) -> HwConnectionStatus {
+        if !self.hw_wallet_connected.load(Ordering::Relaxed) {
+            return HwConnectionStatus::Unreachable;
+        }
+
+        let HwClient::Trezor(ref trezor) = self.hw_wallet;
+        match trezor.try_init_new_session_if_not_occupied().await {
+            Ok(Some((_device_info, _session))) => HwConnectionStatus::Connected,
+            // If we got `None`, the session mutex is occupied by another task,
+            // so for now we can consider the Trezor device as connected.
+            Ok(None) => HwConnectionStatus::Connected,
+            Err(e) => {
+                self.handle_hw_error(&e);
+                HwConnectionStatus::Unreachable
+            },
+        }
     }
 
     pub fn secp256k1_pubkey(&self) -> PublicKey { PublicKey::Compressed(self.hw_internal_pubkey) }
@@ -132,25 +177,11 @@ impl HardwareWalletCtx {
         Ok(H264::from(extended_pubkey.public_key().serialize()))
     }
 
-    async fn check_trezor<Processor>(
-        &self,
-        trezor: &TrezorClient,
-        processor: &Processor,
-    ) -> MmResult<(), HwProcessingError<Processor::Error>>
-    where
-        Processor: TrezorRequestProcessor + Sync,
-    {
-        let mut session = trezor.session().await.mm_err(HwError::from)?;
-        let actual_pubkey = Self::trezor_mm_internal_pubkey(&mut session, processor).await?;
-        if actual_pubkey != self.hw_internal_pubkey {
-            let actual_pubkey = hw_pubkey_from_h264(&actual_pubkey);
-            let expected_pubkey = self.hw_pubkey();
-            return MmError::err(HwProcessingError::HwError(HwError::FoundUnexpectedDevice {
-                actual_pubkey,
-                expected_pubkey,
-            }));
-        }
-        Ok(())
+    /// If either the [`HardwareWalletCtx::hw_wallet`] client failed on a connection check,
+    /// we can't use it anymore.
+    fn handle_hw_error(&self, error: &dyn fmt::Display) {
+        warn!("Error checking Trezor device status. The device is no longer available: '{error}'");
+        self.hw_wallet_connected.store(false, Ordering::Relaxed);
     }
 }
 

--- a/mm2src/crypto/src/hw_error.rs
+++ b/mm2src/crypto/src/hw_error.rs
@@ -1,4 +1,3 @@
-use crate::HwPubkey;
 use derive_more::Display;
 use hw_common::primitives::Bip32Error;
 use mm2_err_handle::prelude::*;
@@ -20,15 +19,8 @@ pub enum HwError {
     ConnectionTimedOut {
         timeout: Duration,
     },
-    #[display(
-        fmt = "Expected a Hardware Wallet device with '{}' pubkey, found '{}'",
-        expected_pubkey,
-        actual_pubkey
-    )]
-    FoundUnexpectedDevice {
-        actual_pubkey: HwPubkey,
-        expected_pubkey: HwPubkey,
-    },
+    #[display(fmt = "Found unexpected Hardware Wallet device")]
+    FoundUnexpectedDevice,
     DeviceDisconnected,
     #[display(fmt = "'{}' transport not supported", transport)]
     TransportNotSupported {
@@ -97,7 +89,7 @@ where
         },
         HwError::CannotChooseDevice { .. } => T::hw_rpc_error(HwRpcError::FoundMultipleDevices),
         HwError::ConnectionTimedOut { timeout } => T::timeout(timeout),
-        HwError::FoundUnexpectedDevice { .. } => T::hw_rpc_error(HwRpcError::FoundUnexpectedDevice),
+        HwError::FoundUnexpectedDevice => T::hw_rpc_error(HwRpcError::FoundUnexpectedDevice),
         other => T::internal(other.to_string()),
     }
 }

--- a/mm2src/crypto/src/lib.rs
+++ b/mm2src/crypto/src/lib.rs
@@ -8,6 +8,7 @@ mod hw_ctx;
 mod hw_error;
 pub mod hw_rpc_task;
 pub mod privkey;
+mod shared_db_id;
 mod standard_hd_path;
 mod xpub;
 

--- a/mm2src/crypto/src/lib.rs
+++ b/mm2src/crypto/src/lib.rs
@@ -19,7 +19,8 @@ mod xpub;
 pub use bip32_child::{Bip32Child, Bip32DerPathError, Bip32DerPathOps, Bip44Tail};
 pub use crypto_ctx::{CryptoCtx, CryptoCtxError, CryptoInitError, CryptoInitResult, HwCtxInitError, KeyPairPolicy};
 pub use global_hd_ctx::GlobalHDAccountArc;
-pub use hw_client::{HwClient, HwDeviceInfo, HwProcessingError, HwPubkey, HwWalletType, TrezorConnectProcessor};
+pub use hw_client::{HwClient, HwConnectionStatus, HwDeviceInfo, HwProcessingError, HwPubkey, HwWalletType,
+                    TrezorConnectProcessor};
 pub use hw_common::primitives::{Bip32Error, ChildNumber, DerivationPath, EcdsaCurve, ExtendedPublicKey,
                                 Secp256k1ExtendedPublicKey, XPub};
 pub use hw_ctx::{HardwareWalletArc, HardwareWalletCtx};

--- a/mm2src/crypto/src/privkey.rs
+++ b/mm2src/crypto/src/privkey.rs
@@ -68,16 +68,17 @@ fn private_from_seed(seed: &str) -> PrivKeyResult<Private> {
                 checksum_type: ChecksumType::DSHA256,
             })
         },
-        None => {
-            let hash = sha256(seed.as_bytes());
+        None => Ok(private_from_seed_hash(seed)),
+    }
+}
 
-            Ok(Private {
-                prefix: 0,
-                secret: secp_privkey_from_hash(hash),
-                compressed: true,
-                checksum_type: ChecksumType::DSHA256,
-            })
-        },
+pub(crate) fn private_from_seed_hash(seed: &str) -> Private {
+    let hash = sha256(seed.as_bytes());
+    Private {
+        prefix: 0,
+        secret: secp_privkey_from_hash(hash),
+        compressed: true,
+        checksum_type: ChecksumType::DSHA256,
     }
 }
 
@@ -109,7 +110,7 @@ pub fn key_pair_from_secret(secret: &[u8]) -> PrivKeyResult<KeyPair> {
         prefix: 0,
         secret: secret.into(),
         compressed: true,
-        checksum_type: Default::default(),
+        checksum_type: ChecksumType::DSHA256,
     };
     Ok(KeyPair::from_private(private)?)
 }

--- a/mm2src/crypto/src/shared_db_id.rs
+++ b/mm2src/crypto/src/shared_db_id.rs
@@ -1,5 +1,6 @@
 use crate::privkey::private_from_seed_hash;
 use derive_more::Display;
+use enum_from::EnumFromStringify;
 use keys::{Error as KeysError, KeyPair};
 use mm2_err_handle::prelude::*;
 use primitives::hash::H160;
@@ -10,16 +11,13 @@ const SHARED_DB_MAGIC_SALT: &str = "uVa*6pcnpc9ki+VBX.6_L.";
 
 pub type SharedDbId = H160;
 
-#[derive(Display)]
+#[derive(Display, EnumFromStringify)]
 pub enum SharedDbIdError {
     #[display(fmt = "Passphrase cannot be empty")]
     NullStringPassphrase,
+    #[from_stringify("KeysError")]
     #[display(fmt = "Internal error: {_0}")]
     Internal(String),
-}
-
-impl From<KeysError> for SharedDbIdError {
-    fn from(e: KeysError) -> Self { SharedDbIdError::Internal(e.to_string()) }
 }
 
 pub fn shared_db_id_from_seed(passphrase: &str) -> MmResult<SharedDbId, SharedDbIdError> {

--- a/mm2src/crypto/src/shared_db_id.rs
+++ b/mm2src/crypto/src/shared_db_id.rs
@@ -13,8 +13,8 @@ pub type SharedDbId = H160;
 
 #[derive(Display, EnumFromStringify)]
 pub enum SharedDbIdError {
-    #[display(fmt = "Passphrase cannot be empty")]
-    NullStringPassphrase,
+    #[display(fmt = "Passphrase cannot be an empty string")]
+    EmptyPassphrase,
     #[from_stringify("KeysError")]
     #[display(fmt = "Internal error: {_0}")]
     Internal(String),
@@ -23,7 +23,7 @@ pub enum SharedDbIdError {
 pub fn shared_db_id_from_seed(passphrase: &str) -> MmResult<SharedDbId, SharedDbIdError> {
     let stripped_passphrase = passphrase.strip_prefix("0x").unwrap_or(passphrase);
     if stripped_passphrase.is_empty() {
-        return MmError::err(SharedDbIdError::NullStringPassphrase);
+        return MmError::err(SharedDbIdError::EmptyPassphrase);
     }
 
     let changed_passphrase = format!("{stripped_passphrase} {SHARED_DB_MAGIC_SALT}");

--- a/mm2src/crypto/src/shared_db_id.rs
+++ b/mm2src/crypto/src/shared_db_id.rs
@@ -1,0 +1,35 @@
+use crate::privkey::private_from_seed_hash;
+use derive_more::Display;
+use keys::{Error as KeysError, KeyPair};
+use mm2_err_handle::prelude::*;
+use primitives::hash::H160;
+
+/// This magic string is used to change the input mnemonic passphrase the way
+/// so `sha256(mnemonic + SHARED_DB_MAGIC_SALT)`
+const SHARED_DB_MAGIC_SALT: &str = "uVa*6pcnpc9ki+VBX.6_L.";
+
+pub type SharedDbId = H160;
+
+#[derive(Display)]
+pub enum SharedDbIdError {
+    #[display(fmt = "Passphrase cannot be empty")]
+    NullStringPassphrase,
+    #[display(fmt = "Internal error: {_0}")]
+    Internal(String),
+}
+
+impl From<KeysError> for SharedDbIdError {
+    fn from(e: KeysError) -> Self { SharedDbIdError::Internal(e.to_string()) }
+}
+
+pub fn shared_db_id_from_seed(passphrase: &str) -> MmResult<SharedDbId, SharedDbIdError> {
+    let stripped_passphrase = passphrase.strip_prefix("0x").unwrap_or(passphrase);
+    if stripped_passphrase.is_empty() {
+        return MmError::err(SharedDbIdError::NullStringPassphrase);
+    }
+
+    let changed_passphrase = format!("{stripped_passphrase} {SHARED_DB_MAGIC_SALT}");
+    let private = private_from_seed_hash(&changed_passphrase);
+    let key_pair = KeyPair::from_private(private)?;
+    Ok(key_pair.public().address_hash())
+}

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -89,7 +89,11 @@ pub struct MmCtx {
     pub coins_activation_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
     pub crypto_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
     /// RIPEMD160(SHA256(x)) where x is secp256k1 pubkey derived from passphrase.
+    /// This hash is **unique** among Iguana and each HD accounts derived from the same passphrase.
     pub rmd160: Constructible<H160>,
+    /// A shared DB identifier - RIPEMD160(SHA256(x)) where x is secp256k1 pubkey derived from (passphrase + magic salt).
+    /// This hash is **the same** for Iguana and all HD accounts derived from the same passphrase.
+    pub shared_db_id: Constructible<H160>,
     /// Coins that should be enabled to kick start the interrupted swaps and orders.
     pub coins_needed_for_kick_start: Mutex<HashSet<String>>,
     /// The context belonging to the `lp_swap` mod: `SwapsContext`.
@@ -137,6 +141,7 @@ impl MmCtx {
             coins_activation_ctx: Mutex::new(None),
             crypto_ctx: Mutex::new(None),
             rmd160: Constructible::default(),
+            shared_db_id: Constructible::default(),
             coins_needed_for_kick_start: Mutex::new(HashSet::new()),
             swaps_ctx: Mutex::new(None),
             stats_ctx: Mutex::new(None),
@@ -159,6 +164,13 @@ impl MmCtx {
             static ref DEFAULT: H160 = [0; 20].into();
         }
         self.rmd160.or(&|| &*DEFAULT)
+    }
+
+    pub fn shared_db_id(&self) -> &H160 {
+        lazy_static! {
+            static ref DEFAULT: H160 = [0; 20].into();
+        }
+        self.shared_db_id.or(&|| &*DEFAULT)
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -17,7 +17,6 @@ use std::collections::HashSet;
 use std::fmt;
 use std::future::Future;
 use std::ops::Deref;
-use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 cfg_wasm32! {
@@ -30,6 +29,7 @@ cfg_native! {
     use mm2_metrics::prometheus;
     use mm2_metrics::MmMetricsError;
     use std::net::{IpAddr, SocketAddr, AddrParseError};
+    use std::path::{Path, PathBuf};
     use std::sync::MutexGuard;
 }
 
@@ -105,6 +105,8 @@ pub struct MmCtx {
     pub wasm_rpc: Constructible<WasmRpcSender>,
     #[cfg(not(target_arch = "wasm32"))]
     pub sqlite_connection: Constructible<Arc<Mutex<Connection>>>,
+    #[cfg(not(target_arch = "wasm32"))]
+    pub shared_sqlite_conn: Constructible<Arc<Mutex<Connection>>>,
     pub mm_version: String,
     pub datetime: String,
     pub mm_init_ctx: Mutex<Option<Arc<dyn Any + 'static + Send + Sync>>>,
@@ -149,6 +151,8 @@ impl MmCtx {
             wasm_rpc: Constructible::default(),
             #[cfg(not(target_arch = "wasm32"))]
             sqlite_connection: Constructible::default(),
+            #[cfg(not(target_arch = "wasm32"))]
+            shared_sqlite_conn: Constructible::default(),
             mm_version: "".into(),
             datetime: "".into(),
             mm_init_ctx: Mutex::new(None),
@@ -201,19 +205,19 @@ impl MmCtx {
     ///     "dbdir": "c:/Users/mm2user/.mm2-db"
     ///
     /// No checks in this method, the paths should be checked in the `fn fix_directories` instead.
-    pub fn dbdir(&self) -> PathBuf {
-        let path = if let Some(dbdir) = self.conf["dbdir"].as_str() {
-            let dbdir = dbdir.trim();
-            if !dbdir.is_empty() {
-                Path::new(dbdir)
-            } else {
-                Path::new("DB")
-            }
-        } else {
-            Path::new("DB")
-        };
-        path.join(hex::encode(self.rmd160().as_slice()))
-    }
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn dbdir(&self) -> PathBuf { path_to_dbdir(self.conf["dbdir"].as_str(), self.rmd160()) }
+
+    /// MM shared database path.
+    /// Defaults to a relative "DB".
+    ///
+    /// Can be changed via the "dbdir" configuration field, for example:
+    ///
+    ///     "dbdir": "c:/Users/mm2user/.mm2-db"
+    ///
+    /// No checks in this method, the paths should be checked in the `fn fix_directories` instead.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn shared_dbdir(&self) -> PathBuf { path_to_dbdir(self.conf["dbdir"].as_str(), self.shared_db_id()) }
 
     pub fn is_watcher(&self) -> bool { self.conf["is_watcher"].as_bool().unwrap_or_default() }
 
@@ -251,6 +255,15 @@ impl MmCtx {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    pub fn init_shared_sqlite_conn(&self) -> Result<(), String> {
+        let sqlite_file_path = self.shared_dbdir().join("MM2-shared.db");
+        log::debug!("Trying to open SQLite database file {}", sqlite_file_path.display());
+        let connection = try_s!(Connection::open(sqlite_file_path));
+        try_s!(self.shared_sqlite_conn.pin(Arc::new(Mutex::new(connection))));
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn sqlite_conn_opt(&self) -> Option<MutexGuard<Connection>> {
         self.sqlite_connection.as_option().map(|conn| conn.lock().unwrap())
     }
@@ -259,6 +272,14 @@ impl MmCtx {
     pub fn sqlite_connection(&self) -> MutexGuard<Connection> {
         self.sqlite_connection
             .or(&|| panic!("sqlite_connection is not initialized"))
+            .lock()
+            .unwrap()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn shared_sqlite_conn(&self) -> MutexGuard<Connection> {
+        self.shared_sqlite_conn
+            .or(&|| panic!("shared_sqlite_conn is not initialized"))
             .lock()
             .unwrap()
     }
@@ -277,6 +298,19 @@ impl Drop for MmCtx {
             .unwrap_or_else(|| "UNKNOWN".to_owned());
         log::info!("MmCtx ({}) has been dropped", ffi_handle)
     }
+}
+
+/// This function can be used later by an FFI function to open a GUI storage.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn path_to_dbdir(db_root: Option<&str>, db_id: &H160) -> PathBuf {
+    const DEFAULT_ROOT: &str = "DB";
+
+    let path = match db_root {
+        Some(dbdir) if !dbdir.is_empty() => Path::new(dbdir),
+        _ => Path::new(DEFAULT_ROOT),
+    };
+
+    path.join(hex::encode(db_id.as_slice()))
 }
 
 // We don't want to send `MmCtx` across threads, it will only obstruct the normal use case

--- a/mm2src/mm2_db/src/indexed_db/db_lock.rs
+++ b/mm2src/mm2_db/src/indexed_db/db_lock.rs
@@ -18,13 +18,26 @@ pub struct ConstructibleDb<Db> {
 }
 
 impl<Db: DbInstance> ConstructibleDb<Db> {
-    pub fn new_shared(ctx: &MmArc) -> SharedDb<Db> { Arc::new(Self::new(ctx)) }
+    pub fn into_shared(self) -> SharedDb<Db> { Arc::new(self) }
 
+    /// Creates a new uninitialized `Db` instance from other Iguana and/or HD accounts.
+    /// This can be initialized later using [`ConstructibleDb::get_or_initialize`].
     pub fn new(ctx: &MmArc) -> Self {
         ConstructibleDb {
             mutex: AsyncMutex::new(None),
             db_namespace: ctx.db_namespace,
             wallet_rmd160: ctx.rmd160().clone(),
+        }
+    }
+
+    /// Creates a new uninitialized `Db` instance shared between Iguana and all HD accounts
+    /// derived from the same passphrase.
+    /// This can be initialized later using [`ConstructibleDb::get_or_initialize`].
+    pub fn new_shared_db(ctx: &MmArc) -> Self {
+        ConstructibleDb {
+            mutex: AsyncMutex::new(None),
+            db_namespace: ctx.db_namespace,
+            wallet_rmd160: ctx.shared_db_id().clone(),
         }
     }
 

--- a/mm2src/mm2_gui_storage/src/account/storage/wasm_storage.rs
+++ b/mm2src/mm2_gui_storage/src/account/storage/wasm_storage.rs
@@ -64,7 +64,7 @@ pub(crate) struct WasmAccountStorage {
 impl WasmAccountStorage {
     pub fn new(ctx: &MmArc) -> Self {
         WasmAccountStorage {
-            account_db: ConstructibleDb::new_shared(ctx),
+            account_db: ConstructibleDb::new_shared_db(ctx).into_shared(),
         }
     }
 

--- a/mm2src/mm2_main/src/database/stats_swaps.rs
+++ b/mm2src/mm2_main/src/database/stats_swaps.rs
@@ -1,7 +1,7 @@
 use crate::mm2::lp_swap::{MakerSavedSwap, SavedSwap, SavedSwapIo, TakerSavedSwap};
 use common::log::{debug, error};
 use db_common::{owned_named_params,
-                sqlite::{rusqlite::{types::Value, Connection, OptionalExtension},
+                sqlite::{rusqlite::{Connection, OptionalExtension},
                          AsSqlNamedParams, OwnedSqlNamedParams}};
 use mm2_core::mm_ctx::MmArc;
 use std::collections::HashSet;

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -149,7 +149,8 @@ pub enum MmInitError {
     SwapsKickStartError(String),
     #[display(fmt = "Order kick start error: {}", _0)]
     OrdersKickStartError(String),
-    NullStringPassphrase,
+    #[display(fmt = "Passphrase cannot be an empty string")]
+    EmptyPassphrase,
     #[display(fmt = "Invalid passphrase: {}", _0)]
     InvalidPassphrase(String),
     #[from_trait(WithHwRpcError::hw_rpc_error)]
@@ -205,7 +206,7 @@ impl From<CryptoInitError> for MmInitError {
             e @ CryptoInitError::InitializedAlready | e @ CryptoInitError::NotInitialized => {
                 MmInitError::Internal(e.to_string())
             },
-            CryptoInitError::NullStringPassphrase => MmInitError::NullStringPassphrase,
+            CryptoInitError::EmptyPassphrase => MmInitError::EmptyPassphrase,
             CryptoInitError::InvalidPassphrase(pass) => MmInitError::InvalidPassphrase(pass.to_string()),
             CryptoInitError::InvalidHdAccount { error, .. } => MmInitError::FieldWrongValueInConfig {
                 field: "hd_account".to_string(),

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -281,8 +281,10 @@ fn default_seednodes(netid: u16) -> Vec<RelayAddress> {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn fix_directories(ctx: &MmCtx) -> MmInitResult<()> {
+    fix_shared_dbdir(ctx)?;
+
     let dbdir = ctx.dbdir();
-    std::fs::create_dir_all(&dbdir).map_to_mm(|e| MmInitError::ErrorCreatingDbDir {
+    fs::create_dir_all(&dbdir).map_to_mm(|e| MmInitError::ErrorCreatingDbDir {
         path: dbdir.clone(),
         error: e.to_string(),
     })?;
@@ -339,6 +341,17 @@ pub fn fix_directories(ctx: &MmCtx) -> MmInitResult<()> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+fn fix_shared_dbdir(ctx: &MmCtx) -> MmInitResult<()> {
+    let shared_db = ctx.shared_dbdir();
+    fs::create_dir_all(&shared_db).map_to_mm(|e| MmInitError::ErrorCreatingDbDir {
+        path: shared_db.clone(),
+        error: e.to_string(),
+    })?;
+
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 fn migrate_db(ctx: &MmArc) -> MmInitResult<()> {
     let migration_num_path = ctx.dbdir().join(".migration");
     let mut current_migration = match std::fs::read(&migration_num_path) {
@@ -378,6 +391,8 @@ pub async fn lp_init_continue(ctx: MmArc) -> MmInitResult<()> {
     {
         fix_directories(&ctx)?;
         ctx.init_sqlite_connection()
+            .map_to_mm(MmInitError::ErrorSqliteInitializing)?;
+        ctx.init_shared_sqlite_conn()
             .map_to_mm(MmInitError::ErrorSqliteInitializing)?;
         init_and_migrate_db(&ctx).await?;
         migrate_db(&ctx)?;

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -5158,20 +5158,26 @@ pub async fn my_orders(ctx: MmArc) -> Result<Response<Vec<u8>>, String> {
         .map_err(|e| ERRL!("{}", e))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn my_maker_orders_dir(ctx: &MmArc) -> PathBuf { ctx.dbdir().join("ORDERS").join("MY").join("MAKER") }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn my_taker_orders_dir(ctx: &MmArc) -> PathBuf { ctx.dbdir().join("ORDERS").join("MY").join("TAKER") }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn my_orders_history_dir(ctx: &MmArc) -> PathBuf { ctx.dbdir().join("ORDERS").join("MY").join("HISTORY") }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn my_maker_order_file_path(ctx: &MmArc, uuid: &Uuid) -> PathBuf {
     my_maker_orders_dir(ctx).join(format!("{}.json", uuid))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn my_taker_order_file_path(ctx: &MmArc, uuid: &Uuid) -> PathBuf {
     my_taker_orders_dir(ctx).join(format!("{}.json", uuid))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn my_order_history_file_path(ctx: &MmArc, uuid: &Uuid) -> PathBuf {
     my_orders_history_dir(ctx).join(format!("{}.json", uuid))
 }

--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -830,8 +830,10 @@ pub struct TransactionIdentifier {
     tx_hash: BytesJson,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn my_swaps_dir(ctx: &MmArc) -> PathBuf { ctx.dbdir().join("SWAPS").join("MY") }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn my_swap_file_path(ctx: &MmArc, uuid: &Uuid) -> PathBuf { my_swaps_dir(ctx).join(format!("{}.json", uuid)) }
 
 pub async fn insert_new_swap_to_db(

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -73,8 +73,10 @@ pub const MAKER_ERROR_EVENTS: [&str; 15] = [
 
 pub const MAKER_PAYMENT_SENT_LOG: &str = "Maker payment sent";
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn stats_maker_swap_dir(ctx: &MmArc) -> PathBuf { ctx.dbdir().join("SWAPS").join("STATS").join("MAKER") }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn stats_maker_swap_file_path(ctx: &MmArc, uuid: &Uuid) -> PathBuf {
     stats_maker_swap_dir(ctx).join(format!("{}.json", uuid))
 }

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -90,8 +90,10 @@ pub const TAKER_ERROR_EVENTS: [&str; 15] = [
 
 pub const WATCHER_MESSAGE_SENT_LOG: &str = "Watcher message sent...";
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn stats_taker_swap_dir(ctx: &MmArc) -> PathBuf { ctx.dbdir().join("SWAPS").join("STATS").join("TAKER") }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn stats_taker_swap_file_path(ctx: &MmArc, uuid: &Uuid) -> PathBuf {
     stats_taker_swap_dir(ctx).join(format!("{}.json", uuid))
 }

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -14,7 +14,8 @@ use coins::my_tx_history_v2::my_tx_history_v2_rpc;
 use coins::rpc_command::{account_balance::account_balance,
                          get_current_mtp::get_current_mtp_rpc,
                          get_enabled_coins::get_enabled_coins,
-                         get_new_address::get_new_address,
+                         get_new_address::{cancel_get_new_address, get_new_address, init_get_new_address,
+                                           init_get_new_address_status, init_get_new_address_user_action},
                          init_account_balance::{cancel_account_balance, init_account_balance,
                                                 init_account_balance_status},
                          init_create_account::{cancel_create_new_account, init_create_new_account,
@@ -225,6 +226,10 @@ async fn rpc_task_dispatcher(
         "enable_utxo::user_action" => {
             handle_mmrpc(ctx, request, init_standalone_coin_user_action::<UtxoStandardCoin>).await
         },
+        "get_new_address::cancel" => handle_mmrpc(ctx, request, cancel_get_new_address).await,
+        "get_new_address::init" => handle_mmrpc(ctx, request, init_get_new_address).await,
+        "get_new_address::status" => handle_mmrpc(ctx, request, init_get_new_address_status).await,
+        "get_new_address::user_action" => handle_mmrpc(ctx, request, init_get_new_address_user_action).await,
         "scan_for_new_addresses::cancel" => handle_mmrpc(ctx, request, cancel_scan_for_new_addresses).await,
         "scan_for_new_addresses::init" => handle_mmrpc(ctx, request, init_scan_for_new_addresses).await,
         "scan_for_new_addresses::status" => handle_mmrpc(ctx, request, init_scan_for_new_addresses_status).await,

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -8,7 +8,7 @@ use crate::mm2::rpc::rate_limiter::{process_rate_limit, RateLimitContext};
 use crate::{mm2::lp_stats::{add_node_to_version_stat, remove_node_from_version_stat, start_version_stat_collection,
                             stop_version_stat_collection, update_version_stat_collection},
             mm2::lp_swap::{recreate_swap_data, trade_preimage_rpc},
-            mm2::rpc::lp_commands::{get_public_key, get_public_key_hash}};
+            mm2::rpc::lp_commands::{get_public_key, get_public_key_hash, get_shared_db_id}};
 use coins::eth::EthCoin;
 use coins::my_tx_history_v2::my_tx_history_v2_rpc;
 use coins::rpc_command::{account_balance::account_balance,
@@ -161,6 +161,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "get_public_key" => handle_mmrpc(ctx, request, get_public_key).await,
         "get_public_key_hash" => handle_mmrpc(ctx, request, get_public_key_hash).await,
         "get_raw_transaction" => handle_mmrpc(ctx, request, get_raw_transaction).await,
+        "get_shared_db_id" => handle_mmrpc(ctx, request, get_shared_db_id).await,
         "get_staking_infos" => handle_mmrpc(ctx, request, get_staking_infos).await,
         "my_tx_history" => handle_mmrpc(ctx, request, my_tx_history_v2_rpc).await,
         "orderbook" => handle_mmrpc(ctx, request, orderbook_rpc_v2).await,

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -8,7 +8,7 @@ use crate::mm2::rpc::rate_limiter::{process_rate_limit, RateLimitContext};
 use crate::{mm2::lp_stats::{add_node_to_version_stat, remove_node_from_version_stat, start_version_stat_collection,
                             stop_version_stat_collection, update_version_stat_collection},
             mm2::lp_swap::{get_locked_amount_rpc, max_maker_vol, recreate_swap_data, trade_preimage_rpc},
-            mm2::rpc::lp_commands::{get_public_key, get_public_key_hash, get_shared_db_id}};
+            mm2::rpc::lp_commands::{get_public_key, get_public_key_hash, get_shared_db_id, trezor_connection_status}};
 use coins::eth::EthCoin;
 use coins::my_tx_history_v2::my_tx_history_v2_rpc;
 use coins::rpc_command::{account_balance::account_balance,
@@ -177,6 +177,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "stop_simple_market_maker_bot" => handle_mmrpc(ctx, request, stop_simple_market_maker_bot).await,
         "stop_version_stat_collection" => handle_mmrpc(ctx, request, stop_version_stat_collection).await,
         "trade_preimage" => handle_mmrpc(ctx, request, trade_preimage_rpc).await,
+        "trezor_connection_status" => handle_mmrpc(ctx, request, trezor_connection_status).await,
         "update_version_stat_collection" => handle_mmrpc(ctx, request, update_version_stat_collection).await,
         "verify_message" => handle_mmrpc(ctx, request, verify_message).await,
         "withdraw" => handle_mmrpc(ctx, request, withdraw).await,

--- a/mm2src/mm2_main/src/rpc/lp_commands/lp_commands.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/lp_commands.rs
@@ -1,5 +1,5 @@
 use common::HttpStatusCode;
-use crypto::{CryptoCtx, CryptoCtxError};
+use crypto::{CryptoCtx, CryptoCtxError, HwConnectionStatus, HwPubkey};
 use derive_more::Display;
 use http::StatusCode;
 use mm2_core::mm_ctx::MmArc;
@@ -57,4 +57,60 @@ pub struct GetSharedDbIdResponse {
 pub async fn get_shared_db_id(ctx: MmArc, _req: Json) -> GetSharedDbIdResult<GetSharedDbIdResponse> {
     let shared_db_id = ctx.shared_db_id().to_owned().into();
     Ok(GetSharedDbIdResponse { shared_db_id })
+}
+
+#[derive(Serialize, Display, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum TrezorConnectionError {
+    #[display(fmt = "Trezor hasn't been initialized yet")]
+    TrezorNotInitialized,
+    #[display(fmt = "Found unexpected device. Please re-initialize Hardware wallet")]
+    FoundUnexpectedDevice,
+    Internal(String),
+}
+
+impl From<CryptoCtxError> for TrezorConnectionError {
+    fn from(e: CryptoCtxError) -> Self { TrezorConnectionError::Internal(format!("'CryptoCtx' is not available: {e}")) }
+}
+
+impl HttpStatusCode for TrezorConnectionError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            TrezorConnectionError::TrezorNotInitialized => StatusCode::BAD_REQUEST,
+            TrezorConnectionError::FoundUnexpectedDevice | TrezorConnectionError::Internal(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            },
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct TrezorConnectionStatusReq {
+    /// Can be used to make sure that the Trezor device is expected.
+    device_pubkey: Option<HwPubkey>,
+}
+
+#[derive(Serialize)]
+pub struct TrezorConnectionStatusRes {
+    status: HwConnectionStatus,
+}
+
+pub async fn trezor_connection_status(
+    ctx: MmArc,
+    req: TrezorConnectionStatusReq,
+) -> MmResult<TrezorConnectionStatusRes, TrezorConnectionError> {
+    let crypto_ctx = CryptoCtx::from_ctx(&ctx)?;
+    let hw_ctx = crypto_ctx
+        .hw_ctx()
+        .or_mm_err(|| TrezorConnectionError::TrezorNotInitialized)?;
+
+    if let Some(expected) = req.device_pubkey {
+        if hw_ctx.hw_pubkey() != expected {
+            return MmError::err(TrezorConnectionError::FoundUnexpectedDevice);
+        }
+    }
+
+    Ok(TrezorConnectionStatusRes {
+        status: hw_ctx.trezor_connection_status().await,
+    })
 }

--- a/mm2src/mm2_main/src/rpc/lp_commands/lp_commands.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/lp_commands.rs
@@ -8,6 +8,8 @@ use rpc::v1::types::H160 as H160Json;
 use serde_json::Value as Json;
 
 pub type GetPublicKeyRpcResult<T> = Result<T, MmError<GetPublicKeyError>>;
+pub type GetSharedDbIdResult<T> = Result<T, MmError<GetSharedDbIdError>>;
+pub type GetSharedDbIdError = GetPublicKeyError;
 
 #[derive(Serialize, Display, SerializeErrorType)]
 #[serde(tag = "error_type", content = "error_data")]
@@ -45,4 +47,14 @@ pub struct GetPublicKeyHashResponse {
 pub async fn get_public_key_hash(ctx: MmArc, _req: Json) -> GetPublicKeyRpcResult<GetPublicKeyHashResponse> {
     let public_key_hash = ctx.rmd160().to_owned().into();
     Ok(GetPublicKeyHashResponse { public_key_hash })
+}
+
+#[derive(Serialize)]
+pub struct GetSharedDbIdResponse {
+    shared_db_id: H160Json,
+}
+
+pub async fn get_shared_db_id(ctx: MmArc, _req: Json) -> GetSharedDbIdResult<GetSharedDbIdResponse> {
+    let shared_db_id = ctx.shared_db_id().to_owned().into();
+    Ok(GetSharedDbIdResponse { shared_db_id })
 }

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -11,9 +11,9 @@ use mm2_test_helpers::electrums::*;
 use mm2_test_helpers::for_tests::init_z_coin_native;
 use mm2_test_helpers::for_tests::{btc_segwit_conf, btc_with_spv_conf, check_recent_swaps, check_stats_swap_status,
                                   enable_eth_coin, enable_qrc20, eth_jst_testnet_conf, eth_testnet_conf,
-                                  find_metrics_in_json, from_env_file, mm_spat, morty_conf, rick_conf, sign_message,
-                                  start_swaps, tbtc_with_spv_conf, test_qrc20_history_impl, tqrc20_conf,
-                                  verify_message, wait_for_swap_contract_negotiation,
+                                  find_metrics_in_json, from_env_file, get_shared_db_id, mm_spat, morty_conf,
+                                  rick_conf, sign_message, start_swaps, tbtc_with_spv_conf, test_qrc20_history_impl,
+                                  tqrc20_conf, verify_message, wait_for_swap_contract_negotiation,
                                   wait_for_swap_negotiation_failure, wait_for_swaps_finish_and_check_status,
                                   wait_till_history_has_records, MarketMakerIt, Mm2InitPrivKeyPolicy, Mm2TestConf,
                                   Mm2TestConfForSwap, RaiiDump, ETH_DEV_NODES, ETH_DEV_SWAP_CONTRACT,
@@ -7354,6 +7354,43 @@ fn test_enable_coins_with_hd_account_id() {
     assert_eq!(qrc20["address"].as_str(), Some("qY8FNq2ZDUh52BjNvaroFoeHdr3AAhqsxW"));
     let btc_segwit = block_on(enable_electrum(&mm_hd_1, "BTC-segwit", TX_HISTORY, RICK_ELECTRUM_ADDRS));
     assert_eq!(btc_segwit.address, "bc1q6kxcwcrsm5z8pe940xxu294q7588mqvarttxcx");
+}
+
+/// `shared_db_id` must be the same for Iguana and all HD accounts derived from the same passphrase.
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_get_shared_db_id() {
+    const PASSPHRASE: &str = "tank abandon bind salon remove wisdom net size aspect direct source fossil";
+    const ANOTHER_PASSPHRASE: &str = "chair lyrics public brick beauty wine panther deer employ panther poet drip";
+
+    let coins = json!([rick_conf()]);
+    let confs = vec![
+        Mm2TestConf::seednode(PASSPHRASE, &coins),
+        Mm2TestConf::seednode_with_hd_account(PASSPHRASE, 0, &coins),
+        Mm2TestConf::seednode_with_hd_account(PASSPHRASE, 1, &coins),
+    ];
+
+    let mut shared_db_id = None;
+    for conf in confs {
+        let mm = MarketMakerIt::start(conf.conf, conf.rpc_password, None).unwrap();
+        let actual = block_on(get_shared_db_id(&mm)).shared_db_id;
+        if let Some(expected) = shared_db_id {
+            assert_eq!(
+                actual, expected,
+                "'shared_db_id' must be the same for Iguana and all HD accounts derived from the same passphrase"
+            );
+        }
+        shared_db_id = Some(actual);
+    }
+
+    let another_conf = Mm2TestConf::seednode(ANOTHER_PASSPHRASE, &coins);
+    let mm_another = MarketMakerIt::start(another_conf.conf, another_conf.rpc_password, None).unwrap();
+    let actual = block_on(get_shared_db_id(&mm_another)).shared_db_id;
+    assert_ne!(
+        Some(actual),
+        shared_db_id,
+        "'shared_db_id' must be different for different passphrases"
+    );
 }
 
 #[test]

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -1,6 +1,7 @@
 //! Helpers used in the unit and integration tests.
 
 use crate::electrums::qtum_electrums;
+use crate::structs::{GetSharedDbIdResult, RpcSuccessResponse};
 use common::custom_futures::repeatable::{Ready, Retry};
 use common::executor::Timer;
 use common::log::debug;
@@ -2308,6 +2309,20 @@ pub async fn my_balance(mm: &MarketMakerIt, coin: &str) -> Json {
         .unwrap();
     assert_eq!(request.0, StatusCode::OK, "'my_balance' failed: {}", request.1);
     json::from_str(&request.1).unwrap()
+}
+
+pub async fn get_shared_db_id(mm: &MarketMakerIt) -> GetSharedDbIdResult {
+    let request = mm
+        .rpc(&json!({
+            "userpass": mm.userpass,
+            "method": "get_shared_db_id",
+            "mmrpc": "2.0",
+        }))
+        .await
+        .unwrap();
+    assert_eq!(request.0, StatusCode::OK, "'get_shared_db_id' failed: {}", request.1);
+    let res: RpcSuccessResponse<_> = json::from_str(&request.1).unwrap();
+    res.result
 }
 
 pub async fn enable_tendermint(

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -2347,7 +2347,6 @@ pub async fn max_maker_vol(mm: &MarketMakerIt, coin: &str) -> RpcResponse {
         }))
         .await
         .unwrap();
-    println!("{}", rc.1);
     RpcResponse::new("max_maker_vol", rc)
 }
 

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -753,8 +753,13 @@ pub fn mm_ctx_with_custom_db() -> MmArc {
     use std::sync::Arc;
 
     let ctx = MmCtxBuilder::new().into_mm_arc();
+
     let connection = Connection::open_in_memory().unwrap();
     let _ = ctx.sqlite_connection.pin(Arc::new(Mutex::new(connection)));
+
+    let connection = Connection::open_in_memory().unwrap();
+    let _ = ctx.shared_sqlite_conn.pin(Arc::new(Mutex::new(connection)));
+
     ctx
 }
 

--- a/mm2src/mm2_test_helpers/src/structs.rs
+++ b/mm2src/mm2_test_helpers/src/structs.rs
@@ -780,6 +780,12 @@ pub struct GetPublicKeyHashResult {
     pub public_key_hash: String,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetSharedDbIdResult {
+    pub shared_db_id: String,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RpcV2Response<T> {

--- a/mm2src/trezor/src/transport/mod.rs
+++ b/mm2src/trezor/src/transport/mod.rs
@@ -37,6 +37,9 @@ pub trait Transport {
 
     async fn write_message(&mut self, message: ProtoMessage) -> TrezorResult<()>;
     async fn read_message(&mut self) -> TrezorResult<ProtoMessage>;
+
+    #[cfg(target_arch = "wasm32")]
+    async fn is_connected(&mut self) -> TrezorResult<bool>;
 }
 
 /// The Trezor session identifier.

--- a/mm2src/trezor/src/transport/protocol.rs
+++ b/mm2src/trezor/src/transport/protocol.rs
@@ -32,6 +32,11 @@ pub struct ProtocolV1<L: Link> {
     pub link: L,
 }
 
+#[cfg(target_arch = "wasm32")]
+impl<L: Link> ProtocolV1<L> {
+    pub(crate) fn link(&self) -> &L { &self.link }
+}
+
 #[async_trait]
 impl<L: Link + Send> Protocol for ProtocolV1<L> {
     /// Protocol V1 doesn't support sessions.

--- a/wasm_build/script.js
+++ b/wasm_build/script.js
@@ -14,7 +14,7 @@ import init, {
     Mm2MainErr,
     MainStatus,
     Mm2RpcErr
-} from "./deps/pkg/mm2.js";
+} from "./deps/pkg/mm2lib.js";
 
 const LOG_LEVEL = LogLevel.Debug;
 


### PR DESCRIPTION
* Remove `mm2_rmd160` property from the HD account table. This is required so either Iguana or an HD account share the same HD account records. Fixes #1621
* Added new `task::get_new_address::*` RPCs that should replace the legacy `get_new_address` RPC. Fixes #1583 
* Added `trezor_connection_status` RPC to allow the GUI to poll the Trezor connection status #1642