### PR TITLE
Enhance enable with tokens methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,17 @@
 **Enhancements/Fixes:**
 - cosmos/iris ethermint account compatibility implemented [#1765](https://github.com/KomodoPlatform/atomicDEX-API/pull/1765)
 - p2p stack is improved [#1755](https://github.com/KomodoPlatform/atomicDEX-API/pull/1755)
-- - Validate topics if they are mixed or not.
-- - Do early return if the message data is not valid (since no point to iterate over and over on the invalid message)
-- - Break the loop right after processing any of `SWAP_PREFIX`, `WATCHER_PREFIX`, `TX_HELPER_PREFIX` topic.
+  - Validate topics if they are mixed or not.
+  - Do early return if the message data is not valid (since no point to iterate over and over on the invalid message)
+  - Break the loop right after processing any of `SWAP_PREFIX`, `WATCHER_PREFIX`, `TX_HELPER_PREFIX` topic.
 - An issue was fixed where we don't have to wait for all EVM nodes to sync the latest account nonce [#1757](https://github.com/KomodoPlatform/atomicDEX-API/pull/1757)
 - optimized dev and release compilation profiles and removed ci [#1759](https://github.com/KomodoPlatform/atomicDEX-API/pull/1759)
 - fix receiver trade fee for cosmos swaps [#1767](https://github.com/KomodoPlatform/atomicDEX-API/pull/1767)
 - All features were enabled to be checked under x86-64 code lint CI step with `--all-features` option [#1760](https://github.com/KomodoPlatform/atomicDEX-API/pull/1760)
 - use OS generated secrets for cryptographically secure randomness in `maker_swap` and `tendermint_coin::get_sender_trade_fee_for_denom` [#1753](https://github.com/KomodoPlatform/atomicDEX-API/pull/1753)
+- Some enhancements were done for `enable_bch_with_tokens`,`enable_eth_with_tokens`,`enable_tendermint_with_assets` RPCs in [#1762](https://github.com/KomodoPlatform/atomicDEX-API/pull/1762)
+  - A new parameter `get_balances` was added to the above methods requests, when this parameter is set to `false`, balances will not be returned in the response. The default value for this parameter is `true` to ensure backward compatibility.
+  - Token balances requests are now performed concurrently for the above methods.
 
 
 ## v1.0.2-beta - 2023-04-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v1.0.4-beta - 2023-05-12
+
+**Features:**
+
+**Enhancements/Fixes:**
+- Some enhancements were done for `enable_bch_with_tokens`,`enable_eth_with_tokens`,`enable_tendermint_with_assets` RPCs in [#1762](https://github.com/KomodoPlatform/atomicDEX-API/pull/1762)
+  - A new parameter `get_balances` was added to the above methods requests, when this parameter is set to `false`, balances will not be returned in the response. The default value for this parameter is `true` to ensure backward compatibility.
+  - Token balances requests are now performed concurrently for the above methods.
+
+
 ## v1.0.3-beta - 2023-04-28
 
 **Features:**
@@ -13,9 +23,6 @@
 - fix receiver trade fee for cosmos swaps [#1767](https://github.com/KomodoPlatform/atomicDEX-API/pull/1767)
 - All features were enabled to be checked under x86-64 code lint CI step with `--all-features` option [#1760](https://github.com/KomodoPlatform/atomicDEX-API/pull/1760)
 - use OS generated secrets for cryptographically secure randomness in `maker_swap` and `tendermint_coin::get_sender_trade_fee_for_denom` [#1753](https://github.com/KomodoPlatform/atomicDEX-API/pull/1753)
-- Some enhancements were done for `enable_bch_with_tokens`,`enable_eth_with_tokens`,`enable_tendermint_with_assets` RPCs in [#1762](https://github.com/KomodoPlatform/atomicDEX-API/pull/1762)
-  - A new parameter `get_balances` was added to the above methods requests, when this parameter is set to `false`, balances will not be returned in the response. The default value for this parameter is `true` to ensure backward compatibility.
-  - Token balances requests are now performed concurrently for the above methods.
 
 
 ## v1.0.2-beta - 2023-04-11

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -43,7 +43,7 @@ use ethereum_types::{Address, H160, H256, U256};
 use ethkey::{public_to_address, KeyPair, Public, Signature};
 use ethkey::{sign, verify_address};
 use futures::compat::Future01CompatExt;
-use futures::future::{join_all, select_ok, Either, FutureExt, TryFutureExt};
+use futures::future::{join_all, select_ok, try_join_all, Either, FutureExt, TryFutureExt};
 use futures01::Future;
 use http::StatusCode;
 use mm2_core::mm_ctx::{MmArc, MmWeak};
@@ -3430,19 +3430,23 @@ impl EthCoin {
     }
 
     pub async fn get_tokens_balance_list(&self) -> Result<HashMap<String, CoinBalance>, MmError<BalanceError>> {
-        let coin = self.clone();
-        let mut token_balances = HashMap::new();
-        for (token_ticker, info) in self.get_erc_tokens_infos().iter() {
-            let balance_as_u256 = coin.get_token_balance_by_address(info.token_address).await?;
-            let balance_as_big_decimal = u256_to_big_decimal(balance_as_u256, info.decimals)?;
-            let balance = CoinBalance {
-                spendable: balance_as_big_decimal,
-                unspendable: BigDecimal::from(0),
+        let selfi = self.clone();
+        let mut requests = Vec::new();
+        for (token_ticker, info) in self.get_erc_tokens_infos() {
+            let coin = selfi.clone();
+            let fut = async move {
+                let balance_as_u256 = coin.get_token_balance_by_address(info.token_address).await?;
+                let balance_as_big_decimal = u256_to_big_decimal(balance_as_u256, info.decimals)?;
+                let balance = CoinBalance {
+                    spendable: balance_as_big_decimal,
+                    unspendable: BigDecimal::from(0),
+                };
+                Ok::<_, MmError<BalanceError>>((token_ticker.clone(), balance))
             };
-            token_balances.insert(token_ticker.clone(), balance);
+            requests.push(fut);
         }
 
-        Ok(token_balances)
+        try_join_all(requests).await.map(|res| res.into_iter().collect())
     }
 
     async fn get_token_balance_by_address(&self, token_address: Address) -> Result<U256, MmError<BalanceError>> {

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -3436,11 +3436,8 @@ impl EthCoin {
             let fut = async move {
                 let balance_as_u256 = coin().get_token_balance_by_address(info.token_address).await?;
                 let balance_as_big_decimal = u256_to_big_decimal(balance_as_u256, info.decimals)?;
-                let balance = CoinBalance {
-                    spendable: balance_as_big_decimal,
-                    unspendable: BigDecimal::from(0),
-                };
-                Ok::<_, MmError<BalanceError>>((token_ticker.clone(), balance))
+                let balance = CoinBalance::new(balance_as_big_decimal);
+                Ok((token_ticker, balance))
             };
             requests.push(fut);
         }

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -3430,12 +3430,11 @@ impl EthCoin {
     }
 
     pub async fn get_tokens_balance_list(&self) -> Result<HashMap<String, CoinBalance>, MmError<BalanceError>> {
-        let selfi = self.clone();
+        let coin = || self;
         let mut requests = Vec::new();
         for (token_ticker, info) in self.get_erc_tokens_infos() {
-            let coin = selfi.clone();
             let fut = async move {
-                let balance_as_u256 = coin.get_token_balance_by_address(info.token_address).await?;
+                let balance_as_u256 = coin().get_token_balance_by_address(info.token_address).await?;
                 let balance_as_big_decimal = u256_to_big_decimal(balance_as_u256, info.decimals)?;
                 let balance = CoinBalance {
                     spendable: balance_as_big_decimal,

--- a/mm2src/coins/solana.rs
+++ b/mm2src/coins/solana.rs
@@ -320,10 +320,9 @@ impl SolanaCoin {
         Ok((hash, fees))
     }
 
-    pub async fn my_balance_spl(&self, infos: &SplTokenInfo) -> Result<CoinBalance, MmError<BalanceError>> {
+    pub async fn my_balance_spl(&self, infos: SplTokenInfo) -> Result<CoinBalance, MmError<BalanceError>> {
         let token_accounts = async_blocking({
             let coin = self.clone();
-            let infos = infos.clone();
             move || {
                 coin.rpc().get_token_accounts_by_owner(
                     &coin.key_pair.pubkey(),

--- a/mm2src/coins/solana/spl.rs
+++ b/mm2src/coins/solana/spl.rs
@@ -219,7 +219,7 @@ impl SplToken {
         let coin = self.clone();
         let fut = async move {
             coin.platform_coin
-                .my_balance_spl(&SplTokenInfo {
+                .my_balance_spl(SplTokenInfo {
                     token_contract_address: coin.conf.token_contract_address,
                     decimals: coin.conf.decimals,
                 })

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -225,7 +225,7 @@ pub struct TendermintCoinImpl {
     pub(super) denom: Denom,
     chain_id: ChainId,
     gas_price: Option<f64>,
-    pub(crate) tokens_info: PaMutex<HashMap<String, ActivatedTokenInfo>>,
+    pub tokens_info: PaMutex<HashMap<String, ActivatedTokenInfo>>,
     /// This spawner is used to spawn coin's related futures that should be aborted on coin deactivation
     /// or on [`MmArc::stop`].
     pub(super) abortable_system: AbortableQueue,

--- a/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
+++ b/mm2src/coins/tendermint/tendermint_tx_history_v2.rs
@@ -877,7 +877,7 @@ pub async fn tendermint_history_loop(
     coin: TendermintCoin,
     storage: impl TxHistoryStorage,
     _ctx: MmArc,
-    _current_balance: BigDecimal,
+    _current_balance: Option<BigDecimal>,
 ) {
     let balances = match coin.all_balances().await {
         Ok(balances) => balances,

--- a/mm2src/coins_activation/src/bch_with_tokens_activation.rs
+++ b/mm2src/coins_activation/src/bch_with_tokens_activation.rs
@@ -300,7 +300,7 @@ impl PlatformWithTokensActivationOps for BchCoin {
         &self,
         ctx: MmArc,
         storage: impl TxHistoryStorage + Send + 'static,
-        initial_balance: BigDecimal,
+        initial_balance: Option<BigDecimal>,
     ) {
         let fut = bch_and_slp_history_loop(self.clone(), storage, ctx.metrics.clone(), initial_balance);
 

--- a/mm2src/coins_activation/src/eth_with_token_activation.rs
+++ b/mm2src/coins_activation/src/eth_with_token_activation.rs
@@ -258,7 +258,7 @@ impl PlatformWithTokensActivationOps for EthCoin {
         &self,
         _ctx: MmArc,
         _storage: impl TxHistoryStorage + Send + 'static,
-        _initial_balance: BigDecimal,
+        _initial_balance: Option<BigDecimal>,
     ) {
     }
 }

--- a/mm2src/coins_activation/src/platform_coin_with_tokens.rs
+++ b/mm2src/coins_activation/src/platform_coin_with_tokens.rs
@@ -150,7 +150,10 @@ pub trait PlatformWithTokensActivationOps: Into<MmCoinEnum> {
         &self,
     ) -> Vec<Box<dyn TokenAsMmCoinInitializer<PlatformCoin = Self, ActivationRequest = Self::ActivationRequest>>>;
 
-    async fn get_activation_result(&self) -> Result<Self::ActivationResult, MmError<Self::ActivationError>>;
+    async fn get_activation_result(
+        &self,
+        activation_request: &Self::ActivationRequest,
+    ) -> Result<Self::ActivationResult, MmError<Self::ActivationError>>;
 
     fn start_history_background_fetching(
         &self,
@@ -311,7 +314,7 @@ where
         mm_tokens.extend(tokens);
     }
 
-    let activation_result = platform_coin.get_activation_result().await?;
+    let activation_result = platform_coin.get_activation_result(&req.request).await?;
     log::info!("{} current block {}", req.ticker, activation_result.current_block());
 
     if req.request.tx_history() {

--- a/mm2src/coins_activation/src/platform_coin_with_tokens.rs
+++ b/mm2src/coins_activation/src/platform_coin_with_tokens.rs
@@ -159,7 +159,7 @@ pub trait PlatformWithTokensActivationOps: Into<MmCoinEnum> {
         &self,
         ctx: MmArc,
         storage: impl TxHistoryStorage,
-        initial_balance: BigDecimal,
+        initial_balance: Option<BigDecimal>,
     );
 }
 
@@ -207,8 +207,6 @@ pub enum EnablePlatformCoinWithTokensError {
     PrivKeyPolicyNotAllowed(PrivKeyPolicyNotAllowed),
     #[display(fmt = "Unexpected derivation method: {}", _0)]
     UnexpectedDerivationMethod(String),
-    #[display(fmt = "Activation request error: {}", _0)]
-    ActivationRequestError(String),
     Transport(String),
     AtLeastOneNodeRequired(String),
     InvalidPayload(String),
@@ -279,7 +277,6 @@ impl HttpStatusCode for EnablePlatformCoinWithTokensError {
             | EnablePlatformCoinWithTokensError::TokenConfigIsNotFound(_)
             | EnablePlatformCoinWithTokensError::UnexpectedPlatformProtocol { .. }
             | EnablePlatformCoinWithTokensError::InvalidPayload { .. }
-            | EnablePlatformCoinWithTokensError::ActivationRequestError(_)
             | EnablePlatformCoinWithTokensError::AtLeastOneNodeRequired(_)
             | EnablePlatformCoinWithTokensError::UnexpectedTokenProtocol { .. } => StatusCode::BAD_REQUEST,
         }
@@ -321,18 +318,11 @@ where
     log::info!("{} current block {}", req.ticker, activation_result.current_block());
 
     if req.request.tx_history() {
-        match activation_result.get_platform_balance() {
-            Some(initial_balance) =>
-                platform_coin.start_history_background_fetching(
-                    ctx.clone(),
-                    TxHistoryStorageBuilder::new(&ctx).build()?,
-                    initial_balance,
-                ),
-            None => return MmError::err(EnablePlatformCoinWithTokensError::ActivationRequestError(
-                "Tx history fetching requires getting balances on activation, current request parameters: `tx_history`=true, `get_balances`=false"
-                    .to_string(),
-            )),
-        }
+        platform_coin.start_history_background_fetching(
+            ctx.clone(),
+            TxHistoryStorageBuilder::new(&ctx).build()?,
+            activation_result.get_platform_balance(),
+        );
     }
 
     let coins_ctx = CoinsContext::from_ctx(&ctx).unwrap();

--- a/mm2src/coins_activation/src/prelude.rs
+++ b/mm2src/coins_activation/src/prelude.rs
@@ -44,7 +44,8 @@ pub enum DerivationMethod {
 pub struct CoinAddressInfo<Balance> {
     pub(crate) derivation_method: DerivationMethod,
     pub(crate) pubkey: String,
-    pub(crate) balances: Balance,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) balances: Option<Balance>,
 }
 
 pub type TokenBalances = HashMap<String, CoinBalance>;

--- a/mm2src/coins_activation/src/prelude.rs
+++ b/mm2src/coins_activation/src/prelude.rs
@@ -7,7 +7,7 @@ use mm2_err_handle::prelude::*;
 use mm2_number::BigDecimal;
 use serde_derive::Serialize;
 use serde_json::{self as json, Value as Json};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 pub trait CurrentBlock {
     fn current_block(&self) -> u64;
@@ -46,6 +46,8 @@ pub struct CoinAddressInfo<Balance> {
     pub(crate) pubkey: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) balances: Option<Balance>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tickers: Option<HashSet<String>>,
 }
 
 pub type TokenBalances = HashMap<String, CoinBalance>;

--- a/mm2src/coins_activation/src/solana_with_tokens_activation.rs
+++ b/mm2src/coins_activation/src/solana_with_tokens_activation.rs
@@ -92,19 +92,17 @@ impl TxHistory for SolanaWithTokensActivationRequest {
 #[derive(Debug, Serialize)]
 pub struct SolanaWithTokensActivationResult {
     current_block: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    solana_addresses_infos: Option<HashMap<String, CoinAddressInfo<CoinBalance>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    spl_addresses_infos: Option<HashMap<String, CoinAddressInfo<TokenBalances>>>,
+    solana_addresses_infos: HashMap<String, CoinAddressInfo<CoinBalance>>,
+    spl_addresses_infos: HashMap<String, CoinAddressInfo<TokenBalances>>,
 }
 
 impl GetPlatformBalance for SolanaWithTokensActivationResult {
     fn get_platform_balance(&self) -> Option<BigDecimal> {
-        self.solana_addresses_infos.as_ref().map(|infos| {
-            infos.iter().fold(BigDecimal::from(0), |total, (_, addr_info)| {
-                &total + &addr_info.balances.get_total()
+        self.solana_addresses_infos
+            .iter()
+            .fold(Some(BigDecimal::from(0)), |total, (_, addr_info)| {
+                total.and_then(|t| addr_info.balances.as_ref().map(|b| t + b.get_total()))
             })
-        })
     }
 }
 
@@ -221,28 +219,29 @@ impl PlatformWithTokensActivationOps for SolanaCoin {
             .await
             .map_to_mm(Self::ActivationError::Internal)?;
 
-        if !activation_request.get_balances {
-            return Ok(SolanaWithTokensActivationResult {
-                current_block,
-                solana_addresses_infos: None,
-                spl_addresses_infos: None,
-            });
-        }
-
         let my_address = self.my_address()?;
 
-        let solana_balance = self
-            .my_balance()
-            .compat()
-            .await
-            .map_err(|e| Self::ActivationError::GetBalanceError(e.into_inner()))?;
+        let solana_balance = if activation_request.get_balances {
+            Some(
+                self.my_balance()
+                    .compat()
+                    .await
+                    .map_err(|e| Self::ActivationError::GetBalanceError(e.into_inner()))?,
+            )
+        } else {
+            None
+        };
 
-        let (token_tickers, requests): (Vec<_>, Vec<_>) = self
-            .get_spl_tokens_infos()
-            .into_iter()
-            .map(|(ticker, info)| (ticker, self.my_balance_spl(info)))
-            .unzip();
-        let token_balances = token_tickers.into_iter().zip(try_join_all(requests).await?).collect();
+        let token_balances = if activation_request.get_balances {
+            let (token_tickers, requests): (Vec<_>, Vec<_>) = self
+                .get_spl_tokens_infos()
+                .into_iter()
+                .map(|(ticker, info)| (ticker, self.my_balance_spl(info)))
+                .unzip();
+            Some(token_tickers.into_iter().zip(try_join_all(requests).await?).collect())
+        } else {
+            None
+        };
 
         let solana_addresses_infos = HashMap::from([(my_address.clone(), CoinAddressInfo {
             derivation_method: DerivationMethod::Iguana,
@@ -252,14 +251,14 @@ impl PlatformWithTokensActivationOps for SolanaCoin {
 
         let spl_addresses_infos = HashMap::from([(my_address.clone(), CoinAddressInfo {
             derivation_method: DerivationMethod::Iguana,
-            pubkey: my_address.clone(),
+            pubkey: my_address,
             balances: token_balances,
         })]);
 
         Ok(SolanaWithTokensActivationResult {
             current_block,
-            solana_addresses_infos: Some(solana_addresses_infos),
-            spl_addresses_infos: Some(spl_addresses_infos),
+            solana_addresses_infos,
+            spl_addresses_infos,
         })
     }
 

--- a/mm2src/coins_activation/src/solana_with_tokens_activation.rs
+++ b/mm2src/coins_activation/src/solana_with_tokens_activation.rs
@@ -100,11 +100,11 @@ pub struct SolanaWithTokensActivationResult {
 
 impl GetPlatformBalance for SolanaWithTokensActivationResult {
     fn get_platform_balance(&self) -> Option<BigDecimal> {
-        self.solana_addresses_infos
-            .iter()
-            .fold(BigDecimal::from(0), |total, (_, addr_info)| {
+        self.solana_addresses_infos.as_ref().map(|infos| {
+            infos.iter().fold(BigDecimal::from(0), |total, (_, addr_info)| {
                 &total + &addr_info.balances.get_total()
             })
+        })
     }
 }
 

--- a/mm2src/coins_activation/src/solana_with_tokens_activation.rs
+++ b/mm2src/coins_activation/src/solana_with_tokens_activation.rs
@@ -267,7 +267,7 @@ impl PlatformWithTokensActivationOps for SolanaCoin {
         &self,
         _ctx: MmArc,
         _storage: impl TxHistoryStorage + Send + 'static,
-        _initial_balance: BigDecimal,
+        _initial_balance: Option<BigDecimal>,
     ) {
     }
 }

--- a/mm2src/coins_activation/src/solana_with_tokens_activation.rs
+++ b/mm2src/coins_activation/src/solana_with_tokens_activation.rs
@@ -92,12 +92,14 @@ impl TxHistory for SolanaWithTokensActivationRequest {
 #[derive(Debug, Serialize)]
 pub struct SolanaWithTokensActivationResult {
     current_block: u64,
-    solana_addresses_infos: HashMap<String, CoinAddressInfo<CoinBalance>>,
-    spl_addresses_infos: HashMap<String, CoinAddressInfo<TokenBalances>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    solana_addresses_infos: Option<HashMap<String, CoinAddressInfo<CoinBalance>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    spl_addresses_infos: Option<HashMap<String, CoinAddressInfo<TokenBalances>>>,
 }
 
 impl GetPlatformBalance for SolanaWithTokensActivationResult {
-    fn get_platform_balance(&self) -> BigDecimal {
+    fn get_platform_balance(&self) -> Option<BigDecimal> {
         self.solana_addresses_infos
             .iter()
             .fold(BigDecimal::from(0), |total, (_, addr_info)| {
@@ -213,50 +215,52 @@ impl PlatformWithTokensActivationOps for SolanaCoin {
         &self,
         activation_request: &Self::ActivationRequest,
     ) -> Result<Self::ActivationResult, MmError<Self::ActivationError>> {
-        let my_address = self.my_address()?;
-
         let current_block = self
             .current_block()
             .compat()
             .await
             .map_to_mm(Self::ActivationError::Internal)?;
 
-        let mut result = SolanaWithTokensActivationResult {
-            current_block,
-            solana_addresses_infos: HashMap::new(),
-            spl_addresses_infos: HashMap::new(),
-        };
-
-        if activation_request.get_balances {
-            let solana_balance = self
-                .my_balance()
-                .compat()
-                .await
-                .map_err(|e| Self::ActivationError::GetBalanceError(e.into_inner()))?;
-
-            let (token_tickers, requests): (Vec<_>, Vec<_>) = self
-                .get_spl_tokens_infos()
-                .into_iter()
-                .map(|(ticker, info)| (ticker, self.my_balance_spl(info)))
-                .unzip();
-            let token_balances = token_tickers.into_iter().zip(try_join_all(requests).await?).collect();
-
-            result
-                .solana_addresses_infos
-                .insert(my_address.clone(), CoinAddressInfo {
-                    derivation_method: DerivationMethod::Iguana,
-                    pubkey: my_address.clone(),
-                    balances: solana_balance,
-                });
-
-            result.spl_addresses_infos.insert(my_address.clone(), CoinAddressInfo {
-                derivation_method: DerivationMethod::Iguana,
-                pubkey: my_address,
-                balances: token_balances,
+        if !activation_request.get_balances {
+            return Ok(SolanaWithTokensActivationResult {
+                current_block,
+                solana_addresses_infos: None,
+                spl_addresses_infos: None,
             });
         }
 
-        Ok(result)
+        let my_address = self.my_address()?;
+
+        let solana_balance = self
+            .my_balance()
+            .compat()
+            .await
+            .map_err(|e| Self::ActivationError::GetBalanceError(e.into_inner()))?;
+
+        let (token_tickers, requests): (Vec<_>, Vec<_>) = self
+            .get_spl_tokens_infos()
+            .into_iter()
+            .map(|(ticker, info)| (ticker, self.my_balance_spl(info)))
+            .unzip();
+        let token_balances = token_tickers.into_iter().zip(try_join_all(requests).await?).collect();
+
+        let solana_addresses_infos = HashMap::from([(my_address.clone(), CoinAddressInfo {
+            derivation_method: DerivationMethod::Iguana,
+            pubkey: my_address.clone(),
+            balances: solana_balance,
+        })]);
+
+        let spl_addresses_infos = HashMap::from([(my_address.clone(), CoinAddressInfo {
+            derivation_method: DerivationMethod::Iguana,
+            pubkey: my_address.clone(),
+            balances: token_balances,
+        })]);
+
+        Ok(SolanaWithTokensActivationResult {
+            current_block,
+            solana_addresses_infos: Some(solana_addresses_infos),
+            spl_addresses_infos: Some(spl_addresses_infos),
+        })
     }
 
     fn start_history_background_fetching(

--- a/mm2src/coins_activation/src/tendermint_with_assets_activation.rs
+++ b/mm2src/coins_activation/src/tendermint_with_assets_activation.rs
@@ -242,7 +242,7 @@ impl PlatformWithTokensActivationOps for TendermintCoin {
         &self,
         ctx: MmArc,
         storage: impl TxHistoryStorage,
-        initial_balance: BigDecimal,
+        initial_balance: Option<BigDecimal>,
     ) {
         let fut = tendermint_history_loop(self.clone(), storage, ctx, initial_balance);
 

--- a/mm2src/coins_activation/src/tendermint_with_assets_activation.rs
+++ b/mm2src/coins_activation/src/tendermint_with_assets_activation.rs
@@ -17,7 +17,7 @@ use mm2_err_handle::prelude::*;
 use mm2_number::BigDecimal;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 impl TokenOf for TendermintToken {
     type PlatformCoin = TendermintCoin;
@@ -131,6 +131,8 @@ pub struct TendermintActivationResult {
     balance: Option<CoinBalance>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tokens_balances: Option<HashMap<String, CoinBalance>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tokens_tickers: Option<HashSet<String>>,
 }
 
 impl CurrentBlock for TendermintActivationResult {
@@ -207,6 +209,7 @@ impl PlatformWithTokensActivationOps for TendermintCoin {
                 current_block,
                 balance: None,
                 tokens_balances: None,
+                tokens_tickers: Some(self.tokens_info.lock().clone().into_keys().collect()),
             });
         }
 
@@ -235,6 +238,7 @@ impl PlatformWithTokensActivationOps for TendermintCoin {
                     .collect(),
             ),
             ticker: self.ticker().to_owned(),
+            tokens_tickers: None,
         })
     }
 

--- a/mm2src/mm2_main/tests/docker_tests/slp_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/slp_tests.rs
@@ -6,6 +6,7 @@ use mm2_test_helpers::for_tests::{assert_coin_not_found_on_balance, disable_coin
                                   enable_bch_with_tokens, enable_slp, my_balance, UtxoRpcMode};
 use mm2_test_helpers::structs::{EnableBchWithTokensResponse, EnableElectrumResponse, EnableSlpResponse, RpcV2Response};
 use serde_json::{self as json, json, Value as Json};
+use std::collections::HashSet;
 use std::time::Duration;
 
 async fn enable_bch_with_tokens_without_balance(
@@ -191,6 +192,7 @@ fn test_enable_bch_with_tokens_v2_without_balance() {
         .next()
         .unwrap();
     assert!(bch_balance.balances.is_none());
+    assert!(bch_balance.tickers.is_none());
 
     let (_, slp_balances) = enable_bch_with_tokens
         .result
@@ -199,6 +201,7 @@ fn test_enable_bch_with_tokens_v2_without_balance() {
         .next()
         .unwrap();
     assert!(slp_balances.balances.is_none());
+    assert_eq!(slp_balances.tickers.unwrap(), HashSet::from(["ADEXSLP".to_string()]));
 }
 
 #[test]

--- a/mm2src/mm2_main/tests/docker_tests/slp_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/slp_tests.rs
@@ -102,29 +102,33 @@ fn test_bch_and_slp_balance_enable_bch_with_tokens_v2() {
     let expected_bch_spendable = BigDecimal::from(1000);
     let expected_bch_unspendable: BigDecimal = "0.00001".parse().unwrap();
 
-    let (_, bch_balance) = enable_bch_with_tokens
+    let bch_balance = enable_bch_with_tokens
         .result
         .bch_addresses_infos
-        .unwrap()
         .into_iter()
         .next()
+        .unwrap()
+        .1
+        .balances
         .unwrap();
 
-    assert_eq!(expected_bch_spendable, bch_balance.balances.spendable);
-    assert_eq!(expected_bch_unspendable, bch_balance.balances.unspendable);
+    assert_eq!(expected_bch_spendable, bch_balance.spendable);
+    assert_eq!(expected_bch_unspendable, bch_balance.unspendable);
 
-    let (_, slp_balances) = enable_bch_with_tokens
+    let slp_balances = enable_bch_with_tokens
         .result
         .slp_addresses_infos
-        .unwrap()
         .into_iter()
         .next()
+        .unwrap()
+        .1
+        .balances
         .unwrap();
 
     let expected_slp_spendable = BigDecimal::from(1000);
     let expected_slp_unspendable: BigDecimal = 0.into();
 
-    let actual_slp = slp_balances.balances.get("ADEXSLP").unwrap();
+    let actual_slp = slp_balances.get("ADEXSLP").unwrap();
     assert_eq!(expected_slp_spendable, actual_slp.spendable);
     assert_eq!(expected_slp_unspendable, actual_slp.unspendable);
 }
@@ -145,8 +149,21 @@ fn test_enable_bch_with_tokens_v2_without_balance() {
     let enable_bch_with_tokens: RpcV2Response<EnableBchWithTokensResponse> =
         json::from_value(enable_bch_with_tokens).unwrap();
 
-    assert!(enable_bch_with_tokens.result.bch_addresses_infos.is_none());
-    assert!(enable_bch_with_tokens.result.slp_addresses_infos.is_none());
+    let (_, bch_balance) = enable_bch_with_tokens
+        .result
+        .bch_addresses_infos
+        .into_iter()
+        .next()
+        .unwrap();
+    assert!(bch_balance.balances.is_none());
+
+    let (_, slp_balances) = enable_bch_with_tokens
+        .result
+        .slp_addresses_infos
+        .into_iter()
+        .next()
+        .unwrap();
+    assert!(slp_balances.balances.is_none());
 }
 
 #[test]

--- a/mm2src/mm2_main/tests/docker_tests/slp_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/slp_tests.rs
@@ -2,7 +2,8 @@ use crate::docker_tests::docker_tests_common::*;
 use crate::integration_tests_common::enable_native;
 use mm2_number::BigDecimal;
 use mm2_test_helpers::for_tests::{assert_coin_not_found_on_balance, disable_coin, disable_coin_err,
-                                  enable_bch_with_tokens, enable_slp, my_balance, UtxoRpcMode};
+                                  enable_bch_with_tokens, enable_bch_with_tokens_without_balance, enable_slp,
+                                  my_balance, UtxoRpcMode};
 use mm2_test_helpers::structs::{EnableBchWithTokensResponse, EnableElectrumResponse, EnableSlpResponse, RpcV2Response};
 use serde_json::{self as json};
 use std::time::Duration;
@@ -104,6 +105,7 @@ fn test_bch_and_slp_balance_enable_bch_with_tokens_v2() {
     let (_, bch_balance) = enable_bch_with_tokens
         .result
         .bch_addresses_infos
+        .unwrap()
         .into_iter()
         .next()
         .unwrap();
@@ -114,6 +116,7 @@ fn test_bch_and_slp_balance_enable_bch_with_tokens_v2() {
     let (_, slp_balances) = enable_bch_with_tokens
         .result
         .slp_addresses_infos
+        .unwrap()
         .into_iter()
         .next()
         .unwrap();
@@ -124,6 +127,26 @@ fn test_bch_and_slp_balance_enable_bch_with_tokens_v2() {
     let actual_slp = slp_balances.balances.get("ADEXSLP").unwrap();
     assert_eq!(expected_slp_spendable, actual_slp.spendable);
     assert_eq!(expected_slp_unspendable, actual_slp.unspendable);
+}
+
+#[test]
+fn test_enable_bch_with_tokens_v2_without_balance() {
+    let mm = slp_supplied_node();
+
+    let tx_history = false;
+    let enable_bch_with_tokens = block_on(enable_bch_with_tokens_without_balance(
+        &mm,
+        "FORSLP",
+        &["ADEXSLP"],
+        UtxoRpcMode::Native,
+        tx_history,
+    ));
+
+    let enable_bch_with_tokens: RpcV2Response<EnableBchWithTokensResponse> =
+        json::from_value(enable_bch_with_tokens).unwrap();
+
+    assert!(enable_bch_with_tokens.result.bch_addresses_infos.is_none());
+    assert!(enable_bch_with_tokens.result.slp_addresses_infos.is_none());
 }
 
 #[test]

--- a/mm2src/mm2_main/tests/docker_tests/solana_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/solana_tests.rs
@@ -23,20 +23,21 @@ fn test_solana_and_spl_balance_enable_spl_v2() {
     let (_, solana_balance) = enable_solana_with_tokens
         .result
         .solana_addresses_infos
-        .unwrap()
         .into_iter()
         .next()
         .unwrap();
-    assert!(solana_balance.balances.spendable > 0.into());
+    assert!(solana_balance.balances.unwrap().spendable > 0.into());
 
-    let (_, spl_balances) = enable_solana_with_tokens
+    let spl_balances = enable_solana_with_tokens
         .result
         .spl_addresses_infos
-        .unwrap()
         .into_iter()
         .next()
+        .unwrap()
+        .1
+        .balances
         .unwrap();
-    let usdc_spl = spl_balances.balances.get("USDC-SOL-DEVNET").unwrap();
+    let usdc_spl = spl_balances.get("USDC-SOL-DEVNET").unwrap();
     assert!(usdc_spl.spendable.is_zero());
 
     let enable_spl = block_on(enable_spl(&mm, "ADEX-SOL-DEVNET"));

--- a/mm2src/mm2_main/tests/docker_tests/solana_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/solana_tests.rs
@@ -23,6 +23,7 @@ fn test_solana_and_spl_balance_enable_spl_v2() {
     let (_, solana_balance) = enable_solana_with_tokens
         .result
         .solana_addresses_infos
+        .unwrap()
         .into_iter()
         .next()
         .unwrap();
@@ -31,6 +32,7 @@ fn test_solana_and_spl_balance_enable_spl_v2() {
     let (_, spl_balances) = enable_solana_with_tokens
         .result
         .spl_addresses_infos
+        .unwrap()
         .into_iter()
         .next()
         .unwrap();

--- a/mm2src/mm2_main/tests/mm2_tests/bch_and_slp_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/bch_and_slp_tests.rs
@@ -650,6 +650,7 @@ fn test_bch_and_slp_with_hd_account_id() {
     let (bch_addr, _) = activation_result
         .result
         .bch_addresses_infos
+        .unwrap()
         .into_iter()
         .exactly_one()
         .unwrap();
@@ -658,6 +659,7 @@ fn test_bch_and_slp_with_hd_account_id() {
     let (slp_addr, _) = activation_result
         .result
         .slp_addresses_infos
+        .unwrap()
         .into_iter()
         .exactly_one()
         .unwrap();
@@ -682,6 +684,7 @@ fn test_bch_and_slp_with_hd_account_id() {
     let (bch_addr, _) = activation_result
         .result
         .bch_addresses_infos
+        .unwrap()
         .into_iter()
         .exactly_one()
         .unwrap();
@@ -690,6 +693,7 @@ fn test_bch_and_slp_with_hd_account_id() {
     let (slp_addr, _) = activation_result
         .result
         .slp_addresses_infos
+        .unwrap()
         .into_iter()
         .exactly_one()
         .unwrap();

--- a/mm2src/mm2_main/tests/mm2_tests/bch_and_slp_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/bch_and_slp_tests.rs
@@ -650,7 +650,6 @@ fn test_bch_and_slp_with_hd_account_id() {
     let (bch_addr, _) = activation_result
         .result
         .bch_addresses_infos
-        .unwrap()
         .into_iter()
         .exactly_one()
         .unwrap();
@@ -659,7 +658,6 @@ fn test_bch_and_slp_with_hd_account_id() {
     let (slp_addr, _) = activation_result
         .result
         .slp_addresses_infos
-        .unwrap()
         .into_iter()
         .exactly_one()
         .unwrap();
@@ -684,7 +682,6 @@ fn test_bch_and_slp_with_hd_account_id() {
     let (bch_addr, _) = activation_result
         .result
         .bch_addresses_infos
-        .unwrap()
         .into_iter()
         .exactly_one()
         .unwrap();
@@ -693,7 +690,6 @@ fn test_bch_and_slp_with_hd_account_id() {
     let (slp_addr, _) = activation_result
         .result
         .slp_addresses_infos
-        .unwrap()
         .into_iter()
         .exactly_one()
         .unwrap();

--- a/mm2src/mm2_main/tests/mm2_tests/eth_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/eth_tests.rs
@@ -135,6 +135,19 @@ fn test_disable_eth_coin_with_token_without_balance() {
     let enable_eth_with_tokens: RpcV2Response<EnableEthWithTokensResponse> =
         json::from_value(enable_eth_with_tokens).unwrap();
 
-    assert!(enable_eth_with_tokens.result.eth_addresses_infos.is_none());
-    assert!(enable_eth_with_tokens.result.erc20_addresses_infos.is_none());
+    let (_, eth_balance) = enable_eth_with_tokens
+        .result
+        .eth_addresses_infos
+        .into_iter()
+        .next()
+        .unwrap();
+    assert!(eth_balance.balances.is_none());
+
+    let (_, erc20_balances) = enable_eth_with_tokens
+        .result
+        .erc20_addresses_infos
+        .into_iter()
+        .next()
+        .unwrap();
+    assert!(erc20_balances.balances.is_none());
 }

--- a/mm2src/mm2_main/tests/mm2_tests/eth_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/eth_tests.rs
@@ -2,7 +2,8 @@ use common::block_on;
 use http::StatusCode;
 use mm2_test_helpers::for_tests::{disable_coin, disable_coin_err, get_passphrase, MarketMakerIt, Mm2TestConf,
                                   ETH_DEV_NODES};
-use serde_json::{json, Value as Json};
+use mm2_test_helpers::structs::{EnableEthWithTokensResponse, RpcV2Response};
+use serde_json::{self as json, json, Value as Json};
 use std::str::FromStr;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -22,6 +23,42 @@ async fn enable_eth_with_tokens(mm: &MarketMakerIt, platform_coin: &str, tokens:
                 "nodes": nodes,
                 "tx_history": true,
                 "erc20_tokens_requests": erc20_tokens_requests,
+            }
+        }))
+        .await
+        .unwrap();
+    assert_eq!(
+        enable.0,
+        StatusCode::OK,
+        "'enable_eth_with_tokens' failed: {}",
+        enable.1
+    );
+    Json::from_str(&enable.1).unwrap()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn enable_eth_with_tokens_without_balance(
+    mm: &MarketMakerIt,
+    platform_coin: &str,
+    tokens: &[&str],
+    nodes: &[&str],
+) -> Json {
+    let erc20_tokens_requests: Vec<_> = tokens.iter().map(|ticker| json!({ "ticker": ticker })).collect();
+    let nodes: Vec<_> = nodes.iter().map(|url| json!({ "url": url })).collect();
+
+    let enable = mm
+        .rpc(&json!({
+        "userpass": mm.userpass,
+        "method": "enable_eth_with_tokens",
+        "mmrpc": "2.0",
+        "params": {
+                "ticker": platform_coin,
+                "swap_contract_address":"0x2b294F029Fde858b2c62184e8390591755521d8E",
+                "fallback_swap_contract":"0x8500AFc0bc5214728082163326C2FF0C73f4a871",
+                "nodes": nodes,
+                "tx_history": true,
+                "erc20_tokens_requests": erc20_tokens_requests,
+                "get_balances": false,
             }
         }))
         .await
@@ -76,4 +113,28 @@ fn test_disable_eth_coin_with_token() {
     assert!(res.cancelled_orders.contains(order_uuid));
     // Then try to disable ETH platform coin.
     block_on(disable_coin(&mm, "ETH"));
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_disable_eth_coin_with_token_without_balance() {
+    let passphrase = get_passphrase(&".env.client", "BOB_PASSPHRASE").unwrap();
+    let coins = json! ([
+        {"coin":"ETH","name":"ethereum","protocol":{"type":"ETH"},"rpcport":80,"mm2":1},
+        {"coin":"JST","name":"jst","rpcport":80,"mm2":1,"protocol":{"type":"ERC20","protocol_data":{"platform":"ETH","contract_address":"0x2b294F029Fde858b2c62184e8390591755521d8E"}}}
+    ]);
+    let conf = Mm2TestConf::seednode(&passphrase, &coins);
+    let mm = block_on(MarketMakerIt::start_async(conf.conf, conf.rpc_password, None)).unwrap();
+    let enable_eth_with_tokens = block_on(enable_eth_with_tokens_without_balance(
+        &mm,
+        "ETH",
+        &["JST"],
+        ETH_DEV_NODES,
+    ));
+
+    let enable_eth_with_tokens: RpcV2Response<EnableEthWithTokensResponse> =
+        json::from_value(enable_eth_with_tokens).unwrap();
+
+    assert!(enable_eth_with_tokens.result.eth_addresses_infos.is_none());
+    assert!(enable_eth_with_tokens.result.erc20_addresses_infos.is_none());
 }

--- a/mm2src/mm2_main/tests/mm2_tests/eth_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/eth_tests.rs
@@ -4,6 +4,8 @@ use mm2_test_helpers::for_tests::{disable_coin, disable_coin_err, get_passphrase
                                   ETH_DEV_NODES};
 use mm2_test_helpers::structs::{EnableEthWithTokensResponse, RpcV2Response};
 use serde_json::{self as json, json, Value as Json};
+use std::collections::HashSet;
+use std::iter::FromIterator;
 use std::str::FromStr;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -142,6 +144,7 @@ fn test_disable_eth_coin_with_token_without_balance() {
         .next()
         .unwrap();
     assert!(eth_balance.balances.is_none());
+    assert!(eth_balance.tickers.is_none());
 
     let (_, erc20_balances) = enable_eth_with_tokens
         .result
@@ -150,4 +153,8 @@ fn test_disable_eth_coin_with_token_without_balance() {
         .next()
         .unwrap();
     assert!(erc20_balances.balances.is_none());
+    assert_eq!(
+        erc20_balances.tickers.unwrap(),
+        HashSet::from_iter(vec!["JST".to_string()])
+    );
 }

--- a/mm2src/mm2_main/tests/mm2_tests/tendermint_ibc_asset_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/tendermint_ibc_asset_tests.rs
@@ -32,11 +32,12 @@ fn test_iris_with_usdc_activation_balance_orderbook() {
     assert_eq!(response.result.address, expected_address);
 
     let expected_iris_balance = BigDecimal::from(100);
-    assert_eq!(response.result.balance.spendable, expected_iris_balance);
+    assert_eq!(response.result.balance.unwrap().spendable, expected_iris_balance);
 
     let expected_usdc_balance: BigDecimal = "0.683142".parse().unwrap();
 
-    let actual_usdc_balance = response.result.tokens_balances.get(USDC_IBC_TICKER).unwrap();
+    let tokens_balances = response.result.tokens_balances.unwrap();
+    let actual_usdc_balance = tokens_balances.get(USDC_IBC_TICKER).unwrap();
     assert_eq!(actual_usdc_balance.spendable, expected_usdc_balance);
 
     let actual_usdc_balance = block_on(my_balance(&mm, USDC_IBC_TICKER)).balance;

--- a/mm2src/mm2_main/tests/mm2_tests/tendermint_ibc_asset_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/tendermint_ibc_asset_tests.rs
@@ -1,10 +1,13 @@
 use common::block_on;
 use mm2_number::BigDecimal;
-use mm2_test_helpers::for_tests::{enable_tendermint, iris_testnet_conf, my_balance, orderbook, orderbook_v2,
-                                  set_price, usdc_ibc_iris_testnet_conf, MarketMakerIt, Mm2TestConf};
+use mm2_test_helpers::for_tests::{enable_tendermint, enable_tendermint_without_balance, iris_testnet_conf, my_balance,
+                                  orderbook, orderbook_v2, set_price, usdc_ibc_iris_testnet_conf, MarketMakerIt,
+                                  Mm2TestConf};
 use mm2_test_helpers::structs::{OrderbookAddress, OrderbookResponse, OrderbookV2Response, RpcV2Response,
                                 TendermintActivationResult};
 use serde_json::{self, json};
+use std::collections::HashSet;
+use std::iter::FromIterator;
 
 const IRIS_TESTNET_RPCS: &[&str] = &["http://34.80.202.172:26657"];
 const IRIS_TICKER: &str = "IRIS-TEST";
@@ -67,4 +70,29 @@ fn test_iris_with_usdc_activation_balance_orderbook() {
 
     let first_bid = orderbook_v2.result.bids.first().unwrap();
     assert_eq!(first_bid.entry.address, expected_address);
+}
+
+#[test]
+fn test_iris_with_usdc_activation_without_balance() {
+    let coins = json!([iris_testnet_conf(), usdc_ibc_iris_testnet_conf()]);
+
+    let conf = Mm2TestConf::seednode(IRIS_USDC_ACTIVATION_SEED, &coins);
+    let mm = MarketMakerIt::start(conf.conf, conf.rpc_password, None).unwrap();
+
+    let activation_result = block_on(enable_tendermint_without_balance(
+        &mm,
+        IRIS_TICKER,
+        &[USDC_IBC_TICKER],
+        IRIS_TESTNET_RPCS,
+        false,
+    ));
+
+    let result: RpcV2Response<TendermintActivationResult> = serde_json::from_value(activation_result).unwrap();
+
+    assert!(result.result.balance.is_none());
+    assert!(result.result.tokens_balances.is_none());
+    assert_eq!(
+        result.result.tokens_tickers.unwrap(),
+        HashSet::from_iter(vec![USDC_IBC_TICKER.to_string()])
+    );
 }

--- a/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
@@ -1,9 +1,10 @@
 use common::block_on;
 use mm2_number::BigDecimal;
 use mm2_test_helpers::for_tests::{atom_testnet_conf, disable_coin, disable_coin_err, enable_tendermint,
-                                  enable_tendermint_token, get_tendermint_my_tx_history, ibc_withdraw,
-                                  iris_nimda_testnet_conf, iris_testnet_conf, my_balance, send_raw_transaction,
-                                  withdraw_v1, MarketMakerIt, Mm2TestConf};
+                                  enable_tendermint_token, enable_tendermint_without_balance,
+                                  get_tendermint_my_tx_history, ibc_withdraw, iris_nimda_testnet_conf,
+                                  iris_testnet_conf, my_balance, send_raw_transaction, withdraw_v1, MarketMakerIt,
+                                  Mm2TestConf};
 use mm2_test_helpers::structs::{RpcV2Response, TendermintActivationResult, TransactionDetails};
 use serde_json::{self as json, json};
 
@@ -34,13 +35,34 @@ fn test_tendermint_activation_and_balance() {
     let result: RpcV2Response<TendermintActivationResult> = json::from_value(activation_result).unwrap();
     assert_eq!(result.result.address, expected_address);
     let expected_balance: BigDecimal = "8.0959".parse().unwrap();
-    assert_eq!(result.result.balance.spendable, expected_balance);
+    assert_eq!(result.result.balance.unwrap().spendable, expected_balance);
 
     let my_balance = block_on(my_balance(&mm, ATOM_TICKER));
     assert_eq!(my_balance.balance, expected_balance);
     assert_eq!(my_balance.unspendable_balance, BigDecimal::default());
     assert_eq!(my_balance.address, expected_address);
     assert_eq!(my_balance.coin, ATOM_TICKER);
+}
+
+#[test]
+fn test_tendermint_activation_without_balance() {
+    let coins = json!([atom_testnet_conf()]);
+
+    let conf = Mm2TestConf::seednode(ATOM_TEST_BALANCE_SEED, &coins);
+    let mm = MarketMakerIt::start(conf.conf, conf.rpc_password, None).unwrap();
+
+    let activation_result = block_on(enable_tendermint_without_balance(
+        &mm,
+        ATOM_TICKER,
+        &[],
+        ATOM_TENDERMINT_RPC_URLS,
+        false,
+    ));
+
+    let result: RpcV2Response<TendermintActivationResult> = json::from_value(activation_result).unwrap();
+
+    assert!(result.result.balance.is_none());
+    assert!(result.result.tokens_balances.is_none());
 }
 
 #[test]

--- a/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs
@@ -1,12 +1,12 @@
 use common::block_on;
-use http::StatusCode;
 use mm2_number::BigDecimal;
 use mm2_test_helpers::for_tests::{atom_testnet_conf, disable_coin, disable_coin_err, enable_tendermint,
-                                  enable_tendermint_token, get_tendermint_my_tx_history, ibc_withdraw,
-                                  iris_nimda_testnet_conf, iris_testnet_conf, my_balance, send_raw_transaction,
-                                  withdraw_v1, MarketMakerIt, Mm2TestConf};
+                                  enable_tendermint_token, enable_tendermint_without_balance,
+                                  get_tendermint_my_tx_history, ibc_withdraw, iris_nimda_testnet_conf,
+                                  iris_testnet_conf, my_balance, send_raw_transaction, withdraw_v1, MarketMakerIt,
+                                  Mm2TestConf};
 use mm2_test_helpers::structs::{RpcV2Response, TendermintActivationResult, TransactionDetails};
-use serde_json::{self as json, json, Value as Json};
+use serde_json::{self as json, json};
 
 const IRIS_TEST_SEED: &str = "iris test seed";
 const ATOM_TEST_BALANCE_SEED: &str = "atom test seed";
@@ -15,43 +15,6 @@ const ATOM_TICKER: &str = "ATOM";
 const ATOM_TENDERMINT_RPC_URLS: &[&str] = &["https://rpc.sentry-02.theta-testnet.polypore.xyz"];
 
 const IRIS_TESTNET_RPC_URLS: &[&str] = &["http://34.80.202.172:26657"];
-
-async fn enable_tendermint_without_balance(
-    mm: &MarketMakerIt,
-    coin: &str,
-    ibc_assets: &[&str],
-    rpc_urls: &[&str],
-    tx_history: bool,
-) -> Json {
-    let ibc_requests: Vec<_> = ibc_assets.iter().map(|ticker| json!({ "ticker": ticker })).collect();
-
-    let request = json!({
-        "userpass": mm.userpass,
-        "method": "enable_tendermint_with_assets",
-        "mmrpc": "2.0",
-        "params": {
-            "ticker": coin,
-            "tokens_params": ibc_requests,
-            "rpc_urls": rpc_urls,
-            "tx_history": tx_history,
-            "get_balances": false
-        }
-    });
-    println!(
-        "enable_tendermint_with_assets request {}",
-        json::to_string(&request).unwrap()
-    );
-
-    let request = mm.rpc(&request).await.unwrap();
-    assert_eq!(
-        request.0,
-        StatusCode::OK,
-        "'enable_tendermint_with_assets' failed: {}",
-        request.1
-    );
-    println!("enable_tendermint_with_assets response {}", request.1);
-    json::from_str(&request.1).unwrap()
-}
 
 #[test]
 fn test_tendermint_activation_and_balance() {
@@ -100,6 +63,7 @@ fn test_tendermint_activation_without_balance() {
 
     assert!(result.result.balance.is_none());
     assert!(result.result.tokens_balances.is_none());
+    assert!(result.result.tokens_tickers.unwrap().is_empty());
 }
 
 #[test]

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -2511,6 +2511,43 @@ pub async fn enable_tendermint(
     json::from_str(&request.1).unwrap()
 }
 
+pub async fn enable_tendermint_without_balance(
+    mm: &MarketMakerIt,
+    coin: &str,
+    ibc_assets: &[&str],
+    rpc_urls: &[&str],
+    tx_history: bool,
+) -> Json {
+    let ibc_requests: Vec<_> = ibc_assets.iter().map(|ticker| json!({ "ticker": ticker })).collect();
+
+    let request = json!({
+        "userpass": mm.userpass,
+        "method": "enable_tendermint_with_assets",
+        "mmrpc": "2.0",
+        "params": {
+            "ticker": coin,
+            "tokens_params": ibc_requests,
+            "rpc_urls": rpc_urls,
+            "tx_history": tx_history,
+            "get_balances": false
+        }
+    });
+    println!(
+        "enable_tendermint_with_assets request {}",
+        serde_json::to_string(&request).unwrap()
+    );
+
+    let request = mm.rpc(&request).await.unwrap();
+    assert_eq!(
+        request.0,
+        StatusCode::OK,
+        "'enable_tendermint_with_assets' failed: {}",
+        request.1
+    );
+    println!("enable_tendermint_with_assets response {}", request.1);
+    serde_json::from_str(&request.1).unwrap()
+}
+
 pub async fn get_tendermint_my_tx_history(mm: &MarketMakerIt, coin: &str, limit: usize, page_number: usize) -> Json {
     let request = json!({
         "userpass": mm.userpass,

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -1736,6 +1736,41 @@ pub async fn enable_bch_with_tokens(
     json::from_str(&enable.1).unwrap()
 }
 
+pub async fn enable_bch_with_tokens_without_balance(
+    mm: &MarketMakerIt,
+    platform_coin: &str,
+    tokens: &[&str],
+    mode: UtxoRpcMode,
+    tx_history: bool,
+) -> Json {
+    let slp_requests: Vec<_> = tokens.iter().map(|ticker| json!({ "ticker": ticker })).collect();
+
+    let enable = mm
+        .rpc(&json!({
+            "userpass": mm.userpass,
+            "method": "enable_bch_with_tokens",
+            "mmrpc": "2.0",
+            "params": {
+                "ticker": platform_coin,
+                "allow_slp_unsafe_conf": true,
+                "bchd_urls": [],
+                "mode": mode,
+                "tx_history": tx_history,
+                "slp_tokens_requests": slp_requests,
+                "get_balances": false,
+            }
+        }))
+        .await
+        .unwrap();
+    assert_eq!(
+        enable.0,
+        StatusCode::OK,
+        "'enable_bch_with_tokens' failed: {}",
+        enable.1
+    );
+    json::from_str(&enable.1).unwrap()
+}
+
 pub async fn enable_solana_with_tokens(
     mm: &MarketMakerIt,
     platform_coin: &str,
@@ -2493,6 +2528,43 @@ pub async fn enable_tendermint(
             "tokens_params": ibc_requests,
             "rpc_urls": rpc_urls,
             "tx_history": tx_history
+        }
+    });
+    println!(
+        "enable_tendermint_with_assets request {}",
+        json::to_string(&request).unwrap()
+    );
+
+    let request = mm.rpc(&request).await.unwrap();
+    assert_eq!(
+        request.0,
+        StatusCode::OK,
+        "'enable_tendermint_with_assets' failed: {}",
+        request.1
+    );
+    println!("enable_tendermint_with_assets response {}", request.1);
+    json::from_str(&request.1).unwrap()
+}
+
+pub async fn enable_tendermint_without_balance(
+    mm: &MarketMakerIt,
+    coin: &str,
+    ibc_assets: &[&str],
+    rpc_urls: &[&str],
+    tx_history: bool,
+) -> Json {
+    let ibc_requests: Vec<_> = ibc_assets.iter().map(|ticker| json!({ "ticker": ticker })).collect();
+
+    let request = json!({
+        "userpass": mm.userpass,
+        "method": "enable_tendermint_with_assets",
+        "mmrpc": "2.0",
+        "params": {
+            "ticker": coin,
+            "tokens_params": ibc_requests,
+            "rpc_urls": rpc_urls,
+            "tx_history": tx_history,
+            "get_balances": false
         }
     });
     println!(

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -1736,41 +1736,6 @@ pub async fn enable_bch_with_tokens(
     json::from_str(&enable.1).unwrap()
 }
 
-pub async fn enable_bch_with_tokens_without_balance(
-    mm: &MarketMakerIt,
-    platform_coin: &str,
-    tokens: &[&str],
-    mode: UtxoRpcMode,
-    tx_history: bool,
-) -> Json {
-    let slp_requests: Vec<_> = tokens.iter().map(|ticker| json!({ "ticker": ticker })).collect();
-
-    let enable = mm
-        .rpc(&json!({
-            "userpass": mm.userpass,
-            "method": "enable_bch_with_tokens",
-            "mmrpc": "2.0",
-            "params": {
-                "ticker": platform_coin,
-                "allow_slp_unsafe_conf": true,
-                "bchd_urls": [],
-                "mode": mode,
-                "tx_history": tx_history,
-                "slp_tokens_requests": slp_requests,
-                "get_balances": false,
-            }
-        }))
-        .await
-        .unwrap();
-    assert_eq!(
-        enable.0,
-        StatusCode::OK,
-        "'enable_bch_with_tokens' failed: {}",
-        enable.1
-    );
-    json::from_str(&enable.1).unwrap()
-}
-
 pub async fn enable_solana_with_tokens(
     mm: &MarketMakerIt,
     platform_coin: &str,
@@ -2528,43 +2493,6 @@ pub async fn enable_tendermint(
             "tokens_params": ibc_requests,
             "rpc_urls": rpc_urls,
             "tx_history": tx_history
-        }
-    });
-    println!(
-        "enable_tendermint_with_assets request {}",
-        json::to_string(&request).unwrap()
-    );
-
-    let request = mm.rpc(&request).await.unwrap();
-    assert_eq!(
-        request.0,
-        StatusCode::OK,
-        "'enable_tendermint_with_assets' failed: {}",
-        request.1
-    );
-    println!("enable_tendermint_with_assets response {}", request.1);
-    json::from_str(&request.1).unwrap()
-}
-
-pub async fn enable_tendermint_without_balance(
-    mm: &MarketMakerIt,
-    coin: &str,
-    ibc_assets: &[&str],
-    rpc_urls: &[&str],
-    tx_history: bool,
-) -> Json {
-    let ibc_requests: Vec<_> = ibc_assets.iter().map(|ticker| json!({ "ticker": ticker })).collect();
-
-    let request = json!({
-        "userpass": mm.userpass,
-        "method": "enable_tendermint_with_assets",
-        "mmrpc": "2.0",
-        "params": {
-            "ticker": coin,
-            "tokens_params": ibc_requests,
-            "rpc_urls": rpc_urls,
-            "tx_history": tx_history,
-            "get_balances": false
         }
     });
     println!(

--- a/mm2src/mm2_test_helpers/src/structs.rs
+++ b/mm2src/mm2_test_helpers/src/structs.rs
@@ -900,6 +900,7 @@ pub struct CoinAddressInfo<Balance> {
     pub derivation_method: DerivationMethod,
     pub pubkey: String,
     pub balances: Option<Balance>,
+    pub tickers: Option<HashSet<String>>,
 }
 
 pub type TokenBalances = HashMap<String, CoinBalance>;
@@ -1104,6 +1105,7 @@ pub struct TendermintActivationResult {
     pub balance: Option<CoinBalance>,
     pub tokens_balances: Option<HashMap<String, CoinBalance>>,
     pub ticker: String,
+    pub tokens_tickers: Option<HashSet<String>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/mm2src/mm2_test_helpers/src/structs.rs
+++ b/mm2src/mm2_test_helpers/src/structs.rs
@@ -906,18 +906,26 @@ pub type TokenBalances = HashMap<String, CoinBalance>;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct EnableEthWithTokensResponse {
+    pub current_block: u64,
+    pub eth_addresses_infos: Option<HashMap<String, CoinAddressInfo<CoinBalance>>>,
+    pub erc20_addresses_infos: Option<HashMap<String, CoinAddressInfo<TokenBalances>>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EnableBchWithTokensResponse {
     pub current_block: u64,
-    pub bch_addresses_infos: HashMap<String, CoinAddressInfo<CoinBalance>>,
-    pub slp_addresses_infos: HashMap<String, CoinAddressInfo<TokenBalances>>,
+    pub bch_addresses_infos: Option<HashMap<String, CoinAddressInfo<CoinBalance>>>,
+    pub slp_addresses_infos: Option<HashMap<String, CoinAddressInfo<TokenBalances>>>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EnableSolanaWithTokensResponse {
     pub current_block: u64,
-    pub solana_addresses_infos: HashMap<String, CoinAddressInfo<CoinBalance>>,
-    pub spl_addresses_infos: HashMap<String, CoinAddressInfo<TokenBalances>>,
+    pub solana_addresses_infos: Option<HashMap<String, CoinAddressInfo<CoinBalance>>>,
+    pub spl_addresses_infos: Option<HashMap<String, CoinAddressInfo<TokenBalances>>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1093,8 +1101,8 @@ pub struct WithdrawResult {}
 pub struct TendermintActivationResult {
     pub address: String,
     pub current_block: u64,
-    pub balance: CoinBalance,
-    pub tokens_balances: HashMap<String, CoinBalance>,
+    pub balance: Option<CoinBalance>,
+    pub tokens_balances: Option<HashMap<String, CoinBalance>>,
     pub ticker: String,
 }
 

--- a/mm2src/mm2_test_helpers/src/structs.rs
+++ b/mm2src/mm2_test_helpers/src/structs.rs
@@ -899,7 +899,7 @@ pub enum DerivationMethod {
 pub struct CoinAddressInfo<Balance> {
     pub derivation_method: DerivationMethod,
     pub pubkey: String,
-    pub balances: Balance,
+    pub balances: Option<Balance>,
 }
 
 pub type TokenBalances = HashMap<String, CoinBalance>;
@@ -908,24 +908,24 @@ pub type TokenBalances = HashMap<String, CoinBalance>;
 #[serde(deny_unknown_fields)]
 pub struct EnableEthWithTokensResponse {
     pub current_block: u64,
-    pub eth_addresses_infos: Option<HashMap<String, CoinAddressInfo<CoinBalance>>>,
-    pub erc20_addresses_infos: Option<HashMap<String, CoinAddressInfo<TokenBalances>>>,
+    pub eth_addresses_infos: HashMap<String, CoinAddressInfo<CoinBalance>>,
+    pub erc20_addresses_infos: HashMap<String, CoinAddressInfo<TokenBalances>>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EnableBchWithTokensResponse {
     pub current_block: u64,
-    pub bch_addresses_infos: Option<HashMap<String, CoinAddressInfo<CoinBalance>>>,
-    pub slp_addresses_infos: Option<HashMap<String, CoinAddressInfo<TokenBalances>>>,
+    pub bch_addresses_infos: HashMap<String, CoinAddressInfo<CoinBalance>>,
+    pub slp_addresses_infos: HashMap<String, CoinAddressInfo<TokenBalances>>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EnableSolanaWithTokensResponse {
     pub current_block: u64,
-    pub solana_addresses_infos: Option<HashMap<String, CoinAddressInfo<CoinBalance>>>,
-    pub spl_addresses_infos: Option<HashMap<String, CoinAddressInfo<TokenBalances>>>,
+    pub solana_addresses_infos: HashMap<String, CoinAddressInfo<CoinBalance>>,
+    pub spl_addresses_infos: HashMap<String, CoinAddressInfo<TokenBalances>>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
fixes #1748

- This PR introduces several enhancements to the `enable_bch_with_tokens`, `enable_eth_with_tokens`, and `enable_tendermint_with_assets` requests.
- Firstly, token balance requests are now performed concurrently, which is expected to resolve any timeout issues that were occurring in GUIs if a shorter timeout is selected.
- Additionally, a new parameter called `get_balances` has been added to these requests. When set to `false`, balances and addresses are not requested or returned in the response. This option can be useful for users who prefer to poll `my_balance` for balances after activation, as it can speed up coin activations.
- Please note that the default value of `get_balances` is `true`, meaning that if this parameter is not set, the previous behavior will be maintained.