### PR TITLE
create base image for building mm2 and use it for CI

### DIFF
--- a/.docker/Dockerfile.ci-container
+++ b/.docker/Dockerfile.ci-container
@@ -1,0 +1,55 @@
+FROM docker.io/debian:buster-slim
+
+MAINTAINER Onur Özkan <onur@komodoplatform.com>
+
+RUN apt-get update -y
+
+RUN apt-get install -y 	\
+	build-essential 	\
+	cmake 			 	\
+	gcc-multilib 		\
+    ca-certificates 	\
+    curl 				\
+	wget 				\
+    gnupg 				\
+	git 				\
+	zip 				\
+	sudo
+
+RUN ln -s /usr/bin/python3 /bin/python
+
+RUN apt install -y  			\
+	software-properties-common 	\
+	lsb-release 				\
+	gnupg
+
+RUN wget https://apt.llvm.org/llvm.sh
+
+RUN chmod +x llvm.sh
+
+RUN ./llvm.sh 16
+
+RUN rm ./llvm.sh
+
+RUN ln -s /usr/bin/clang-16 /usr/bin/clang
+
+ENV AR=/usr/bin/llvm-ar-16
+ENV CC=/usr/bin/clang-16
+
+RUN mkdir -m 0755 -p /etc/apt/keyrings
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+RUN echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update -y
+
+RUN apt-get install -y 	  \
+	docker-ce 			  \
+	docker-ce-cli 		  \
+	containerd.io 		  \
+	docker-buildx-plugin
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -16,9 +16,18 @@ env:
 jobs:
   linux-x86-64:
     timeout-minutes: 30
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: komodoofficial/ci-container:latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: pre scripts for ci container
+      run: |
+        git config --global --add safe.directory /__w/atomicDEX-API/atomicDEX-API
+        echo "/bin" >> $GITHUB_PATH
+        echo "/usr/bin" >> $GITHUB_PATH
+        echo "/root/.cargo/bin" >> $GITHUB_PATH
+
     - name: Install toolchain
       run: |
         rustup toolchain install nightly-2022-10-29 --no-self-update --profile=minimal
@@ -219,9 +228,18 @@ jobs:
 
   wasm:
     timeout-minutes: 30
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: komodoofficial/ci-container:latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: pre scripts for ci container
+      run: |
+        git config --global --add safe.directory /__w/atomicDEX-API/atomicDEX-API
+        echo "/bin" >> $GITHUB_PATH
+        echo "/usr/bin" >> $GITHUB_PATH
+        echo "/root/.cargo/bin" >> $GITHUB_PATH
+
     - name: Install toolchain
       run: |
         rustup toolchain install nightly-2022-10-29 --no-self-update --profile=minimal
@@ -229,7 +247,7 @@ jobs:
         rustup target add wasm32-unknown-unknown
 
     - name: Install wasm-pack
-      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash -s -- -y
 
     - name: Calculate commit hash for PR commit
       if: github.event_name == 'pull_request'
@@ -319,9 +337,18 @@ jobs:
 
   android-aarch64:
     timeout-minutes: 30
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: komodoofficial/ci-container:latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: pre scripts for ci container
+      run: |
+        git config --global --add safe.directory /__w/atomicDEX-API/atomicDEX-API
+        echo "/bin" >> $GITHUB_PATH
+        echo "/usr/bin" >> $GITHUB_PATH
+        echo "/root/.cargo/bin" >> $GITHUB_PATH
+
     - name: Install toolchain
       run: |
         rustup toolchain install nightly-2022-10-29 --no-self-update --profile=minimal
@@ -373,9 +400,18 @@ jobs:
 
   android-armv7:
     timeout-minutes: 30
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: komodoofficial/ci-container:latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: pre scripts for ci container
+      run: |
+        git config --global --add safe.directory /__w/atomicDEX-API/atomicDEX-API
+        echo "/bin" >> $GITHUB_PATH
+        echo "/usr/bin" >> $GITHUB_PATH
+        echo "/root/.cargo/bin" >> $GITHUB_PATH
+
     - name: Install toolchain
       run: |
         rustup toolchain install nightly-2022-10-29 --no-self-update --profile=minimal
@@ -430,9 +466,17 @@ jobs:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
     needs: linux-x86-64
     timeout-minutes: 15
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: komodoofficial/ci-container:latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: pre scripts for ci container
+        run: |
+          git config --global --add safe.directory /__w/atomicDEX-API/atomicDEX-API
+          echo "/bin" >> $GITHUB_PATH
+          echo "/usr/bin" >> $GITHUB_PATH
+          echo "/root/.cargo/bin" >> $GITHUB_PATH
 
       - name: Calculate commit hash for PR commit
         if: github.event_name == 'pull_request'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,9 +16,18 @@ env:
 jobs:
   linux-x86-64:
     timeout-minutes: 60
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: komodoofficial/ci-container:latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: pre scripts for ci container
+      run: |
+        git config --global --add safe.directory /__w/atomicDEX-API/atomicDEX-API
+        echo "/bin" >> $GITHUB_PATH
+        echo "/usr/bin" >> $GITHUB_PATH
+        echo "/root/.cargo/bin" >> $GITHUB_PATH
+
     - name: Install toolchain
       run: |
         rustup toolchain install nightly-2022-10-29 --no-self-update --profile=minimal
@@ -193,9 +202,18 @@ jobs:
 
   wasm:
     timeout-minutes: 60
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: komodoofficial/ci-container:latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: pre scripts for ci container
+      run: |
+        git config --global --add safe.directory /__w/atomicDEX-API/atomicDEX-API
+        echo "/bin" >> $GITHUB_PATH
+        echo "/usr/bin" >> $GITHUB_PATH
+        echo "/root/.cargo/bin" >> $GITHUB_PATH
+
     - name: Install toolchain
       run: |
         rustup toolchain install nightly-2022-10-29 --no-self-update --profile=minimal
@@ -281,9 +299,18 @@ jobs:
 
   android-aarch64:
     timeout-minutes: 60
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: komodoofficial/ci-container:latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: pre scripts for ci container
+      run: |
+        git config --global --add safe.directory /__w/atomicDEX-API/atomicDEX-API
+        echo "/bin" >> $GITHUB_PATH
+        echo "/usr/bin" >> $GITHUB_PATH
+        echo "/root/.cargo/bin" >> $GITHUB_PATH
+
     - name: Install toolchain
       run: |
         rustup toolchain install nightly-2022-10-29 --no-self-update --profile=minimal
@@ -329,9 +356,18 @@ jobs:
 
   android-armv7:
     timeout-minutes: 60
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    container: komodoofficial/ci-container:latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: pre scripts for ci container
+      run: |
+        git config --global --add safe.directory /__w/atomicDEX-API/atomicDEX-API
+        echo "/bin" >> $GITHUB_PATH
+        echo "/usr/bin" >> $GITHUB_PATH
+        echo "/root/.cargo/bin" >> $GITHUB_PATH
+
     - name: Install toolchain
       run: |
         rustup toolchain install nightly-2022-10-29 --no-self-update --profile=minimal

--- a/scripts/ci/android-ndk.sh
+++ b/scripts/ci/android-ndk.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -ex
 
 NDK_URL=https://dl.google.com/android/repository/android-ndk-r21b-linux-x86_64.zip
@@ -9,6 +11,7 @@ main() {
     local dependencies=(
         unzip
         python3
+        python3-distutils
         curl
     )
 


### PR DESCRIPTION
Created base image to provide more glibc compatible binaries on linux https://hub.docker.com/r/komodoofficial/ci-container/tags and used that image on build steps of CI workflows

Resolves #1734 and #1740