### PR TITLE
fix `get_receiver_trade_fee` for cosmos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - - Break the loop right after processing any of `SWAP_PREFIX`, `WATCHER_PREFIX`, `TX_HELPER_PREFIX` topic.
 - An issue was fixed where we don't have to wait for all EVM nodes to sync the latest account nonce [#1757](https://github.com/KomodoPlatform/atomicDEX-API/pull/1757)
 - optimized dev and release compilation profiles and removed ci [#1759](https://github.com/KomodoPlatform/atomicDEX-API/pull/1759)
+- fix receiver trade fee for cosmos swaps [#1767](https://github.com/KomodoPlatform/atomicDEX-API/pull/1767)
 
 
 ## v1.0.2-beta - 2023-04-11

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -4320,7 +4320,7 @@ impl MmCoin for EthCoin {
         })
     }
 
-    fn get_receiver_trade_fee(&self, _send_amount: BigDecimal, stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
+    fn get_receiver_trade_fee(&self, stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
         let coin = self.clone();
         let fut = async move {
             let gas_price = coin.get_gas_price().compat().await?;

--- a/mm2src/coins/eth/eth_tests.rs
+++ b/mm2src/coins/eth/eth_tests.rs
@@ -957,7 +957,7 @@ fn get_receiver_trade_preimage() {
     };
 
     let actual = coin
-        .get_receiver_trade_fee(Default::default(), FeeApproxStage::WithoutApprox)
+        .get_receiver_trade_fee(FeeApproxStage::WithoutApprox)
         .wait()
         .expect("!get_sender_trade_fee");
     assert_eq!(actual, expected_fee);

--- a/mm2src/coins/lightning.rs
+++ b/mm2src/coins/lightning.rs
@@ -1301,7 +1301,7 @@ impl MmCoin for LightningCoin {
     }
 
     // Todo: This uses dummy data for now for the sake of swap P.O.C., this should be implemented probably after agreeing on how fees will work for lightning
-    fn get_receiver_trade_fee(&self, _send_amount: BigDecimal, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
+    fn get_receiver_trade_fee(&self, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
         Box::new(futures01::future::ok(TradeFee {
             coin: self.ticker().to_owned(),
             amount: Default::default(),

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2190,7 +2190,7 @@ pub trait MmCoin:
     ) -> TradePreimageResult<TradeFee>;
 
     /// Get fee to be paid by receiver per whole swap and check if the wallet has sufficient balance to pay the fee.
-    fn get_receiver_trade_fee(&self, send_amount: BigDecimal, stage: FeeApproxStage) -> TradePreimageFut<TradeFee>;
+    fn get_receiver_trade_fee(&self, stage: FeeApproxStage) -> TradePreimageFut<TradeFee>;
 
     /// Get transaction fee the Taker has to pay to send a `TakerFee` transaction and check if the wallet has sufficient balance to pay the fee.
     async fn get_fee_to_send_taker_fee(

--- a/mm2src/coins/qrc20.rs
+++ b/mm2src/coins/qrc20.rs
@@ -1375,7 +1375,7 @@ impl MmCoin for Qrc20Coin {
         })
     }
 
-    fn get_receiver_trade_fee(&self, _send_amount: BigDecimal, stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
+    fn get_receiver_trade_fee(&self, stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
         let selfi = self.clone();
         let fut = async move {
             // pass the dummy params

--- a/mm2src/coins/qrc20/qrc20_tests.rs
+++ b/mm2src/coins/qrc20/qrc20_tests.rs
@@ -916,7 +916,7 @@ fn test_receiver_trade_preimage() {
     check_tx_fee(&coin, ActualTxFee::FixedPerKb(EXPECTED_TX_FEE as u64));
 
     let actual = coin
-        .get_receiver_trade_fee(Default::default(), FeeApproxStage::WithoutApprox)
+        .get_receiver_trade_fee(FeeApproxStage::WithoutApprox)
         .wait()
         .expect("!get_receiver_trade_fee");
     // only one contract call should be included into the expected trade fee

--- a/mm2src/coins/solana.rs
+++ b/mm2src/coins/solana.rs
@@ -727,9 +727,7 @@ impl MmCoin for SolanaCoin {
         unimplemented!()
     }
 
-    fn get_receiver_trade_fee(&self, _send_amount: BigDecimal, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
-        unimplemented!()
-    }
+    fn get_receiver_trade_fee(&self, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> { unimplemented!() }
 
     async fn get_fee_to_send_taker_fee(
         &self,

--- a/mm2src/coins/solana/spl.rs
+++ b/mm2src/coins/solana/spl.rs
@@ -520,9 +520,7 @@ impl MmCoin for SplToken {
         unimplemented!()
     }
 
-    fn get_receiver_trade_fee(&self, _send_amount: BigDecimal, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
-        unimplemented!()
-    }
+    fn get_receiver_trade_fee(&self, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> { unimplemented!() }
 
     async fn get_fee_to_send_taker_fee(
         &self,

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -1988,13 +1988,18 @@ impl MmCoin for TendermintCoin {
             .await
     }
 
-    fn get_receiver_trade_fee(&self, send_amount: BigDecimal, stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
+    fn get_receiver_trade_fee(&self, stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
         let coin = self.clone();
         let fut = async move {
             // We can't simulate Claim Htlc without having information about broadcasted htlc tx.
             // Since create and claim htlc fees are almost same, we can simply simulate create htlc tx.
-            coin.get_sender_trade_fee_for_denom(coin.ticker.clone(), coin.denom.clone(), coin.decimals, send_amount)
-                .await
+            coin.get_sender_trade_fee_for_denom(
+                coin.ticker.clone(),
+                coin.denom.clone(),
+                coin.decimals,
+                coin.min_tx_amount(),
+            )
+            .await
         };
         Box::new(fut.boxed().compat())
     }

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -739,14 +739,19 @@ impl MmCoin for TendermintToken {
             .await
     }
 
-    fn get_receiver_trade_fee(&self, send_amount: BigDecimal, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
+    fn get_receiver_trade_fee(&self, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
         let token = self.clone();
         let fut = async move {
             // We can't simulate Claim Htlc without having information about broadcasted htlc tx.
             // Since create and claim htlc fees are almost same, we can simply simulate create htlc tx.
             token
                 .platform_coin
-                .get_sender_trade_fee_for_denom(token.ticker.clone(), token.denom.clone(), token.decimals, send_amount)
+                .get_sender_trade_fee_for_denom(
+                    token.ticker.clone(),
+                    token.denom.clone(),
+                    token.decimals,
+                    token.min_tx_amount(),
+                )
                 .await
         };
         Box::new(fut.boxed().compat())

--- a/mm2src/coins/test_coin.rs
+++ b/mm2src/coins/test_coin.rs
@@ -318,9 +318,7 @@ impl MmCoin for TestCoin {
         unimplemented!()
     }
 
-    fn get_receiver_trade_fee(&self, _send_amount: BigDecimal, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
-        unimplemented!()
-    }
+    fn get_receiver_trade_fee(&self, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> { unimplemented!() }
 
     async fn get_fee_to_send_taker_fee(
         &self,

--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -1234,7 +1234,7 @@ impl MmCoin for BchCoin {
         utxo_common::get_sender_trade_fee(self, value, stage).await
     }
 
-    fn get_receiver_trade_fee(&self, _send_amount: BigDecimal, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
+    fn get_receiver_trade_fee(&self, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
         utxo_common::get_receiver_trade_fee(self.clone())
     }
 

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -924,7 +924,7 @@ impl MmCoin for QtumCoin {
         utxo_common::get_sender_trade_fee(self, value, stage).await
     }
 
-    fn get_receiver_trade_fee(&self, _send_amount: BigDecimal, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
+    fn get_receiver_trade_fee(&self, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
         utxo_common::get_receiver_trade_fee(self.clone())
     }
 

--- a/mm2src/coins/utxo/slp.rs
+++ b/mm2src/coins/utxo/slp.rs
@@ -1788,7 +1788,7 @@ impl MmCoin for SlpToken {
         })
     }
 
-    fn get_receiver_trade_fee(&self, _send_amount: BigDecimal, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
+    fn get_receiver_trade_fee(&self, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
         let coin = self.clone();
 
         let fut = async move {

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -687,7 +687,7 @@ impl MmCoin for UtxoStandardCoin {
         utxo_common::get_sender_trade_fee(self, value, stage).await
     }
 
-    fn get_receiver_trade_fee(&self, _send_amount: BigDecimal, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
+    fn get_receiver_trade_fee(&self, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
         utxo_common::get_receiver_trade_fee(self.clone())
     }
 

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -1618,7 +1618,7 @@ impl MmCoin for ZCoin {
         })
     }
 
-    fn get_receiver_trade_fee(&self, _send_amount: BigDecimal, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
+    fn get_receiver_trade_fee(&self, _stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
         utxo_common::get_receiver_trade_fee(self.clone())
     }
 

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -475,9 +475,7 @@ impl MakerSwap {
                 )]))
             },
         };
-        let taker_payment_spend_trade_fee_fut = self
-            .taker_coin
-            .get_receiver_trade_fee(self.maker_amount.clone(), stage.clone());
+        let taker_payment_spend_trade_fee_fut = self.taker_coin.get_receiver_trade_fee(stage.clone());
         let taker_payment_spend_trade_fee = match taker_payment_spend_trade_fee_fut.compat().await {
             Ok(fee) => fee,
             Err(e) => {
@@ -2149,7 +2147,7 @@ pub async fn check_balance_for_maker_swap(
                 .await
                 .mm_err(|e| CheckBalanceError::from_trade_preimage_error(e, my_coin.ticker()))?;
             let taker_payment_spend_trade_fee = other_coin
-                .get_receiver_trade_fee(volume.to_decimal(), stage)
+                .get_receiver_trade_fee(stage)
                 .compat()
                 .await
                 .mm_err(|e| CheckBalanceError::from_trade_preimage_error(e, other_coin.ticker()))?;
@@ -2203,7 +2201,7 @@ pub async fn maker_swap_trade_preimage(
         .await
         .mm_err(|e| TradePreimageRpcError::from_trade_preimage_error(e, base_coin_ticker))?;
     let rel_coin_fee = rel_coin
-        .get_receiver_trade_fee(volume.to_decimal(), FeeApproxStage::TradePreimage)
+        .get_receiver_trade_fee(FeeApproxStage::TradePreimage)
         .compat()
         .await
         .mm_err(|e| TradePreimageRpcError::from_trade_preimage_error(e, rel_coin_ticker))?;

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -971,9 +971,7 @@ impl TakerSwap {
                 )]))
             },
         };
-        let maker_payment_spend_trade_fee_fut = self
-            .maker_coin
-            .get_receiver_trade_fee(self.taker_amount.to_decimal(), stage.clone());
+        let maker_payment_spend_trade_fee_fut = self.maker_coin.get_receiver_trade_fee(stage.clone());
         let maker_payment_spend_trade_fee = match maker_payment_spend_trade_fee_fut.compat().await {
             Ok(fee) => fee,
             Err(e) => {
@@ -2257,7 +2255,7 @@ pub async fn check_balance_for_taker_swap(
                 .await
                 .mm_err(|e| CheckBalanceError::from_trade_preimage_error(e, my_coin.ticker()))?;
             let maker_payment_spend_trade_fee = other_coin
-                .get_receiver_trade_fee(volume.to_decimal(), stage)
+                .get_receiver_trade_fee(stage)
                 .compat()
                 .await
                 .mm_err(|e| CheckBalanceError::from_trade_preimage_error(e, other_coin.ticker()))?;
@@ -2352,7 +2350,7 @@ pub async fn taker_swap_trade_preimage(
         .await
         .mm_err(|e| TradePreimageRpcError::from_trade_preimage_error(e, my_coin_ticker))?;
     let other_coin_trade_fee = other_coin
-        .get_receiver_trade_fee(my_coin_volume.to_decimal(), stage.clone())
+        .get_receiver_trade_fee(stage.clone())
         .compat()
         .await
         .mm_err(|e| TradePreimageRpcError::from_trade_preimage_error(e, other_coin_ticker))?;


### PR DESCRIPTION
`send_amount: BigDecimal` parameter was initially added for calculating receiver trade fee in cosmos swaps.

As it's been explained with the comments here:
https://github.com/KomodoPlatform/atomicDEX-API/blob/547a30a79b16da38769411772d837548922ee529/mm2src/coins/tendermint/tendermint_coin.rs#L1994-L1997

We are trying to simulate create HTLC transactions with the received amount, which causes tx errors if the sender sends more amount than what cosmos address has.

Because htlc amount doesn't increase the gas fee, I decided to remove that send amount parameter and use the minimum tx amount instead.

ref txs with different amounts and close gas fees:
- https://irishub.iobscan.io/#/txs/7B86592AD12C66AF86E42AC4BAB2D2C6A566495BC3914A7F75ABE3531C2B7C81
- https://irishub.iobscan.io/#/txs/A5F194096EF8E6AF609FF356330ED18C72CCECE04946313F083C43E94C4AB1E0
- https://irishub.iobscan.io/#/txs/379F0BE7FF6BA71A2669E725C6A50541B868B674A97BE516D48F2F8170C489AF
- https://irishub.iobscan.io/#/txs/1E085D084A4B0DC9E125FD4F79F3F666B23DE53CC62EB8D59601E70F3A001D09