### PR TITLE
[r2r] improve rpc client rotation of tendermint

### DIFF
--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -190,13 +190,13 @@ impl RpcCommonOps for TendermintCoin {
                 },
                 Ok(Err(rpc_error)) => {
                     debug!(
-                        "Could not perform healthcheck on: {:?}. Error: {:?}",
+                        "Could not perform healthcheck on: {:?}. Error: {}",
                         &client, rpc_error
                     );
                 },
                 Err(timeout_error) => {
                     debug!(
-                        "Healthcheck timeout exceed on: {:?}. Error: {:?}",
+                        "Healthcheck timeout exceed on: {:?}. Error: {}",
                         &client, timeout_error
                     );
                 },

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -189,16 +189,10 @@ impl RpcCommonOps for TendermintCoin {
                     return Ok(client);
                 },
                 Ok(Err(rpc_error)) => {
-                    debug!(
-                        "Could not perform healthcheck on: {:?}. Error: {}",
-                        &client, rpc_error
-                    );
+                    debug!("Could not perform healthcheck on: {:?}. Error: {}", &client, rpc_error);
                 },
                 Err(timeout_error) => {
-                    debug!(
-                        "Healthcheck timeout exceed on: {:?}. Error: {}",
-                        &client, timeout_error
-                    );
+                    debug!("Healthcheck timeout exceed on: {:?}. Error: {}", &client, timeout_error);
                 },
             };
         }

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 use bitcrypto::{dhash160, sha256};
 use common::executor::{abortable_queue::AbortableQueue, AbortableSystem};
 use common::executor::{AbortedError, Timer};
-use common::log::warn;
+use common::log::{debug, warn};
 use common::{get_utc_timestamp, now_ms, Future01CompatExt, DEX_FEE_ADDR_PUBKEY};
 use cosmrs::bank::MsgSend;
 use cosmrs::crypto::secp256k1::SigningKey;
@@ -182,16 +182,25 @@ impl RpcCommonOps for TendermintCoin {
         let mut client_impl = self.client.0.lock().await;
         // try to find first live client
         for (i, client) in client_impl.rpc_clients.clone().into_iter().enumerate() {
-            if client
-                .perform(HealthRequest)
-                .timeout(Duration::from_secs(3))
-                .await
-                .is_ok()
-            {
-                // Bring the live client to the front of rpc_clients
-                client_impl.rpc_clients.rotate_left(i);
-                return Ok(client);
-            }
+            match client.perform(HealthRequest).timeout(Duration::from_secs(5)).await {
+                Ok(Ok(_)) => {
+                    // Bring the live client to the front of rpc_clients
+                    client_impl.rpc_clients.rotate_left(i);
+                    return Ok(client);
+                },
+                Ok(Err(rpc_error)) => {
+                    debug!(
+                        "Could not perform healthcheck on: {:?}. Error: {:?}",
+                        &client, rpc_error
+                    );
+                },
+                Err(timeout_error) => {
+                    debug!(
+                        "Healthcheck timeout exceed on: {:?}. Error: {:?}",
+                        &client, timeout_error
+                    );
+                },
+            };
         }
         return Err(TendermintCoinRpcError::RpcClientError(
             "All the current rpc nodes are unavailable.".to_string(),


### PR DESCRIPTION
Previous implementation was only checking timeout error, with this change we also check the healthcheck result. And print friendly debug messages.

Also increased timeout to 5 seconds from 3.