### PR TITLE
[r2r] Better error message for failing swaps due to a time difference between maker and taker

### DIFF
--- a/dev-logs/2023-feb/fixes/fix_swap_time_difference_err_message
+++ b/dev-logs/2023-feb/fixes/fix_swap_time_difference_err_message
@@ -1,0 +1,4 @@
+Changed the error message for failing swaps due to a time difference between maker and taker to a more informative one
+
+
+author: @shamardy <shamardy@gmail.com>

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -597,7 +597,7 @@ impl MakerSwap {
         if time_dif > 60 {
             self.broadcast_negotiated_false();
             return Ok((Some(MakerSwapCommand::Finish), vec![MakerSwapEvent::NegotiateFailed(
-                ERRL!("Started_at time_dif over 60 {}", time_dif).into(),
+                ERRL!("There is a time difference of {} seconds between when you and the other side started the swap, please make sure that your system clock is synced to the correct time before starting another swap!", time_dif).into(),
             )]));
         }
 

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -597,7 +597,7 @@ impl MakerSwap {
         if time_dif > 60 {
             self.broadcast_negotiated_false();
             return Ok((Some(MakerSwapCommand::Finish), vec![MakerSwapEvent::NegotiateFailed(
-                ERRL!("There is a time difference of {} seconds between when you and the other side started the swap, please make sure that your system clock is synced to the correct time before starting another swap!", time_dif).into(),
+                ERRL!("The time difference between you and the taker cannot be longer than 60 seconds. Current difference: {}. Please make sure that your system clock is synced to the correct time before starting another swap!", time_dif).into(),
             )]));
         }
 

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1053,7 +1053,7 @@ impl TakerSwap {
         let time_dif = self.r().data.started_at.abs_diff(maker_data.started_at());
         if time_dif > 60 {
             return Ok((Some(TakerSwapCommand::Finish), vec![TakerSwapEvent::NegotiateFailed(
-                ERRL!("There is a time difference of {} seconds between when you and the other side started the swap, please make sure that your system clock is synced to the correct time before starting another swap!", time_dif).into(),
+                ERRL!("The time difference between you and the maker cannot be longer than 60 seconds. Current difference: {}. Please make sure that your system clock is synced to the correct time before starting another swap!", time_dif).into(),
             )]));
         }
 

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1053,7 +1053,7 @@ impl TakerSwap {
         let time_dif = self.r().data.started_at.abs_diff(maker_data.started_at());
         if time_dif > 60 {
             return Ok((Some(TakerSwapCommand::Finish), vec![TakerSwapEvent::NegotiateFailed(
-                ERRL!("Started_at time_dif over 60 {}", time_dif).into(),
+                ERRL!("There is a time difference of {} seconds between when you and the other side started the swap, please make sure that your system clock is synced to the correct time before starting another swap!", time_dif).into(),
             )]));
         }
 


### PR DESCRIPTION
https://github.com/KomodoPlatform/atomicDEX-API/issues/1115#issuecomment-1443738940