### PR TITLE
build linux x86-64 with reasonable glibc

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,8 +1,8 @@
 [env]
 JEMALLOC_SYS_WITH_MALLOC_CONF = "percpu_arena:percpu,oversize_threshold:0,background_thread:true,metadata_thp:auto,dirty_decay_ms:5000,muzzy_decay_ms:5000"
 
-[target.'cfg(all())']
-rustflags = [ "-Zshare-generics=y" ]
+# [target.'cfg(all())']
+# rustflags = [ "-Zshare-generics=y" ]
 
 # # Install lld using package manager
 # [target.x86_64-unknown-linux-gnu]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,8 +1,8 @@
 [env]
-JEMALLOC_SYS_WITH_MALLOC_CONF = "percpu_arena:percpu,oversize_threshold:0,background_thread:true,metadata_thp:auto,dirty_decay_ms:5000,muzzy_decay_ms:5000"
+JEMALLOC_SYS_WITH_MALLOC_CONF = "background_thread:true,narenas:1,tcache:false,dirty_decay_ms:0,muzzy_decay_ms:0,metadata_thp:auto"
 
-# [target.'cfg(all())']
-# rustflags = [ "-Zshare-generics=y" ]
+[target.'cfg(all())']
+rustflags = [ "-Zshare-generics=y" ]
 
 # # Install lld using package manager
 # [target.x86_64-unknown-linux-gnu]

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   linux-x86-64:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
     - name: Install toolchain

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -14,6 +14,7 @@ concurrency:
 env:
  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
  MANUAL_MM_VERSION: true
+ JEMALLOC_SYS_WITH_MALLOC_CONF: 'background_thread:true,narenas:1,tcache:false,dirty_decay_ms:0,muzzy_decay_ms:0,metadata_thp:auto'
 
 jobs:
   linux-x86-64:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
  MANUAL_MM_VERSION: true

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -197,7 +197,7 @@ jobs:
 
   wasm:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
     - name: Install toolchain
@@ -285,7 +285,7 @@ jobs:
 
   android-aarch64:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
     - name: Install toolchain
@@ -333,7 +333,7 @@ jobs:
 
   android-armv7:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
     - name: Install toolchain
@@ -384,7 +384,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: linux-x86-64
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/fmt-and-lint.yml
+++ b/.github/workflows/fmt-and-lint.yml
@@ -9,6 +9,10 @@ on:
       - main
       - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fmt-and-lint:
     timeout-minutes: 45

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   linux-x86-64:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
     - name: Install toolchain

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -11,6 +11,7 @@ concurrency:
 env:
  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
  MANUAL_MM_VERSION: true
+ JEMALLOC_SYS_WITH_MALLOC_CONF: 'background_thread:true,narenas:1,tcache:false,dirty_decay_ms:0,muzzy_decay_ms:0,metadata_thp:auto'
 
 jobs:
   linux-x86-64:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -192,7 +192,7 @@ jobs:
 
   wasm:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
     - name: Install toolchain
@@ -280,7 +280,7 @@ jobs:
 
   android-aarch64:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
     - name: Install toolchain
@@ -328,7 +328,7 @@ jobs:
 
   android-armv7:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
     - name: Install toolchain

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
  MANUAL_MM_VERSION: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
       - main
       - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
  FROM_SHARED_RUNNER: true
 

--- a/.github/workflows/virustotal_scan.yml
+++ b/.github/workflows/virustotal_scan.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created, edited, released, published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   virustotal:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@
 - CI/CD migrated from Azure to Github runners [#1699](https://github.com/KomodoPlatform/atomicDEX-API/pull/1699)
 - CI tests are much stabilized [#1699](https://github.com/KomodoPlatform/atomicDEX-API/pull/1699)
 - Integration and unit tests are seperated on CI stack [#1699](https://github.com/KomodoPlatform/atomicDEX-API/pull/1699)
-- Jemalloc configuration updated for optimization purposes [#1699](https://github.com/KomodoPlatform/atomicDEX-API/pull/1699)
 - Codebase is updated in linting rules at wasm and test stack [#1699](https://github.com/KomodoPlatform/atomicDEX-API/pull/1699)
 - `crossbeam` bumped to `0.8` from `0.7` [#1699](https://github.com/KomodoPlatform/atomicDEX-API/pull/1699)
 - Un-used/Unstable parts of mm2 excluded from build outputs which avoids mm2 runtime from potential UB [#1699](https://github.com/KomodoPlatform/atomicDEX-API/pull/1699)


### PR DESCRIPTION
Using `ubuntu-latest` builds mm2 with gcc 12, which breaks compatibility with older versions. We must used a version that is not too old/recent(which this pr provides already) to provide wide support.

Resolves #1732 