### PR TITLE
improve CI/CD workflows

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,11 +1,8 @@
 name: Development builds
 on:
   push:
-    branches:
-      - dev
-  pull_request:
-    branches:
-      - dev
+    branches-ignore:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -42,6 +39,9 @@ jobs:
         cargo build --bin mm2 --profile ci
 
     - name: Compress build output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       run: |
         NAME="mm2_$COMMIT_HASH-linux-x86-64.zip"
         zip $NAME target/ci/mm2 -j
@@ -49,6 +49,9 @@ jobs:
         mv $NAME ./$BRANCH_NAME/
 
     - name: Upload output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       uses: garygrossgarten/github-action-scp@release
       with:
         host: ${{ secrets.FILE_SERVER_HOST }}
@@ -59,11 +62,11 @@ jobs:
         remote: "/uploads/${{ env.BRANCH_NAME }}"
 
     - name: Login to dockerhub
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
       run: docker login --username ${{ secrets.DOCKER_HUB_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}  docker.io
 
     - name: Build and push container image
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
       run: |
         CONTAINER_TAG="dev-$COMMIT_HASH"
         docker build -t komodoofficial/atomicdexapi:"$CONTAINER_TAG" -t komodoofficial/atomicdexapi:dev-latest -f Dockerfile.dev-release .
@@ -95,6 +98,9 @@ jobs:
         cargo build --bin mm2 --profile ci --target x86_64-apple-darwin
 
     - name: Compress build output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       run: |
         NAME="mm2_$COMMIT_HASH-mac-x86-64.zip"
         zip $NAME target/x86_64-apple-darwin/ci/mm2 -j
@@ -102,6 +108,9 @@ jobs:
         mv $NAME ./$BRANCH_NAME/
 
     - name: Upload output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       uses: garygrossgarten/github-action-scp@release
       with:
         host: ${{ secrets.FILE_SERVER_HOST }}
@@ -138,6 +147,9 @@ jobs:
         cargo build --bin mm2 --profile ci
 
     - name: Compress build output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       run: |
         $NAME="mm2_$Env:COMMIT_HASH-win-x86-64.zip"
         7z a $NAME .\target\ci\mm2.exe .\target\ci\*.dll
@@ -145,6 +157,9 @@ jobs:
         mv $NAME ./$Env:BRANCH_NAME/
 
     - name: Upload output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       uses: garygrossgarten/github-action-scp@release
       with:
         host: ${{ secrets.FILE_SERVER_HOST }}
@@ -179,6 +194,9 @@ jobs:
         cargo rustc --target x86_64-apple-darwin --lib --profile ci --package mm2_bin_lib --crate-type=staticlib
 
     - name: Compress build output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       run: |
         NAME="mm2_$COMMIT_HASH-mac-dylib-x86-64.zip"
         mv target/x86_64-apple-darwin/ci/libmm2lib.a target/x86_64-apple-darwin/ci/libmm2.a
@@ -187,6 +205,9 @@ jobs:
         mv $NAME ./$BRANCH_NAME/
 
     - name: Upload output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       uses: garygrossgarten/github-action-scp@release
       with:
         host: ${{ secrets.FILE_SERVER_HOST }}
@@ -225,6 +246,9 @@ jobs:
         wasm-pack build mm2src/mm2_bin_lib --target web --out-dir ../../target/target-wasm-release
 
     - name: Compress build output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       run: |
         NAME="mm2_$COMMIT_HASH-wasm.zip"
         zip $NAME ./target/target-wasm-release/mm2lib_bg.wasm ./target/target-wasm-release/mm2lib.js ./target/target-wasm-release/snippets -j
@@ -232,6 +256,9 @@ jobs:
         mv $NAME ./$BRANCH_NAME/
 
     - name: Upload output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       uses: garygrossgarten/github-action-scp@release
       with:
         host: ${{ secrets.FILE_SERVER_HOST }}
@@ -267,6 +294,9 @@ jobs:
         cargo rustc --target aarch64-apple-ios --lib --profile ci --package mm2_bin_lib --crate-type=staticlib
 
     - name: Compress build output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       run: |
         NAME="mm2_$COMMIT_HASH-ios-aarch64.zip"
         mv target/aarch64-apple-ios/ci/libmm2lib.a target/aarch64-apple-ios/ci/libmm2.a
@@ -275,6 +305,9 @@ jobs:
         mv $NAME ./$BRANCH_NAME/
 
     - name: Upload output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       uses: garygrossgarten/github-action-scp@release
       with:
         host: ${{ secrets.FILE_SERVER_HOST }}
@@ -315,6 +348,9 @@ jobs:
         CC_aarch64_linux_android=aarch64-linux-android21-clang CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android21-clang cargo rustc --target=aarch64-linux-android --lib --profile ci --crate-type=staticlib --package mm2_bin_lib
 
     - name: Compress build output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       run: |
         NAME="mm2_$COMMIT_HASH-android-aarch64.zip"
         mv target/aarch64-linux-android/ci/libmm2lib.a target/aarch64-linux-android/ci/libmm2.a
@@ -323,6 +359,9 @@ jobs:
         mv $NAME ./$BRANCH_NAME/
 
     - name: Upload output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       uses: garygrossgarten/github-action-scp@release
       with:
         host: ${{ secrets.FILE_SERVER_HOST }}
@@ -363,6 +402,9 @@ jobs:
         CC_armv7_linux_androideabi=armv7a-linux-androideabi21-clang CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=armv7a-linux-androideabi21-clang cargo rustc --target=armv7-linux-androideabi --lib --profile ci --crate-type=staticlib --package mm2_bin_lib
 
     - name: Compress build output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       run: |
         NAME="mm2_$COMMIT_HASH-android-armv7.zip"
         mv target/armv7-linux-androideabi/ci/libmm2lib.a target/armv7-linux-androideabi/ci/libmm2.a
@@ -371,6 +413,9 @@ jobs:
         mv $NAME ./$BRANCH_NAME/
 
     - name: Upload output
+      env:
+        AVAILABLE: ${{ secrets.FILE_SERVER_KEY }}
+      if: ${{ env.AVAILABLE != '' }}
       uses: garygrossgarten/github-action-scp@release
       with:
         host: ${{ secrets.FILE_SERVER_HOST }}
@@ -382,7 +427,7 @@ jobs:
 
 
   deployment-commitment:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
     needs: linux-x86-64
     timeout-minutes: 15
     runs-on: ubuntu-18.04

--- a/.github/workflows/fmt-and-lint.yml
+++ b/.github/workflows/fmt-and-lint.yml
@@ -1,13 +1,5 @@
 name: Format and Lint
-on:
-  push:
-    branches:
-      - main
-      - dev
-  pull_request:
-    branches:
-      - main
-      - dev
+on: [push]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,5 @@
 name: Test
-on:
-  push:
-    branches:
-      - main
-      - dev
-  pull_request:
-    branches:
-      - main
-      - dev
+on: [push]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## {inc-release}
+
+**Features:**
+
+**Enhancements/Fixes:**
+- CI/CD workflow logics are improved [#1736](https://github.com/KomodoPlatform/atomicDEX-API/pull/1736)
+
 ## v1.0.1-beta - 2023-03-17
 
 **Features:**


### PR DESCRIPTION
- Skip certain steps for forked repositories (e.g [auth required ones](https://github.com/KomodoPlatform/atomicDEX-API/actions/runs/4514462628/jobs/7950614166#step:8:20))
- Do not run fmt/lint and test steps twice on dev-to-main PRs
- Start pipelines with a commit push right away without requiring PR opening to main or dev