### PR TITLE
increase validate fee wait time

### DIFF
--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -764,7 +764,7 @@ impl MakerSwap {
             {
                 Ok(_) => break,
                 Err(err) => {
-                    if attempts >= 3 {
+                    if attempts >= 6 {
                         return Ok((Some(MakerSwapCommand::Finish), vec![
                             MakerSwapEvent::TakerFeeValidateFailed(ERRL!("{}", err).into()),
                         ]));


### PR DESCRIPTION
There was an occurance of taker fee validation failing due to the maker not finding it in the mempool when the fee tx was actually sent but wasn't found in one of the electrum nodes in time. Increasing the wait time to 60 seconds can give the fee tx more time to be found.