### PR TITLE
Hotfix: lightning swaps maker payment instructions

### DIFF
--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -944,7 +944,7 @@ impl TakerSwap {
         let watcher_reward = self.r().watcher_reward && self.maker_coin.is_eth();
         let wait_until = wait_for_maker_payment_conf_until(self.r().data.started_at, self.r().data.lock_duration);
         let instructions = self
-            .taker_coin
+            .maker_coin
             .maker_payment_instructions(PaymentInstructionArgs {
                 secret_hash: &secret_hash,
                 amount: maker_amount,


### PR DESCRIPTION
In the ETH/ERC20/UTXO swaps with watcher rewards PR https://github.com/KomodoPlatform/atomicDEX-API/pull/1750 , the coin used for `maker_payment_instructions` was changed from `maker_coin` to `taker_coin`
https://github.com/KomodoPlatform/atomicDEX-API/blob/a1fc8f7c92819f68c0dcdf7b1c650d86cdf945ad/mm2src/mm2_main/src/lp_swap/taker_swap.rs#L946-L956
This caused lightning swaps to fail. It wasn't catched by CI since lightning swaps unit tests are ignored because the `tBTC` addresses are required to be refilled periodically by coins which makes the test unstable.
https://github.com/KomodoPlatform/atomicDEX-API/blob/a1fc8f7c92819f68c0dcdf7b1c650d86cdf945ad/mm2src/mm2_main/tests/mm2_tests/lightning_tests.rs#L685-L689
This problem was also missed in the PR review.

I try to fix this issue in this PR but I guess it will mess up some of the watchers operations if only the coin was changed back as done here. @caglaryucekaya please comment with what needs to be changed for watchers operations to work as they were after this PR https://github.com/KomodoPlatform/atomicDEX-API/pull/1750.

Please note that in the other side of the swap (the maker swap), the instructions are validated using the `maker_coin`, meaning the fix in this PR is the right way to do this.
https://github.com/KomodoPlatform/atomicDEX-API/blob/a1fc8f7c92819f68c0dcdf7b1c650d86cdf945ad/mm2src/mm2_main/src/lp_swap/maker_swap.rs#L723-L724
Taker swap should also mirror maker swap in operations.
https://github.com/KomodoPlatform/atomicDEX-API/blob/a1fc8f7c92819f68c0dcdf7b1c650d86cdf945ad/mm2src/mm2_main/src/lp_swap/maker_swap.rs#L455-L456
The instructions are supposed to tell the other side how to send their coin payment so it's supposed to use the other side's coin to generate the instructions.