### PR TITLE
feat(kmd): reduce KMD AUR from 5% to 0.01% starting at nS7HardforkHeight

### DIFF
--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -1574,7 +1574,6 @@ impl UtxoHDAccount {
 }
 
 /// Function calculating KMD interest
-/// https://komodoplatform.atlassian.net/wiki/spaces/KPSD/pages/71729215/What+is+the+5+Komodo+Stake+Reward
 /// https://github.com/KomodoPlatform/komodo/blob/master/src/komodo_interest.h
 fn kmd_interest(
     height: Option<u64>,
@@ -1584,6 +1583,8 @@ fn kmd_interest(
 ) -> Result<u64, KmdRewardsNotAccruedReason> {
     const KOMODO_ENDOFERA: u64 = 7_777_777;
     const LOCKTIME_THRESHOLD: u64 = 500_000_000;
+    // dPoW Season 7, Fri Jun 30 2023
+    const N_S7_HARDFORK_HEIGHT: u64 = 3_484_958;
 
     // value must be at least 10 KMD
     if value < 1_000_000_000 {
@@ -1625,9 +1626,16 @@ fn kmd_interest(
     if height >= 1_000_000 && minutes > 31 * 24 * 60 {
         minutes = 31 * 24 * 60;
     }
-    // next 2 lines ported as is from Komodo codebase
+    // next lines ported as is from Komodo codebase
     minutes -= 59;
-    let accrued = (value / 10_512_000) * minutes;
+    let mut accrued = (value / 10_512_000) * minutes;
+    // KIP-0001 proposed a reduction of the AUR from 5% to 0.01%
+    // https://github.com/KomodoPlatform/kips/blob/main/kip-0001.mediawiki
+    // https://github.com/KomodoPlatform/komodo/pull/584
+    if height >= N_S7_HARDFORK_HEIGHT {
+        accrued /= 500;
+    };
+    drop_mutability!(accrued);
 
     Ok(accrued)
 }

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -1585,6 +1585,10 @@ fn kmd_interest(
     const LOCKTIME_THRESHOLD: u64 = 500_000_000;
     // dPoW Season 7, Fri Jun 30 2023
     const N_S7_HARDFORK_HEIGHT: u64 = 3_484_958;
+    // MINUTES_PER_YEAR = 365 * 24 * 60
+    const MINUTES_PER_YEAR: u64 = 525_600;
+    // Active user rewards per minute before N_S7_HARDFORK_HEIGHT
+    const AUR_PER_MINUTE: f64 = 0.05 / MINUTES_PER_YEAR as f64;
 
     // value must be at least 10 KMD
     if value < 1_000_000_000 {
@@ -1619,16 +1623,16 @@ fn kmd_interest(
     }
 
     // interest stop accruing after 1 year before block 1000000
-    if minutes > 365 * 24 * 60 {
-        minutes = 365 * 24 * 60
+    if minutes > MINUTES_PER_YEAR {
+        minutes = MINUTES_PER_YEAR
     };
     // interest stop accruing after 1 month past 1000000 block
     if height >= 1_000_000 && minutes > 31 * 24 * 60 {
         minutes = 31 * 24 * 60;
     }
-    // next lines ported as is from Komodo codebase
+    // Some of these lines are ported as is from Komodo codebase
     minutes -= 59;
-    let mut accrued = (value / 10_512_000) * minutes;
+    let mut accrued = (value as f64 * AUR_PER_MINUTE) as u64 * minutes;
     // KIP-0001 proposed a reduction of the AUR from 5% to 0.01%
     // https://github.com/KomodoPlatform/kips/blob/main/kip-0001.mediawiki
     // https://github.com/KomodoPlatform/komodo/pull/584

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -349,6 +349,21 @@ fn test_kmd_interest_accrue_stop_at() {
 }
 
 #[test]
+// Test case taken from this PR: https://github.com/KomodoPlatform/komodo/pull/584
+fn test_kmd_interest_kip_0001_reduction() {
+    let height = Some(7777776);
+    let value = 64605500822;
+    let lock_time = 1663839248;
+    let current_time = 1663839248 + (31 * 24 * 60 - 1) * 60 + 3600;
+
+    // Starting from dPoW 7th season, according to KIP0001 AUR should be reduced from 5% to 0.01%, i.e. div by 500
+    let expected = value / 10512000 * (31 * 24 * 60 - 59) / 500;
+    println!("expected: {}", expected);
+    let actual = kmd_interest(height, value, lock_time, current_time).unwrap();
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn test_sat_from_big_decimal() {
     let amount = "0.000001".parse().unwrap();
     let sat = sat_from_big_decimal(&amount, 18).unwrap();


### PR DESCRIPTION
KMD interest calculation is adjusted to reduce AUR (Active User Rewards) from 5% to 0.01% starting from KMD block height `3484958` (Fri Jun 30 2023) according to [KIP-0001](https://github.com/KomodoPlatform/kips/blob/main/kip-0001.mediawiki)

fixes #1840