### PR TITLE
Bugfix pubkey impersonation via keepalive

### DIFF
--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -201,6 +201,7 @@ fn process_pubkey_full_trie(
             order,
             params.protocol_infos.get(&uuid).cloned().unwrap_or_default(),
             params.conf_infos.get(&uuid).cloned(),
+            params.pubkey.into()
         ));
     }
 
@@ -223,6 +224,7 @@ fn process_trie_delta(
                 order,
                 params.protocol_infos.get(&uuid).cloned().unwrap_or_default(),
                 params.conf_infos.get(&uuid).cloned(),
+                params.pubkey.into()
             )),
             None => {
                 orderbook.remove_order_trie_update(uuid);
@@ -4157,9 +4159,10 @@ impl OrderbookItem {
         o: OrderbookP2PItem,
         proto_info: BaseRelProtocolInfo,
         conf_info: Option<OrderConfirmationsSettings>,
+        from_pubkey: String
     ) -> Self {
         OrderbookItem {
-            pubkey: o.pubkey,
+            pubkey: from_pubkey,
             base: o.base,
             rel: o.rel,
             price: o.price,

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -201,7 +201,7 @@ fn process_pubkey_full_trie(
             order,
             params.protocol_infos.get(&uuid).cloned().unwrap_or_default(),
             params.conf_infos.get(&uuid).cloned(),
-            params.pubkey.into()
+            params.pubkey.into(),
         ));
     }
 
@@ -224,7 +224,7 @@ fn process_trie_delta(
                 order,
                 params.protocol_infos.get(&uuid).cloned().unwrap_or_default(),
                 params.conf_infos.get(&uuid).cloned(),
-                params.pubkey.into()
+                params.pubkey.into(),
             )),
             None => {
                 orderbook.remove_order_trie_update(uuid);
@@ -4159,7 +4159,7 @@ impl OrderbookItem {
         o: OrderbookP2PItem,
         proto_info: BaseRelProtocolInfo,
         conf_info: Option<OrderConfirmationsSettings>,
-        from_pubkey: String
+        from_pubkey: String,
     ) -> Self {
         OrderbookItem {
             pubkey: from_pubkey,

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -201,7 +201,7 @@ fn process_pubkey_full_trie(
             order,
             params.protocol_infos.get(&uuid).cloned().unwrap_or_default(),
             params.conf_infos.get(&uuid).cloned(),
-            params.pubkey.into(),
+            params.pubkey.to_owned(),
         ));
     }
 

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -224,7 +224,7 @@ fn process_trie_delta(
                 order,
                 params.protocol_infos.get(&uuid).cloned().unwrap_or_default(),
                 params.conf_infos.get(&uuid).cloned(),
-                params.pubkey.into(),
+                params.pubkey.to_owned(),
             )),
             None => {
                 orderbook.remove_order_trie_update(uuid);

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -2302,7 +2302,8 @@ fn test_process_sync_pubkey_orderbook_state_after_new_orders_added() {
             (
                 *uuid.as_bytes(),
                 order.map(|o| {
-                    let o = OrderbookItem::from_p2p_and_info(o, BaseRelProtocolInfo::default(), None, order.pubkey);
+                    let from_pubkey = o.pubkey.clone();
+                    let o = OrderbookItem::from_p2p_and_info(o, BaseRelProtocolInfo::default(), None, from_pubkey);
                     o.trie_state_bytes()
                 }),
             )

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -1731,7 +1731,7 @@ fn test_process_get_orderbook_request() {
                     order.clone(),
                     BaseRelProtocolInfo::default(),
                     Some(OrderConfirmationsSettings::default()),
-                    order.pubkey,
+                    order.pubkey.clone(),
                 )
             })
             .collect();

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -1731,7 +1731,7 @@ fn test_process_get_orderbook_request() {
                     order.clone(),
                     BaseRelProtocolInfo::default(),
                     Some(OrderConfirmationsSettings::default()),
-                    order.pubkey
+                    order.pubkey,
                 )
             })
             .collect();

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -1731,6 +1731,7 @@ fn test_process_get_orderbook_request() {
                     order.clone(),
                     BaseRelProtocolInfo::default(),
                     Some(OrderConfirmationsSettings::default()),
+                    order.pubkey
                 )
             })
             .collect();
@@ -2301,7 +2302,7 @@ fn test_process_sync_pubkey_orderbook_state_after_new_orders_added() {
             (
                 *uuid.as_bytes(),
                 order.map(|o| {
-                    let o = OrderbookItem::from_p2p_and_info(o, BaseRelProtocolInfo::default(), None);
+                    let o = OrderbookItem::from_p2p_and_info(o, BaseRelProtocolInfo::default(), None, order.pubkey);
                     o.trie_state_bytes()
                 }),
             )


### PR DESCRIPTION
This fixes several issues with the PubkeyKeepAlive network message type.

Prior to this fix, the `pubkey` value inside `OrderbookItem` objects could differ from the pubkey that signed the network message. 

Impersonating pubkeys was possible by sending the target a `PubkeyKeepAlive` message and responding with a fabricated `OrderbookItem` object. The `pubkey` value of this `OrderbookItem` object was not validated against the pubkey signing the network message. The code of this PR addresses this disparity between the `pubkey` value inside the `OrderbookItem` and the pubkey that signed the incoming network message.

A bad actor could place orders from pubkeys they did not own. These were generally benign other than spamming the network with orders that will never fulfill. 

A bad actor could broadcast these fabricated orders to a target and use the target's own pubkey. The target would confuse these orders with their own(based on the `ismine` flag) and begin broadcasting them via keepalives. This allowed the bad actor to force the target to begin spamming the network with invalid orders.

A bad actor could also send enough invalid orders to break the networking stack of the target. This would break the target's ability to broadcast valid orders. e.g.
```shell
25 16:43:29, libp2p_core:apply:155] DEBUG Failed to apply negotiated protocol
25 16:43:29, libp2p_swarm:lib:767] DEBUG Connection closed with error Handler(A(A(B(Upgrade(Apply(Custom { kind: InvalidData, error: "Try to send data size over maximum" })))))): Connected { endpoint: Listener { local_addr: "/ip4/192.168.1.155/tcp/38891", send_back_addr: "/ip4/192.168.1.154/tcp/56453" }, peer_id: PeerId("12D3KooWKt2XQz2gjRHYiyVSEsjPzVCGjyv873xsSQqUFdki8vPN") }; Total (peer): 0.
25 16:43:29, atomicdex_gossipsub:behaviour:1332] DEBUG Peer disconnected: PeerId("12D3KooWKt2XQz2gjRHYiyVSEsjPzVCGjyv873xsSQqUFdki8vPN")
25 16:43:29, atomicdex_behaviour:781] DEBUG Swarm event ConnectionClosed { peer_id: PeerId("12D3KooWKt2XQz2gjRHYiyVSEsjPzVCGjyv873xsSQqUFdki8vPN"), endpoint: Listener { local_addr: "/ip4/192.168.1.155/tcp/38891", send_back_addr: "/ip4/192.168.1.154/tcp/56453" }, num_established: 0, cause: Some(Handler(A(A(B(Upgrade(Apply(Custom { kind: InvalidData, error: "Try to send data size over maximum" }))))))) }
25 16:43:29, request_response:175] ERROR Error on receive a request: ConnectionClosed
```

Finally, this allowed sending invalid orders to a target that would break the target's ability to display the orderbooks. This is a result of the `pubkey` value inside `OrderbookItem` being a `String`. Sending a fabricated order with a `String` is not valid hex would result in the target being unable to display the orderbooks for a given pair.  e.g.
```shell
{"error":"rpc:211] dispatcher_legacy:141] orderbook_rpc:155] utxo:1859] Invalid character 'g' at position 0"}
```

We should discuss changing the `OrderbookItem` struct to use `PublicKey` type instead of a `String` to avoid any similar issues in the future. 

