### PR TITLE
change expected_balance in tendermint activation and balance test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `OperationFailure::Other` error was expanded. New error variants were matched with `HwRpcError`, so error type will be `HwError`, not `InternalError` [#1719](https://github.com/KomodoPlatform/atomicDEX-API/pull/1719)
 - RPC calls for evm chains was reduced in `wait_for_confirmations` function in [#1724](https://github.com/KomodoPlatform/atomicDEX-API/pull/1724)
 - A possible endless loop in evm `wait_for_htlc_tx_spend` was fixed in [#1724](https://github.com/KomodoPlatform/atomicDEX-API/pull/1724)
+- Fix test_tendermint_activation_and_balance test [#1731](https://github.com/KomodoPlatform/atomicDEX-API/pull/1731)
 
 
 ## v1.0.0-beta - 2023-03-08

--- a/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
@@ -33,7 +33,7 @@ fn test_tendermint_activation_and_balance() {
 
     let result: RpcV2Response<TendermintActivationResult> = json::from_value(activation_result).unwrap();
     assert_eq!(result.result.address, expected_address);
-    let expected_balance: BigDecimal = "0.0959".parse().unwrap();
+    let expected_balance: BigDecimal = "8.0959".parse().unwrap();
     assert_eq!(result.result.balance.spendable, expected_balance);
 
     let my_balance = block_on(my_balance(&mm, ATOM_TICKER));


### PR DESCRIPTION
Right now expected balance on[ test address](https://explorer.theta-testnet.polypore.xyz/accounts/cosmos1svaw0aqc4584x825ju7ua03g5xtxwd0ahl86hz) should be 8.0959