### PR TITLE
[r2r] Update pirate & zombie domains for tests

### DIFF
--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -124,10 +124,10 @@ pub const MORTY_ELECTRUM_ADDRS: &[&str] = &[
 ];
 pub const ZOMBIE_TICKER: &str = "ZOMBIE";
 pub const ARRR: &str = "ARRR";
-pub const ZOMBIE_ELECTRUMS: &[&str] = &["zombie.sirseven.me:10033"];
-pub const ZOMBIE_LIGHTWALLETD_URLS: &[&str] = &["http://zombie.sirseven.me:443"];
-pub const PIRATE_ELECTRUMS: &[&str] = &["pirate.sirseven.me:10032"];
-pub const PIRATE_LIGHTWALLETD_URLS: &[&str] = &["http://pirate.sirseven.me:443"];
+pub const ZOMBIE_ELECTRUMS: &[&str] = &["zombie.dragonhound.info:10033"];
+pub const ZOMBIE_LIGHTWALLETD_URLS: &[&str] = &["http://zombie.dragonhound.info:443"];
+pub const PIRATE_ELECTRUMS: &[&str] = &["pirate.dragonhound.info:10032"];
+pub const PIRATE_LIGHTWALLETD_URLS: &[&str] = &["http://pirate.dragonhound.info:443"];
 pub const DEFAULT_RPC_PASSWORD: &str = "pass";
 pub const QRC20_ELECTRUMS: &[&str] = &[
     "electrum1.cipig.net:10071",


### PR DESCRIPTION
Test are passing locally except for `test qrc20::qrc20_tests::test_wait_for_confirmations_excepted ... FAILED` which is unrelated to these changes.