### PR TITLE
exclude `wasm-timer` deprecated dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.0.5-beta - ${release-date}
+
+**Features:**
+
+**Enhancements/Fixes:**
+- Remove deprecated dependency `wasm-timer` from mm2 tree [#1836](https://github.com/KomodoPlatform/atomicDEX-API/pull/1836)
+
 ## v1.0.4-beta - 2023-05-23
 
 **Features:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-timer",
  "web-sys",
  "web3",
  "webpki-roots",
@@ -1191,6 +1190,7 @@ dependencies = [
  "http-body 0.1.0",
  "hyper",
  "hyper-rustls",
+ "instant",
  "itertools",
  "js-sys",
  "lazy_static",
@@ -1216,7 +1216,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-timer",
  "web-sys",
  "winapi",
 ]
@@ -4365,7 +4364,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-timer",
  "web-sys",
  "winapi",
 ]
@@ -4411,7 +4409,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-timer",
 ]
 
 [[package]]

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -150,7 +150,6 @@ winapi = "0.3"
 
 [dev-dependencies]
 mm2_test_helpers = { path = "../mm2_test_helpers" }
-wasm-timer = "0.2.4"
 
 [build-dependencies]
 prost-build = { version = "0.10.4", default-features = false }

--- a/mm2src/coins/lp_price.rs
+++ b/mm2src/coins/lp_price.rs
@@ -295,7 +295,7 @@ mod tests {
     #[test]
     fn test_get_cex_rates() {
         use mm2_number::MmNumber;
-        use wasm_timer::SystemTime;
+        use std::time::SystemTime;
 
         use crate::lp_price::{Provider, TickerInfos, TickerInfosRegistry};
 

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -44,12 +44,13 @@ ser_error_derive = { path = "../derives/ser_error_derive" }
 sha2 = "0.9"
 shared_ref_counter = { path = "shared_ref_counter", optional = true }
 uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
-wasm-timer = "0.2.4"
+instant = { version = "0.1.12" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] } # see https://docs.rs/getrandom/0.2.0/getrandom/#webassembly-support
 gstuff = { version = "0.7", features = ["nightly"] }
+instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 js-sys = "0.3.27"
 serde_repr = "0.1.6"
 serde-wasm-bindgen = "0.4.3"

--- a/mm2src/common/time_cache.rs
+++ b/mm2src/common/time_cache.rs
@@ -21,12 +21,12 @@
 //! This implements a time-based LRU cache for checking gossipsub message duplicates.
 
 use fnv::FnvHashMap;
+use instant::Instant;
 use std::collections::hash_map::{self,
                                  Entry::{Occupied, Vacant},
                                  Iter, Keys};
 use std::collections::VecDeque;
 use std::time::Duration;
-use wasm_timer::Instant;
 
 #[derive(Debug)]
 pub struct ExpiringElement<Element> {

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -90,7 +90,7 @@ sp-trie = { version = "6.0", default-features = false }
 trie-db = { version = "0.23.1", default-features = false }
 trie-root = "0.16.0"
 uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
-wasm-timer = "0.2.4"
+instant = { version = "0.1.12" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }

--- a/mm2src/mm2_main/src/lp_network.rs
+++ b/mm2src/mm2_main/src/lp_network.rs
@@ -23,6 +23,7 @@ use common::executor::SpawnFuture;
 use common::{log, Future01CompatExt};
 use derive_more::Display;
 use futures::{channel::oneshot, StreamExt};
+use instant::Instant;
 use keys::KeyPair;
 use mm2_core::mm_ctx::{MmArc, MmWeak};
 use mm2_err_handle::prelude::*;
@@ -37,7 +38,6 @@ use parking_lot::Mutex as PaMutex;
 use serde::de;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
-use wasm_timer::Instant;
 
 use crate::mm2::lp_ordermatch;
 use crate::mm2::{lp_stats, lp_swap};

--- a/mm2src/mm2_main/src/lp_ordermatch/order_requests_tracker.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/order_requests_tracker.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
+use instant::Instant;
 use std::{collections::hash_map::{HashMap, RawEntryMut},
           num::NonZeroUsize,
           time::Duration};
-use wasm_timer::Instant;
 
 const ONE_SECOND: Duration = Duration::from_secs(1);
 

--- a/mm2src/mm2_metrics/Cargo.toml
+++ b/mm2src/mm2_metrics/Cargo.toml
@@ -18,7 +18,6 @@ mm2_err_handle = { path = "../mm2_err_handle" }
 serde = "1"
 serde_derive = "1"
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
-wasm-timer = "0.2.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper = { version = "0.14.11", features = ["client", "http2", "server", "tcp"] }

--- a/mm2src/mm2_metrics/src/mm_metrics.rs
+++ b/mm2src/mm2_metrics/src/mm_metrics.rs
@@ -386,7 +386,7 @@ mod test {
     use common::{block_on,
                  executor::{abortable_queue::AbortableQueue, Timer},
                  log::{LogArc, LogState}};
-    use wasm_timer::Instant;
+    use std::time::Instant;
 
     #[test]
     fn test_collect_json() {


### PR DESCRIPTION
This change excludes the deprecated dependency `wasm-timer` from mm2 tree. Right now, it's only used in the `p2p` stack from `libp2p` which will be removed from there as well with the https://github.com/KomodoPlatform/atomicDEX-API/issues/1756