### PR TITLE
get rid of crossterm and crates dependent on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - A bug was fixed in [#1706](https://github.com/KomodoPlatform/atomicDEX-API/pull/1706) where EVM swap transactions were failing if sent before the approval transaction confirmation.
 - Tendermint account sequence problem due to running multiple instances were fixed in [#1694](https://github.com/KomodoPlatform/atomicDEX-API/pull/1694)
 - Maker/taker pubkeys were added to new columns in `stats_swaps` table in [#1665](https://github.com/KomodoPlatform/atomicDEX-API/pull/1665)
+- Get rid of unnecessary / old dependencies: `crossterm`, `crossterm_winapi`, `mio 0.7.13`, `miow`, `ntapi`, `signal-hook`, `signal-hook-mio` in [#1710](https://github.com/KomodoPlatform/atomicDEX-API/pull/1710)
 
 ## v1.0.0-beta - 2023-03-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "crossbeam",
- "crossterm",
  "findshlibs",
  "fnv",
  "futures 0.1.29",
@@ -1474,31 +1473,6 @@ checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "libc",
- "mio 0.7.13",
- "parking_lot 0.11.1",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -2709,7 +2683,6 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e38a0ee5e8e3debd1336135939e6615d283b8375fab2f99d8b89dba718502212"
 dependencies = [
- "crossterm",
  "lazy_static",
  "libc",
 ]
@@ -4122,19 +4095,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
-dependencies = [
- "libc",
- "log 0.4.14",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
@@ -4143,15 +4103,6 @@ dependencies = [
  "log 0.4.14",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -4537,7 +4488,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "common",
- "crossterm",
  "crypto",
  "db_common",
  "futures 0.3.15",
@@ -4681,15 +4631,6 @@ dependencies = [
  "lexical-core",
  "memchr",
  "version_check",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -6536,27 +6477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
-dependencies = [
- "libc",
- "mio 0.7.13",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8097,7 +8017,7 @@ dependencies = [
  "bytes 1.1.0",
  "libc",
  "memchr",
- "mio 0.8.6",
+ "mio",
  "num_cpus",
  "parking_lot 0.12.0",
  "pin-project-lite 0.2.9",

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -58,8 +58,7 @@ web-sys = { version = "0.3.55", features = ["console", "CloseEvent", "DomExcepti
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 anyhow = "1.0"
 chrono = "0.4"
-crossterm = "0.20"
-gstuff = { version = "0.7", features = ["crossterm", "nightly"] }
+gstuff = { version = "0.7", features = ["nightly"] }
 hyper = { version = "0.14.11", features = ["client", "http2", "server", "tcp"] }
 # using webpki-tokio to avoid rejecting valid certificates
 # got "invalid certificate: UnknownIssuer" for https://ropsten.infura.io on iOS using default-features

--- a/mm2src/mm2_core/Cargo.toml
+++ b/mm2src/mm2_core/Cargo.toml
@@ -29,4 +29,4 @@ gstuff = { version = "0.7", features = ["nightly"] }
 mm2_rpc = { path = "../mm2_rpc" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gstuff = { version = "0.7", features = ["crossterm", "nightly"] }
+gstuff = { version = "0.7", features = ["nightly"] }

--- a/mm2src/mm2_io/Cargo.toml
+++ b/mm2src/mm2_io/Cargo.toml
@@ -20,4 +20,4 @@ async-std = { version = "1.5", features = ["unstable"] }
 gstuff = { version = "0.7", features = ["nightly"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gstuff = { version = "0.7", features = ["crossterm", "nightly"] }
+gstuff = { version = "0.7", features = ["nightly"] }

--- a/mm2src/mm2_net/Cargo.toml
+++ b/mm2src/mm2_net/Cargo.toml
@@ -33,4 +33,4 @@ js-sys = "0.3.27"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper = { version = "0.14.11", features = ["client", "http2", "server", "tcp"] }
-gstuff = { version = "0.7", features = ["crossterm", "nightly"] }
+gstuff = { version = "0.7", features = ["nightly"] }

--- a/mm2src/mm2_rpc/Cargo.toml
+++ b/mm2src/mm2_rpc/Cargo.toml
@@ -21,4 +21,4 @@ ser_error_derive = { path = "../derives/ser_error_derive" }
 gstuff = { version = "0.7", features = ["nightly"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gstuff = { version = "0.7", features = ["crossterm", "nightly"] }
+gstuff = { version = "0.7", features = ["nightly"] }

--- a/mm2src/mm2_test_helpers/Cargo.toml
+++ b/mm2src/mm2_test_helpers/Cargo.toml
@@ -34,5 +34,4 @@ gstuff = { version = "0.7", features = ["nightly"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = "0.4"
-crossterm = "0.20"
-gstuff = { version = "0.7", features = ["crossterm", "nightly"] }
+gstuff = { version = "0.7", features = ["nightly"] }

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -874,8 +874,12 @@ impl Drop for RaiiDump {
         // we can use something like https://docs.rs/atty/latest/atty/ here, look like it's more cross-platform than gstuff::ISATTY .
 
         if nocapture == true {
-            std::io::stdout().write(format!("vvv {:?} vvv\n", self.log_path).as_bytes()).expect("Printing to stdout failed");
-            std::io::stdout().write(log.as_bytes()).expect("Printing to stdout failed");
+        std::io::stdout()
+            .write(format!("{}vvv {:?} vvv\n", DARK_YELLOW_ANSI_CODE, self.log_path).as_bytes())
+            .expect("Printing to stdout failed");
+        std::io::stdout()
+            .write(format!("{}{}{}", YELLOW_ANSI_CODE, log, RESET_COLOR_ANSI_CODE).as_bytes())
+            .expect("Printing to stdout failed");
         } else {
             log!("vvv {:?} vvv\n{}", self.log_path, log);
         }

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -859,7 +859,6 @@ pub struct RaiiDump {
 #[cfg(not(target_arch = "wasm32"))]
 impl Drop for RaiiDump {
     fn drop(&mut self) {
-
         const DARK_YELLOW_ANSI_CODE: &str = "\x1b[33m";
         const YELLOW_ANSI_CODE: &str = "\x1b[93m";
         const RESET_COLOR_ANSI_CODE: &str = "\x1b[0m";
@@ -877,13 +876,13 @@ impl Drop for RaiiDump {
         // If we want to determine is a tty or not here and write logs to stdout only if it's tty,
         // we can use something like https://docs.rs/atty/latest/atty/ here, look like it's more cross-platform than gstuff::ISATTY .
 
-        if nocapture == true {
-        std::io::stdout()
-            .write(format!("{}vvv {:?} vvv\n", DARK_YELLOW_ANSI_CODE, self.log_path).as_bytes())
-            .expect("Printing to stdout failed");
-        std::io::stdout()
-            .write(format!("{}{}{}\n", YELLOW_ANSI_CODE, log, RESET_COLOR_ANSI_CODE).as_bytes())
-            .expect("Printing to stdout failed");
+        if nocapture {
+            std::io::stdout()
+                .write_all(format!("{}vvv {:?} vvv\n", DARK_YELLOW_ANSI_CODE, self.log_path).as_bytes())
+                .expect("Printing to stdout failed");
+            std::io::stdout()
+                .write_all(format!("{}{}{}\n", YELLOW_ANSI_CODE, log, RESET_COLOR_ANSI_CODE).as_bytes())
+                .expect("Printing to stdout failed");
         } else {
             log!("vvv {:?} vvv\n{}", self.log_path, log);
         }

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -860,6 +860,10 @@ pub struct RaiiDump {
 impl Drop for RaiiDump {
     fn drop(&mut self) {
 
+        const DARK_YELLOW_ANSI_CODE: &str = "\x1b[33m";
+        const YELLOW_ANSI_CODE: &str = "\x1b[93m";
+        const RESET_COLOR_ANSI_CODE: &str = "\x1b[0m";
+
         // `term` bypasses the stdout capturing, we should only use it if the capturing was disabled.
         let nocapture = env::args().any(|a| a == "--nocapture");
 
@@ -878,7 +882,7 @@ impl Drop for RaiiDump {
             .write(format!("{}vvv {:?} vvv\n", DARK_YELLOW_ANSI_CODE, self.log_path).as_bytes())
             .expect("Printing to stdout failed");
         std::io::stdout()
-            .write(format!("{}{}{}", YELLOW_ANSI_CODE, log, RESET_COLOR_ANSI_CODE).as_bytes())
+            .write(format!("{}{}{}\n", YELLOW_ANSI_CODE, log, RESET_COLOR_ANSI_CODE).as_bytes())
             .expect("Printing to stdout failed");
         } else {
             log!("vvv {:?} vvv\n{}", self.log_path, log);

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -37,7 +37,6 @@ cfg_native! {
     use bytes::Bytes;
     use futures::channel::oneshot;
     use futures::task::SpawnExt;
-    use gstuff::ISATTY;
     use http::Request;
     use regex::Regex;
     use std::fs;
@@ -871,7 +870,10 @@ impl Drop for RaiiDump {
         let log = String::from_utf8_lossy(&log);
         let log = log.trim();
 
-        if let (true, true) = (nocapture, *ISATTY) {
+        // If we want to determine is a tty or not here and write logs to stdout only if it's tty,
+        // we can use something like https://docs.rs/atty/latest/atty/ here, look like it's more cross-platform than gstuff::ISATTY .
+
+        if nocapture == true {
             std::io::stdout().write(format!("vvv {:?} vvv\n", self.log_path).as_bytes()).expect("Printing to stdout failed");
             std::io::stdout().write(log.as_bytes()).expect("Printing to stdout failed");
         } else {


### PR DESCRIPTION
the purpose of this PR is to get rid of almost unused `crossterm` dependency (it used only for colored log files output in tests) and couple of other "old" unneeded dependencies in tree, such as `crossterm_winapi`, `mio 0.7.13`, `miow`, `ntapi`, `signal-hook`, `signal-hook-mio`.