### PR TITLE
[wip] Fix `disable_coin`

### DIFF
--- a/mm2src/mm2_main/tests/docker_tests/slp_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/slp_tests.rs
@@ -1,8 +1,8 @@
 use crate::docker_tests::docker_tests_common::*;
 use crate::integration_tests_common::enable_native;
-use http::StatusCode;
 use mm2_number::BigDecimal;
-use mm2_test_helpers::for_tests::{enable_bch_with_tokens, enable_slp, UtxoRpcMode};
+use mm2_test_helpers::for_tests::{assert_coin_not_found_on_balance, disable_coin, disable_platform_coin_err,
+                                  enable_bch_with_tokens, enable_slp, my_balance, UtxoRpcMode};
 use mm2_test_helpers::structs::{EnableBchWithTokensResponse, EnableElectrumResponse, EnableSlpResponse, RpcV2Response};
 use serde_json::{self as json};
 use std::time::Duration;
@@ -151,27 +151,6 @@ fn test_withdraw_bch_max_must_not_spend_slp() {
 
 #[test]
 fn test_disable_platform_coin_with_tokens() {
-    fn assert_coin_not_found_on_balance(mm: &MarketMakerIt, token: &str) {
-        let balance = block_on(mm.rpc(&json! ({
-            "userpass": mm.userpass,
-            "method": "my_balance",
-            "coin": token
-        })))
-        .unwrap();
-        assert_eq!(balance.0, StatusCode::INTERNAL_SERVER_ERROR);
-        assert!(balance.1.contains(&format!("No such coin: {token}")));
-    }
-
-    fn assert_ok_200(mm: &MarketMakerIt, token: &str, method: &str) {
-        let disable = block_on(mm.rpc(&json! ({
-            "userpass": mm.userpass,
-            "method": method,
-            "coin": token,
-        })))
-        .unwrap();
-        assert_eq!(disable.0, StatusCode::OK);
-    }
-
     let mm = slp_supplied_node();
     let _ = block_on(enable_bch_with_tokens(
         &mm,
@@ -181,13 +160,13 @@ fn test_disable_platform_coin_with_tokens() {
         false,
     ));
     // Try to disable ADEXSLP token.
-    assert_ok_200(&mm, "ADEXSLP", "disable_coin");
+    block_on(disable_coin(&mm, "ADEXSLP", None));
     // Check if platform_coin FORSLP is still enabled.
-    assert_ok_200(&mm, "FORSLP", "my_balance");
+    block_on(my_balance(&mm, "FORSLP"));
     // Check if ADEXSLP token still enabled.
-    assert_coin_not_found_on_balance(&mm, "ADEXSLP");
-    // // Try to disable patform_coin.
-    assert_ok_200(&mm, "FORSLP", "disable_coin");
+    block_on(assert_coin_not_found_on_balance(&mm, "ADEXSLP"));
+    // Try to disable patform_coin.
+    block_on(disable_coin(&mm, "FORSLP", None));
 
     // Enable enable_bch_with_tokens again to restart the process
     let _ = block_on(enable_bch_with_tokens(
@@ -197,10 +176,16 @@ fn test_disable_platform_coin_with_tokens() {
         UtxoRpcMode::Native,
         false,
     ));
-    // Try to disable platform_coin.
-    assert_ok_200(&mm, "FORSLP", "disable_coin");
-    // Check if platform_coin FORSLP is still enabled.
-    assert_coin_not_found_on_balance(&mm, "FORSLP");
-    // Check if ADEXSLP token is still enabled.
-    assert_coin_not_found_on_balance(&mm, "ADEXSLP");
+    // Try to disable platform coin, FORSLP. This should fail without the `disable_tokens` flag.
+    block_on(disable_platform_coin_err(&mm, "FORSLP"));
+
+    // Try to disable platform coin, FORSLP, with the `disable_tokens` flag.
+    // FORSLP and ADEXSLP should be deactivated at once.
+    let res = block_on(disable_coin(&mm, "FORSLP", Some(true)));
+    assert!(res.tokens.contains("ADEXSLP"));
+
+    // Check if platform_coin FORSLP is not active anymore.
+    block_on(assert_coin_not_found_on_balance(&mm, "FORSLP"));
+    // Check if ADEXSLP token is not active anymore.
+    block_on(assert_coin_not_found_on_balance(&mm, "ADEXSLP"));
 }

--- a/mm2src/mm2_main/tests/docker_tests/solana_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/solana_tests.rs
@@ -1,7 +1,7 @@
 use crate::docker_tests::docker_tests_common::*;
-use http::StatusCode;
 use mm2_number::bigdecimal::Zero;
-use mm2_test_helpers::for_tests::{enable_solana_with_tokens, enable_spl, sign_message, verify_message};
+use mm2_test_helpers::for_tests::{assert_coin_not_found_on_balance, disable_coin, disable_platform_coin_err,
+                                  enable_solana_with_tokens, enable_spl, sign_message, verify_message};
 use mm2_test_helpers::structs::{EnableSolanaWithTokensResponse, EnableSplResponse, RpcV2Response, SignatureResponse,
                                 VerificationResponse};
 use serde_json as json;
@@ -125,41 +125,21 @@ fn test_disable_solana_platform_coin_with_tokens() {
     ));
     block_on(enable_spl(&mm, "ADEX-SOL-DEVNET"));
 
-    // Try to disable platform coin, SOL-DEVNET
-    let disable = block_on(mm.rpc(&json! ({
-        "userpass": mm.userpass,
-        "method": "disable_coin",
-        "coin": "SOL-DEVNET",
-    })))
-    .unwrap();
-    assert_eq!(disable.0, StatusCode::OK);
+    // Try to disable platform coin, SOL-DEVNET. This should fail without the `disable_tokens` flag.
+    block_on(disable_platform_coin_err(&mm, "SOL-DEVNET"));
 
-    // Confirm that token, USDC-SOL-DEVNET is also disabled
-    let response = block_on(mm.rpc(&json! ({
-        "userpass": mm.userpass,
-        "method": "my_balance",
-        "coin": "USDC-SOL-DEVNET"
-    })))
-    .unwrap();
-    assert_eq!(response.0, StatusCode::INTERNAL_SERVER_ERROR);
-    assert!(response.1.contains("No such coin: USDC-SOL-DEVNET"));
+    // Try to disable platform coin, SOL-DEVNET, with the `disable_tokens` flag.
+    // SOL-DEVNET, USDC-SOL-DEVNET and ADEX-SOL-DEVNET should be deactivated at once.
+    let res = block_on(disable_coin(&mm, "SOL-DEVNET", Some(true)));
 
-    // Confirm that token, ADEX-SOL-DEVNET is also disabled
-    let response = block_on(mm.rpc(&json! ({
-        "userpass": mm.userpass,
-        "method": "my_balance",
-        "coin": "ADEX-SOL-DEVNET"
-    })))
-    .unwrap();
-    assert_eq!(response.0, StatusCode::INTERNAL_SERVER_ERROR);
-    assert!(response.1.contains("No such coin: ADEX-SOL-DEVNET"));
+    // Confirm that token, USDC-SOL-DEVNET is also disabled.
+    assert!(res.tokens.contains("USDC-SOL-DEVNET"));
+    block_on(assert_coin_not_found_on_balance(&mm, "USDC-SOL-DEVNET"));
 
-    // Confirm that platform coin, SOL-DEVNET is also disabled
-    let response = block_on(mm.rpc(&json! ({
-        "userpass": mm.userpass,
-        "method": "my_balance",
-        "coin": "SOL-DEVNET"
-    })))
-    .unwrap();
-    assert_eq!(response.0, StatusCode::INTERNAL_SERVER_ERROR);
+    // Confirm that token, ADEX-SOL-DEVNET is also disabled.
+    assert!(res.tokens.contains("ADEX-SOL-DEVNET"));
+    block_on(assert_coin_not_found_on_balance(&mm, "ADEX-SOL-DEVNET"));
+
+    // Confirm that token, SOL-DEVNET is disabled.
+    block_on(assert_coin_not_found_on_balance(&mm, "SOL-DEVNET"));
 }

--- a/mm2src/mm2_main/tests/mm2_tests/bch_and_slp_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/bch_and_slp_tests.rs
@@ -2,7 +2,7 @@ use common::custom_futures::repeatable::{Ready, Retry};
 use common::{block_on, log, repeatable};
 use http::StatusCode;
 use itertools::Itertools;
-use mm2_test_helpers::for_tests::{enable_bch_with_tokens, enable_slp, my_tx_history_v2, sign_message,
+use mm2_test_helpers::for_tests::{disable_coin, enable_bch_with_tokens, enable_slp, my_tx_history_v2, sign_message,
                                   tbch_for_slp_conf, tbch_usdf_conf, verify_message, MarketMakerIt, Mm2TestConf,
                                   UtxoRpcMode};
 use mm2_test_helpers::structs::{EnableBchWithTokensResponse, RpcV2Response, SignatureResponse, StandardHistoryV2Res,
@@ -170,13 +170,7 @@ fn test_withdraw_cashaddresses() {
     thread::sleep(Duration::from_secs(5));
 
     //Disable BCH to enable in Legacy Mode
-    let rc = block_on(mm.rpc(&json!({
-        "userpass": mm.userpass,
-        "method": "disable_coin",
-        "coin": "BCH",
-    })))
-    .unwrap();
-    assert_eq!(rc.0, StatusCode::OK, "RPC «disable_coin» failed with status «{}»", rc.0);
+    block_on(disable_coin(&mm, "BCH", None));
 
     let electrum = block_on(mm.rpc(&json! ({
         "userpass": mm.userpass,

--- a/mm2src/mm2_main/tests/mm2_tests/eth_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/eth_tests.rs
@@ -1,6 +1,7 @@
 use common::block_on;
 use http::StatusCode;
-use mm2_test_helpers::for_tests::{get_passphrase, MarketMakerIt, Mm2TestConf, ETH_DEV_NODES};
+use mm2_test_helpers::for_tests::{assert_coin_not_found_on_balance, disable_coin, disable_platform_coin_err,
+                                  get_passphrase, MarketMakerIt, Mm2TestConf, ETH_DEV_NODES};
 use serde_json::{json, Value as Json};
 use std::str::FromStr;
 
@@ -64,24 +65,15 @@ fn test_disable_eth_coin_with_token() {
     let order_uuid = Json::from_str(&*make_test_order.1).unwrap();
     let order_uuid = order_uuid.get("result").unwrap().get("uuid").unwrap().as_str().unwrap();
 
-    // Disable platform coin ETH
-    let disable = block_on(mm.rpc(&json!({
-        "userpass": mm.userpass,
-        "method": "disable_coin",
-        "coin": "ETH",
-    })))
-    .unwrap();
-    assert_eq!(disable.0, StatusCode::OK);
-    // We expected make_test_order to be cancelled
-    assert!(disable.1.contains(order_uuid));
+    // Try to disable platform coin, ETH. This should fail without the `disable_tokens` flag.
+    block_on(disable_platform_coin_err(&mm, "ETH"));
 
-    // We also expected token, "JST" to be deactivated
-    let my_balance = block_on(mm.rpc(&json!({
-        "userpass": mm.userpass,
-        "method": "my_balance",
-        "coin": "JST",
-    })))
-    .unwrap();
-    assert_eq!(my_balance.0, StatusCode::INTERNAL_SERVER_ERROR);
-    assert!(my_balance.1.contains("No such coin: JST"));
+    // Try to disable platform coin, ETH, with the `disable_tokens` flag.
+    // ETH and JST should be deactivated at once.
+    let res = block_on(disable_coin(&mm, "ETH", Some(true)));
+    // We expected make_test_order to be cancelled
+    assert!(res.cancelled_orders.contains(order_uuid));
+    // Confirm that JST is also disabled.
+    assert!(res.tokens.contains("JST"));
+    block_on(assert_coin_not_found_on_balance(&mm, "JST"));
 }

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -2332,6 +2332,53 @@ pub async fn max_maker_vol(mm: &MarketMakerIt, coin: &str) -> RpcResponse {
     RpcResponse::new("max_maker_vol", rc)
 }
 
+pub async fn disable_coin(mm: &MarketMakerIt, coin: &str, disable_tokens: Option<bool>) -> DisableResult {
+    let mut req = json! ({
+        "userpass": mm.userpass,
+        "method": "disable_coin",
+        "coin": coin,
+    });
+    if let Some(disable_tokens) = disable_tokens {
+        req["disable_tokens"] = Json::Bool(disable_tokens);
+    }
+
+    let disable = mm.rpc(&req).await.unwrap();
+    assert_eq!(disable.0, StatusCode::OK, "!disable_coin: {}", disable.1);
+    let res: Json = json::from_str(&disable.1).unwrap();
+    json::from_value(res["result"].clone()).unwrap()
+}
+
+/// Checks whether the `disable_coin` RPC fails due to the following error:
+/// "There are tokens dependent on '$TICKER'".
+pub async fn disable_platform_coin_err(mm: &MarketMakerIt, coin: &str) {
+    let disable = mm
+        .rpc(&json! ({
+            "userpass": mm.userpass,
+            "method": "disable_coin",
+            "coin": coin,
+        }))
+        .await
+        .unwrap();
+    assert!(
+        !disable.0.is_success(),
+        "'disable_coin' should have failed without 'disable_tokens' flag"
+    );
+    assert!(disable.1.contains(&format!("There are tokens dependent on '{coin}'")));
+}
+
+pub async fn assert_coin_not_found_on_balance(mm: &MarketMakerIt, coin: &str) {
+    let balance = mm
+        .rpc(&json! ({
+            "userpass": mm.userpass,
+            "method": "my_balance",
+            "coin": coin
+        }))
+        .await
+        .unwrap();
+    assert_eq!(balance.0, StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(balance.1.contains(&format!("No such coin: {coin}")));
+}
+
 pub async fn enable_tendermint(
     mm: &MarketMakerIt,
     coin: &str,

--- a/mm2src/mm2_test_helpers/src/structs.rs
+++ b/mm2src/mm2_test_helpers/src/structs.rs
@@ -1151,3 +1151,11 @@ pub struct WatcherConf {
     #[serde(default = "common::three_hundred_f64")]
     pub search_interval: f64,
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct DisableResult {
+    pub coin: String,
+    pub cancelled_orders: HashSet<String>,
+    pub tokens: HashSet<String>,
+}


### PR DESCRIPTION
`disable_coin` should fail if there are tokens dependent on the platform.

* Also add an option to disable such tokens by specifying the `disable_tokens` parameter.