### PR TITLE
Add workflow for VirusTotal results

### DIFF
--- a/.github/workflows/virustotal_scan.yml
+++ b/.github/workflows/virustotal_scan.yml
@@ -1,0 +1,18 @@
+name: VirusTotal Scan
+
+on:
+  release:
+    types: [created, edited, released, published]
+
+jobs:
+  virustotal:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: VirusTotal Scan
+        uses: crazy-max/ghaction-virustotal@v3
+        with:
+          vt_api_key: ${{ secrets.VT_API_KEY }}
+          update_release_body: true
+          files: |
+            .zip$


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/atomicDEX-API/issues/790

I've added my VirusTotal API key to github secrets for this repo.
Tested workflow in fork at https://github.com/smk762/atomicDEX-API/actions
Example results at https://github.com/smk762/atomicDEX-API/releases/tag/test

Current triggers will initiate workflow whenever a release is created, edited, prereleased or published. In testing, it was found that the VirusTotal results will append to the release body, which will result in duplicated VirusTotal results section if prior results not deleted. 

We can limit the triggers, or just make sure to remove old results from the release body text when edits are made (e.g. file uploads, adding changelog etc).


