### PR TITLE
use OS generated secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - - Break the loop right after processing any of `SWAP_PREFIX`, `WATCHER_PREFIX`, `TX_HELPER_PREFIX` topic.
 - An issue was fixed where we don't have to wait for all EVM nodes to sync the latest account nonce [#1757](https://github.com/KomodoPlatform/atomicDEX-API/pull/1757)
 - optimized dev and release compilation profiles and removed ci [#1759](https://github.com/KomodoPlatform/atomicDEX-API/pull/1759)
-
+- use OS generated secrets for cryptographically secure randomness in `maker_swap` and `tendermint_coin::get_sender_trade_fee_for_denom` [#1753](https://github.com/KomodoPlatform/atomicDEX-API/pull/1753)
 
 ## v1.0.2-beta - 2023-04-11
 

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -62,7 +62,6 @@ use mm2_number::MmNumber;
 use parking_lot::Mutex as PaMutex;
 use primitives::hash::H256;
 use prost::{DecodeError, Message};
-use rand::{thread_rng, Rng};
 use rpc::v1::types::Bytes as BytesJson;
 use serde_json::{self as json, Value as Json};
 use std::collections::HashMap;
@@ -1461,7 +1460,11 @@ impl TendermintCoin {
         amount: BigDecimal,
     ) -> TradePreimageResult<TradeFee> {
         const TIME_LOCK: u64 = 1750;
-        let sec: [u8; 32] = thread_rng().gen();
+
+        let mut sec = [0u8; 32];
+        common::os_rng(&mut sec).map_err(|e| MmError::new(TradePreimageError::InternalError(e.to_string())))?;
+        drop_mutability!(sec);
+
         let to_address = account_id_from_pubkey_hex(&self.account_prefix, DEX_FEE_ADDR_PUBKEY)
             .map_err(|e| MmError::new(TradePreimageError::InternalError(e.into_inner().to_string())))?;
 
@@ -2627,7 +2630,6 @@ pub mod tendermint_coin_tests {
     use common::{block_on, DEX_FEE_ADDR_RAW_PUBKEY};
     use cosmrs::proto::cosmos::tx::v1beta1::{GetTxRequest, GetTxResponse, GetTxsEventResponse};
     use crypto::privkey::key_pair_from_seed;
-    use rand::{thread_rng, Rng};
     use std::mem::discriminant;
 
     pub const IRIS_TESTNET_HTLC_PAIR1_SEED: &str = "iris test seed";
@@ -2731,7 +2733,11 @@ pub mod tendermint_coin_tests {
         const UAMOUNT: u64 = 1;
         let amount: cosmrs::Decimal = UAMOUNT.into();
         let amount_dec = big_decimal_from_sat_unsigned(UAMOUNT, coin.decimals);
-        let sec: [u8; 32] = thread_rng().gen();
+
+        let mut sec = [0u8; 32];
+        common::os_rng(&mut sec).unwrap();
+        drop_mutability!(sec);
+
         let time_lock = 1000;
 
         let create_htlc_tx = coin

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -138,6 +138,7 @@ use futures01::{future, Future};
 use http::header::CONTENT_TYPE;
 use http::Response;
 use parking_lot::{Mutex as PaMutex, MutexGuard as PaMutexGuard};
+use rand::RngCore;
 use rand::{rngs::SmallRng, SeedableRng};
 use serde::{de, ser};
 use serde_json::{self as json, Value as Json};
@@ -746,6 +747,9 @@ pub fn writeln(line: &str) {
 }
 
 pub fn small_rng() -> SmallRng { SmallRng::seed_from_u64(now_ms()) }
+
+#[inline(always)]
+pub fn os_rng(dest: &mut [u8]) -> Result<(), rand::Error> { rand::rngs::OsRng.try_fill_bytes(dest) }
 
 #[derive(Debug, Clone)]
 /// Ordered from low to height inclusive range.

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -2992,6 +2992,15 @@ fn lp_connect_start_bob(ctx: MmArc, maker_match: MakerMatch, maker_order: MakerO
         if let Err(e) = insert_new_swap_to_db(ctx.clone(), maker_coin.ticker(), taker_coin.ticker(), uuid, now).await {
             error!("Error {} on new swap insertion", e);
         }
+
+        let secret = match MakerSwap::generate_secret() {
+            Ok(s) => s.into(),
+            Err(e) => {
+                error!("Error {} on secret generation", e);
+                return;
+            },
+        };
+
         let maker_swap = MakerSwap::new(
             ctx.clone(),
             alice,
@@ -3005,7 +3014,7 @@ fn lp_connect_start_bob(ctx: MmArc, maker_match: MakerMatch, maker_order: MakerO
             taker_coin,
             lock_time,
             maker_order.p2p_privkey.map(SerializableSecp256k1Keypair::into_inner),
-            MakerSwap::generate_secret().into(),
+            secret,
         );
         run_maker_swap(RunMakerSwapInput::StartNew(maker_swap), ctx).await;
     };

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -31,7 +31,6 @@ use mm2_err_handle::prelude::*;
 use mm2_number::{BigDecimal, MmNumber};
 use parking_lot::Mutex as PaMutex;
 use primitives::hash::{H256, H264};
-use rand::Rng;
 use rpc::v1::types::{Bytes as BytesJson, H256 as H256Json, H264 as H264Json};
 use std::any::TypeId;
 use std::path::PathBuf;
@@ -238,8 +237,11 @@ impl MakerSwap {
     #[inline]
     fn r(&self) -> RwLockReadGuard<MakerSwapMut> { self.mutable.read().unwrap() }
 
-    #[inline]
-    pub fn generate_secret() -> [u8; 32] { rand::thread_rng().gen() }
+    pub fn generate_secret() -> Result<[u8; 32], rand::Error> {
+        let mut sec = [0u8; 32];
+        common::os_rng(&mut sec)?;
+        Ok(sec)
+    }
 
     #[inline]
     fn secret_hash(&self) -> Vec<u8> {

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
@@ -683,7 +683,7 @@ fn test_watcher_validate_taker_payment_eth() {
     let wait_for_confirmation_until = now_ms() / 1000 + time_lock_duration;
     let time_lock = wait_for_confirmation_until as u32;
     let amount = BigDecimal::from_str("0.01").unwrap();
-    let secret_hash = dhash160(&MakerSwap::generate_secret());
+    let secret_hash = dhash160(&MakerSwap::generate_secret().unwrap());
     let watcher_reward = Some(
         block_on(watcher_reward_amount(
             &MmCoinEnum::from(taker_coin.clone()),
@@ -809,7 +809,7 @@ fn test_watcher_validate_taker_payment_eth() {
     }
 
     // Used to get wrong swap id
-    let wrong_secret_hash = dhash160(&MakerSwap::generate_secret());
+    let wrong_secret_hash = dhash160(&MakerSwap::generate_secret().unwrap());
     let error = taker_coin
         .watcher_validate_taker_payment(coins::WatcherValidatePaymentInput {
             payment_tx: taker_payment.tx_hex(),
@@ -957,7 +957,7 @@ fn test_watcher_validate_taker_payment_erc20() {
     let wait_for_confirmation_until = now_ms() / 1000 + time_lock_duration;
     let time_lock = wait_for_confirmation_until as u32;
 
-    let secret_hash = dhash160(&MakerSwap::generate_secret());
+    let secret_hash = dhash160(&MakerSwap::generate_secret().unwrap());
     let watcher_reward = Some(
         block_on(watcher_reward_amount(
             &MmCoinEnum::from(taker_coin.clone()),
@@ -1082,7 +1082,7 @@ fn test_watcher_validate_taker_payment_erc20() {
     }
 
     // Used to get wrong swap id
-    let wrong_secret_hash = dhash160(&MakerSwap::generate_secret());
+    let wrong_secret_hash = dhash160(&MakerSwap::generate_secret().unwrap());
     let error = taker_coin
         .watcher_validate_taker_payment(WatcherValidatePaymentInput {
             payment_tx: taker_payment.tx_hex(),
@@ -1577,7 +1577,7 @@ fn test_watcher_validate_taker_payment_utxo() {
     let (_ctx, maker_coin, _) = generate_utxo_coin_with_random_privkey("MYCOIN", 1000u64.into());
     let maker_pubkey = maker_coin.my_public_key().unwrap();
 
-    let secret_hash = dhash160(&MakerSwap::generate_secret());
+    let secret_hash = dhash160(&MakerSwap::generate_secret().unwrap());
 
     let taker_payment = taker_coin
         .send_taker_payment(SendPaymentArgs {
@@ -1654,7 +1654,7 @@ fn test_watcher_validate_taker_payment_utxo() {
         _ => panic!("Expected `WrongPaymentTx` {INVALID_SENDER_ERR_LOG}, found {:?}", error),
     }
 
-    let wrong_secret_hash = dhash160(&MakerSwap::generate_secret());
+    let wrong_secret_hash = dhash160(&MakerSwap::generate_secret().unwrap());
     let error = taker_coin
         .watcher_validate_taker_payment(WatcherValidatePaymentInput {
             payment_tx: taker_payment.tx_hex(),


### PR DESCRIPTION
use OS generated secrets in `maker_swap` and `tendermint_coin::get_sender_trade_fee_for_denom` to achieve cryptographically secure randomness