### PR TITLE
[r2r] hotfix: add payment instructions success events to is_success check

### DIFF
--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -1613,6 +1613,7 @@ impl MakerSwapEvent {
             self,
             MakerSwapEvent::Started(_)
                 | MakerSwapEvent::Negotiated(_)
+                | MakerSwapEvent::MakerPaymentInstructionsReceived(_)
                 | MakerSwapEvent::TakerFeeValidated(_)
                 | MakerSwapEvent::MakerPaymentSent(_)
                 | MakerSwapEvent::TakerPaymentReceived(_)

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -662,6 +662,7 @@ impl TakerSwapEvent {
             TakerSwapEvent::Started(_)
                 | TakerSwapEvent::Negotiated(_)
                 | TakerSwapEvent::TakerFeeSent(_)
+                | TakerSwapEvent::TakerPaymentInstructionsReceived(_)
                 | TakerSwapEvent::MakerPaymentReceived(_)
                 | TakerSwapEvent::MakerPaymentWaitConfirmStarted
                 | TakerSwapEvent::WatcherMessageSent(_, _)


### PR DESCRIPTION
fixes #1637