### PR TITLE
chore(release): v1.0.5-beta

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,42 @@
+name: "PR Lint"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            deps
+            test
+            refactor
+            ci
+          requireScope: true
+          # Do not allow starting with uppercase for subject part
+          subjectPattern: ^(?![A-Z]).+$
+          headerPatternCorrespondence: type, scope, subject
+
+      - name: Check PR title length
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          title_length=${#TITLE}
+          if [ $title_length -gt 72 ]
+          then
+            echo "PR title is too long (greater than 72 characters)"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-## v1.0.5-beta - ${release-date}
+## v1.0.5-beta - 2023-06-02
 
 **Features:**
+- NFT integration [#900](https://github.com/KomodoPlatform/atomicDEX-API/issues/900)
+  - UriMeta was added to get info from token uri, status and metadata in nft tx history [#1823](https://github.com/KomodoPlatform/atomicDEX-API/pull/1823)
 
 **Enhancements/Fixes:**
-- Remove deprecated dependency `wasm-timer` from mm2 tree [#1836](https://github.com/KomodoPlatform/atomicDEX-API/pull/1836)
-- UriMeta to get info from token uri, status and metadata in nft tx history were added [#1823](https://github.com/KomodoPlatform/atomicDEX-API/pull/1823)
+- Deprecated `wasm-timer` dependency was removed from mm2 tree [#1836](https://github.com/KomodoPlatform/atomicDEX-API/pull/1836)
+- `log`, `getrandom` and `wasm-bindgen` dependencies were updated to more recent versions that are inline with the latest libp2p upstream [#1837](https://github.com/KomodoPlatform/atomicDEX-API/pull/1837)
+- A CI lint pipeline was added that validates pull request titles to ensure that they comply with the conventional commit specifications [#1839](https://github.com/KomodoPlatform/atomicDEX-API/pull/1839)
+- KMD AUR were reduced from 5% to 0.01% starting at `nS7HardforkHeight` to comply with [KIP-0001](https://github.com/KomodoPlatform/kips/blob/main/kip-0001.mediawiki) [#1841](https://github.com/KomodoPlatform/atomicDEX-API/pull/1841)
+
 
 ## v1.0.4-beta - 2023-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Enhancements/Fixes:**
 - Remove deprecated dependency `wasm-timer` from mm2 tree [#1836](https://github.com/KomodoPlatform/atomicDEX-API/pull/1836)
+- UriMeta to get info from token uri, status and metadata in nft tx history were added [#1823](https://github.com/KomodoPlatform/atomicDEX-API/pull/1823)
 
 ## v1.0.4-beta - 2023-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.5-beta - 2023-06-02
+## v1.0.5-beta - 2023-06-08
 
 **Features:**
 - NFT integration [#900](https://github.com/KomodoPlatform/atomicDEX-API/issues/900)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.0.5-beta - ${release-date}
+
+**Features:**
+
+**Enhancements/Fixes:**
+- Remove deprecated dependency `wasm-timer` from mm2 tree [#1836](https://github.com/KomodoPlatform/atomicDEX-API/pull/1836)
+
 ## v1.0.4-beta - 2023-05-23
 
 **Features:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "mm2_bin_lib"
-version = "1.0.4-beta"
+version = "1.0.5-beta"
 dependencies = [
  "chrono",
  "common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
@@ -198,7 +198,7 @@ dependencies = [
  "futures-io",
  "futures-timer",
  "kv-log-macro",
- "log 0.4.14",
+ "log 0.4.17",
  "memchr",
  "num_cpus",
  "once_cell",
@@ -225,8 +225,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -242,8 +242,8 @@ version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -286,7 +286,7 @@ dependencies = [
  "libp2p-plaintext",
  "libp2p-swarm",
  "libp2p-yamux",
- "log 0.4.14",
+ "log 0.4.17",
  "prost",
  "prost-build",
  "quickcheck",
@@ -719,7 +719,7 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.39",
+ "proc-macro2 1.0.58",
  "syn 1.0.95",
 ]
 
@@ -729,8 +729,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -740,8 +740,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -797,8 +797,8 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e215f8c2f9f79cb53c8335e687ffd07d5bfcb6fe5fc80723762d0be46e7cc54"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -1183,7 +1183,7 @@ dependencies = [
  "futures 0.1.29",
  "futures 0.3.15",
  "futures-timer",
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
  "gstuff",
  "hex 0.4.3",
  "http 0.2.7",
@@ -1196,7 +1196,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "lightning",
- "log 0.4.14",
+ "log 0.4.17",
  "parking_lot 0.12.0",
  "parking_lot_core 0.6.2",
  "primitive-types",
@@ -1260,7 +1260,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
  "web-sys",
 ]
 
@@ -1317,7 +1317,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "ecdsa",
  "eyre",
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
  "k256",
  "prost",
  "prost-types",
@@ -1626,7 +1626,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
 dependencies = [
- "quote 1.0.18",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -1707,8 +1707,8 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "lazy_static",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "scratch",
  "syn 1.0.95",
 ]
@@ -1725,8 +1725,8 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -1753,7 +1753,7 @@ version = "0.1.0"
 dependencies = [
  "common",
  "hex 0.4.3",
- "log 0.4.14",
+ "log 0.4.17",
  "rusqlite",
  "sql-builder",
  "uuid 1.2.2",
@@ -1799,8 +1799,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -1810,8 +1810,8 @@ version = "0.99.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -2070,8 +2070,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
 dependencies = [
  "heck",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -2082,7 +2082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
 dependencies = [
  "num-traits",
- "quote 1.0.18",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -2091,8 +2091,8 @@ name = "enum_from"
 version = "0.1.0"
 dependencies = [
  "itertools",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -2104,7 +2104,7 @@ checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.14",
+ "log 0.4.17",
  "regex",
  "termcolor",
 ]
@@ -2240,8 +2240,8 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
  "synstructure",
 ]
@@ -2487,8 +2487,8 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -2611,14 +2611,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -3104,8 +3104,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -3261,7 +3261,7 @@ dependencies = [
  "futures 0.3.15",
  "futures-executor",
  "futures-util",
- "log 0.4.14",
+ "log 0.4.17",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3333,7 +3333,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ff57d6d215f7ca7eb35a9a64d656ba4d9d2bef114d741dc08048e75e2f5d418"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
 ]
 
 [[package]]
@@ -3379,7 +3379,7 @@ dependencies = [
  "bytes 1.1.0",
  "futures 0.3.15",
  "futures-timer",
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
  "instant",
  "lazy_static",
  "libp2p-core",
@@ -3417,7 +3417,7 @@ dependencies = [
  "instant",
  "lazy_static",
  "libsecp256k1 0.7.0",
- "log 0.4.14",
+ "log 0.4.17",
  "multiaddr",
  "multihash",
  "multistream-select",
@@ -3444,7 +3444,7 @@ source = "git+https://github.com/libp2p/rust-libp2p.git?tag=v0.45.1#802d00e64589
 dependencies = [
  "futures 0.3.15",
  "libp2p-core",
- "log 0.4.14",
+ "log 0.4.17",
  "parking_lot 0.12.0",
  "smallvec 1.6.1",
  "trust-dns-resolver",
@@ -3474,7 +3474,7 @@ dependencies = [
  "futures 0.3.15",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.14",
+ "log 0.4.17",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -3501,7 +3501,7 @@ dependencies = [
  "bytes 1.1.0",
  "futures 0.3.15",
  "libp2p-core",
- "log 0.4.14",
+ "log 0.4.17",
  "nohash-hasher",
  "parking_lot 0.12.0",
  "rand 0.7.3",
@@ -3519,7 +3519,7 @@ dependencies = [
  "futures 0.3.15",
  "lazy_static",
  "libp2p-core",
- "log 0.4.14",
+ "log 0.4.17",
  "prost",
  "prost-build",
  "rand 0.8.4",
@@ -3540,7 +3540,7 @@ dependencies = [
  "instant",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.14",
+ "log 0.4.17",
  "rand 0.7.3",
  "void",
 ]
@@ -3554,7 +3554,7 @@ dependencies = [
  "bytes 1.1.0",
  "futures 0.3.15",
  "libp2p-core",
- "log 0.4.14",
+ "log 0.4.17",
  "prost",
  "prost-build",
  "unsigned-varint 0.7.1",
@@ -3572,7 +3572,7 @@ dependencies = [
  "instant",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.14",
+ "log 0.4.17",
  "rand 0.7.3",
  "smallvec 1.6.1",
  "unsigned-varint 0.7.1",
@@ -3589,7 +3589,7 @@ dependencies = [
  "futures-timer",
  "instant",
  "libp2p-core",
- "log 0.4.14",
+ "log 0.4.17",
  "pin-project 1.0.10",
  "rand 0.7.3",
  "smallvec 1.6.1",
@@ -3602,7 +3602,7 @@ name = "libp2p-swarm-derive"
 version = "0.27.2"
 source = "git+https://github.com/libp2p/rust-libp2p.git?tag=v0.45.1#802d00e645894d8895f2f9f665b921452d992b86"
 dependencies = [
- "quote 1.0.18",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -3617,7 +3617,7 @@ dependencies = [
  "ipnet",
  "libc",
  "libp2p-core",
- "log 0.4.14",
+ "log 0.4.17",
  "socket2 0.4.4",
  "tokio",
 ]
@@ -3644,7 +3644,7 @@ dependencies = [
  "futures 0.3.15",
  "futures-rustls 0.22.1",
  "libp2p-core",
- "log 0.4.14",
+ "log 0.4.17",
  "parking_lot 0.12.0",
  "quicksink",
  "rw-stream-sink",
@@ -3886,14 +3886,14 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
  "value-bag",
@@ -4033,8 +4033,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49e30813093f757be5cf21e50389a24dc7dbb22c49f23b7e8f51d69b508a5ffa"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -4090,7 +4090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
- "log 0.4.14",
+ "log 0.4.17",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
 ]
@@ -4107,12 +4107,12 @@ dependencies = [
  "env_logger",
  "futures 0.3.15",
  "futures-rustls 0.21.1",
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
  "hex 0.4.3",
  "lazy_static",
  "libp2p",
  "libp2p-floodsub 0.22.0",
- "log 0.4.14",
+ "log 0.4.17",
  "rand 0.7.3",
  "regex",
  "rmp-serde",
@@ -4511,8 +4511,8 @@ version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3048ef3680533a27f9f8e7d6a0bce44dc61e4895ea0f42709337fa1c8616fefe"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -4555,8 +4555,8 @@ checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro-error",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
  "synstructure",
 ]
@@ -4574,7 +4574,7 @@ source = "git+https://github.com/libp2p/rust-libp2p.git?tag=v0.45.1#802d00e64589
 dependencies = [
  "bytes 1.1.0",
  "futures 0.3.15",
- "log 0.4.14",
+ "log 0.4.17",
  "pin-project 1.0.10",
  "smallvec 1.6.1",
  "unsigned-varint 0.7.1",
@@ -4650,8 +4650,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -4714,8 +4714,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
 dependencies = [
  "proc-macro-crate 1.1.3",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -4789,8 +4789,8 @@ checksum = "44a0b52c2cbaef7dffa5fec1a43274afe8bd2a644fa9fc50a9ef4ff0269b1257"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -4846,8 +4846,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c45ed1f39709f5a89338fab50e59816b2e8815f5bb58276e7ddf9afd495f73f8"
 dependencies = [
  "proc-macro-crate 1.1.3",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -4881,7 +4881,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.39",
+ "proc-macro2 1.0.58",
  "syn 1.0.95",
  "synstructure",
 ]
@@ -4997,8 +4997,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aa52829b8decbef693af90202711348ab001456803ba2a98eb4ec8fb70844c"
 dependencies = [
  "peg-runtime",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
 ]
 
 [[package]]
@@ -5047,8 +5047,8 @@ version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "044964427019eed9d49d9d5bbce6047ef18f37100ea400912a9fa4a3523ab12a"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -5058,8 +5058,8 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -5133,7 +5133,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28f53e8b192565862cf99343194579a022eb9c7dd3a8d03134734803c7b3125"
 dependencies = [
- "proc-macro2 1.0.39",
+ "proc-macro2 1.0.58",
  "syn 1.0.95",
 ]
 
@@ -5187,8 +5187,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
  "version_check",
 ]
@@ -5199,8 +5199,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "version_check",
 ]
 
@@ -5221,9 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -5246,8 +5246,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e12d01b9d66ad9eb4529c57666b6263fc1993cb30261d83ead658fdd932652"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -5273,7 +5273,7 @@ dependencies = [
  "heck",
  "itertools",
  "lazy_static",
- "log 0.4.14",
+ "log 0.4.17",
  "multimap",
  "petgraph",
  "prost",
@@ -5291,8 +5291,8 @@ checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -5400,11 +5400,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
- "proc-macro2 1.0.39",
+ "proc-macro2 1.0.58",
 ]
 
 [[package]]
@@ -5563,7 +5563,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -5730,7 +5730,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
  "redox_syscall 0.2.10",
 ]
 
@@ -5749,8 +5749,8 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c523ccaed8ac4b0288948849a350b37d3035827413c458b6a40ddb614bb4f72"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -5790,7 +5790,7 @@ dependencies = [
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.14",
+ "log 0.4.17",
  "mime",
  "percent-encoding",
  "pin-project-lite 0.2.9",
@@ -5904,7 +5904,7 @@ dependencies = [
  "chain",
  "keys",
  "lazy_static",
- "log 0.4.14",
+ "log 0.4.17",
  "primitives",
  "rustc-hex",
  "script",
@@ -6030,7 +6030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64 0.13.0",
- "log 0.4.14",
+ "log 0.4.17",
  "ring",
  "sct 0.6.0",
  "webpki 0.21.3",
@@ -6042,7 +6042,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
  "ring",
  "sct 0.7.0",
  "webpki 0.22.0",
@@ -6116,8 +6116,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e334bb10a245e28e5fd755cabcafd96cfcd167c99ae63a46924ca8d8703a3c"
 dependencies = [
  "proc-macro-crate 1.1.3",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -6147,7 +6147,7 @@ dependencies = [
  "blake2b_simd",
  "chain",
  "keys",
- "log 0.4.14",
+ "log 0.4.17",
  "primitives",
  "serde",
  "serialization",
@@ -6271,8 +6271,8 @@ dependencies = [
 name = "ser_error_derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "ser_error",
  "syn 1.0.95",
 ]
@@ -6312,8 +6312,8 @@ version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -6335,8 +6335,8 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -6464,7 +6464,7 @@ dependencies = [
 name = "shared_ref_counter"
 version = "0.1.0"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
 ]
 
 [[package]]
@@ -6589,7 +6589,7 @@ dependencies = [
  "flate2",
  "futures 0.3.15",
  "httparse",
- "log 0.4.14",
+ "log 0.4.17",
  "rand 0.8.4",
  "sha-1",
 ]
@@ -6625,7 +6625,7 @@ checksum = "0c60728aec35d772e6614319558cdccbe3f845102699b65ba5ac7497da0b626a"
 dependencies = [
  "bincode",
  "bytemuck",
- "log 0.4.14",
+ "log 0.4.17",
  "num-derive",
  "num-traits",
  "rustc_version 0.4.0",
@@ -6645,7 +6645,7 @@ checksum = "1ddcd7c6adb802bc812a5a80c8de06ba0f0e8df0cca296a8b4e67cd04c16218f"
 dependencies = [
  "bv",
  "fnv",
- "log 0.4.14",
+ "log 0.4.17",
  "rand 0.7.3",
  "rayon",
  "rustc_version 0.4.0",
@@ -6663,7 +6663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3435b145894971a58a08a7b6be997ec782239fdecd5edd9846cd1d6aa5986"
 dependencies = [
  "fs_extra",
- "log 0.4.14",
+ "log 0.4.17",
  "memmap2",
  "rand 0.7.3",
  "rayon",
@@ -6717,7 +6717,7 @@ dependencies = [
  "clap",
  "indicatif",
  "jsonrpc-core",
- "log 0.4.14",
+ "log 0.4.17",
  "rayon",
  "reqwest",
  "semver 1.0.6",
@@ -6772,7 +6772,7 @@ dependencies = [
  "bincode",
  "byteorder 1.4.3",
  "clap",
- "log 0.4.14",
+ "log 0.4.17",
  "serde",
  "serde_derive",
  "solana-clap-utils",
@@ -6795,7 +6795,7 @@ dependencies = [
  "bs58",
  "bv",
  "generic-array 0.14.5",
- "log 0.4.14",
+ "log 0.4.17",
  "memmap2",
  "rustc_version 0.4.0",
  "serde",
@@ -6812,8 +6812,8 @@ version = "1.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402fffb54bf5d335e6df26fc1719feecfbd7a22fafdf6649fe78380de3c47384"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "rustc_version 0.4.0",
  "syn 1.0.95",
 ]
@@ -6826,7 +6826,7 @@ checksum = "942dc59fc9da66d178362051b658646b65dc11cea0bc804e4ecd2528d3c1279f"
 dependencies = [
  "env_logger",
  "lazy_static",
- "log 0.4.14",
+ "log 0.4.17",
 ]
 
 [[package]]
@@ -6835,7 +6835,7 @@ version = "1.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ccd5b1278b115249d6ca5a203fd852f7d856e048488c24442222ee86e682bd9"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
  "solana-sdk",
 ]
 
@@ -6848,7 +6848,7 @@ dependencies = [
  "env_logger",
  "gethostname",
  "lazy_static",
- "log 0.4.14",
+ "log 0.4.17",
  "reqwest",
  "solana-sdk",
 ]
@@ -6861,7 +6861,7 @@ checksum = "4cb530af085d8aab563530ed39703096aa526249d350082823882fdd59cdf839"
 dependencies = [
  "bincode",
  "clap",
- "log 0.4.14",
+ "log 0.4.17",
  "nix",
  "rand 0.7.3",
  "serde",
@@ -6890,7 +6890,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "libc",
- "log 0.4.14",
+ "log 0.4.17",
  "nix",
  "rand 0.7.3",
  "rayon",
@@ -6926,7 +6926,7 @@ dependencies = [
  "js-sys",
  "lazy_static",
  "libsecp256k1 0.6.0",
- "log 0.4.14",
+ "log 0.4.17",
  "num-derive",
  "num-traits",
  "parking_lot 0.11.1",
@@ -6957,7 +6957,7 @@ dependencies = [
  "itertools",
  "libc",
  "libloading",
- "log 0.4.14",
+ "log 0.4.17",
  "num-derive",
  "num-traits",
  "rustc_version 0.4.0",
@@ -6990,7 +6990,7 @@ dependencies = [
  "console",
  "dialoguer",
  "hidapi",
- "log 0.4.14",
+ "log 0.4.17",
  "num-derive",
  "num-traits",
  "parking_lot 0.11.1",
@@ -7022,7 +7022,7 @@ dependencies = [
  "index_list",
  "itertools",
  "lazy_static",
- "log 0.4.14",
+ "log 0.4.17",
  "memmap2",
  "num-derive",
  "num-traits",
@@ -7081,7 +7081,7 @@ dependencies = [
  "js-sys",
  "lazy_static",
  "libsecp256k1 0.6.0",
- "log 0.4.14",
+ "log 0.4.17",
  "memmap2",
  "num-derive",
  "num-traits",
@@ -7114,8 +7114,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c834b4e02ac911b13c13aed08b3f847e722f6be79d31b1c660c1dbd2dee83cdb"
 dependencies = [
  "bs58",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "rustversion",
  "syn 1.0.95",
 ]
@@ -7127,7 +7127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92597c0ed16d167d5ee48e5b13e92dfaed9c55b23a13ec261440136cd418649"
 dependencies = [
  "bincode",
- "log 0.4.14",
+ "log 0.4.17",
  "num-derive",
  "num-traits",
  "rustc_version 0.4.0",
@@ -7154,7 +7154,7 @@ dependencies = [
  "bincode",
  "bs58",
  "lazy_static",
- "log 0.4.14",
+ "log 0.4.17",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7176,7 +7176,7 @@ version = "1.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222e2c91640d45cd9617dfc07121555a9bdac10e6e105f6931b758f46db6faaa"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
@@ -7192,7 +7192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4cc64945010e9e76d368493ad091aa5cf43ee16f69296290ebb5c815e433232"
 dependencies = [
  "bincode",
- "log 0.4.14",
+ "log 0.4.17",
  "num-derive",
  "num-traits",
  "rustc_version 0.4.0",
@@ -7217,7 +7217,7 @@ dependencies = [
  "byteorder 1.4.3",
  "hash-db",
  "hash256-std-hasher",
- "log 0.4.14",
+ "log 0.4.17",
  "num-traits",
  "parity-scale-codec",
  "parity-util-mem",
@@ -7238,8 +7238,8 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d676664972e22a0796176e81e7bec41df461d1edf52090955cdab55f2c956ff2"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -7268,8 +7268,8 @@ checksum = "22ecb916b9664ed9f90abef0ff5a3e61454c1efea5861b2997e03f39b59b955f"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.3",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -7416,8 +7416,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f9799e6d412271cb2414597581128b03f3285f260ea49f5363d07df6a332b3e"
 dependencies = [
  "Inflector",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "serde",
  "serde_json",
  "unicode-xid 0.2.0",
@@ -7464,8 +7464,8 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "serde",
  "serde_derive",
  "syn 1.0.95",
@@ -7478,8 +7478,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7554,8 +7554,19 @@ version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+dependencies = [
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "unicode-ident",
 ]
 
@@ -7580,8 +7591,8 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
  "unicode-xid 0.2.0",
 ]
@@ -7608,7 +7619,7 @@ name = "tc_cli_client"
 version = "0.2.0"
 source = "git+https://github.com/KomodoPlatform/mm2-testcontainers-rs.git#65e738093488f1b37185af0f1d3cf0ffd23e840d"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7622,7 +7633,7 @@ source = "git+https://github.com/KomodoPlatform/mm2-testcontainers-rs.git#65e738
 dependencies = [
  "hex 0.3.2",
  "hmac 0.7.1",
- "log 0.4.14",
+ "log 0.4.17",
  "rand 0.7.3",
  "sha2 0.8.2",
  "tc_core",
@@ -7634,7 +7645,7 @@ version = "0.3.0"
 source = "git+https://github.com/KomodoPlatform/mm2-testcontainers-rs.git#65e738093488f1b37185af0f1d3cf0ffd23e840d"
 dependencies = [
  "debug_stub_derive",
- "log 0.4.14",
+ "log 0.4.17",
 ]
 
 [[package]]
@@ -7642,7 +7653,7 @@ name = "tc_dynamodb_local"
 version = "0.2.0"
 source = "git+https://github.com/KomodoPlatform/mm2-testcontainers-rs.git#65e738093488f1b37185af0f1d3cf0ffd23e840d"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
  "tc_core",
 ]
 
@@ -7667,7 +7678,7 @@ name = "tc_parity_parity"
 version = "0.5.0"
 source = "git+https://github.com/KomodoPlatform/mm2-testcontainers-rs.git#65e738093488f1b37185af0f1d3cf0ffd23e840d"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
  "tc_core",
 ]
 
@@ -7676,7 +7687,7 @@ name = "tc_postgres"
 version = "0.2.0"
 source = "git+https://github.com/KomodoPlatform/mm2-testcontainers-rs.git#65e738093488f1b37185af0f1d3cf0ffd23e840d"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
  "tc_core",
 ]
 
@@ -7780,7 +7791,7 @@ checksum = "a13e63f57ee05a1e927887191c76d1b139de9fa40c180b9f8727ee44377242a6"
 dependencies = [
  "bytes 1.1.0",
  "flex-error",
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
  "peg",
  "pin-project 1.0.10",
  "serde",
@@ -7864,8 +7875,8 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -7928,8 +7939,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "standback",
  "syn 1.0.95",
 ]
@@ -8032,8 +8043,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -8125,9 +8136,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9263bf4c9bfaae7317c1c2faf7f18491d2fe476f70c414b73bf5d445b00ffa1"
 dependencies = [
  "prettyplease",
- "proc-macro2 1.0.39",
+ "proc-macro2 1.0.58",
  "prost-build",
- "quote 1.0.18",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -8189,7 +8200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.14",
+ "log 0.4.17",
  "pin-project-lite 0.2.9",
  "tracing-attributes",
  "tracing-core",
@@ -8201,8 +8212,8 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
 ]
 
@@ -8257,7 +8268,7 @@ checksum = "d32d034c0d3db64b43c31de38e945f15b40cd4ca6d2dcfc26d4798ce8de4ab83"
 dependencies = [
  "hash-db",
  "hashbrown 0.12.1",
- "log 0.4.14",
+ "log 0.4.17",
  "smallvec 1.6.1",
 ]
 
@@ -8295,7 +8306,7 @@ dependencies = [
  "idna",
  "ipnet",
  "lazy_static",
- "log 0.4.14",
+ "log 0.4.17",
  "rand 0.8.4",
  "smallvec 1.6.1",
  "thiserror",
@@ -8314,7 +8325,7 @@ dependencies = [
  "futures-util",
  "ipconfig",
  "lazy_static",
- "log 0.4.14",
+ "log 0.4.17",
  "lru-cache",
  "parking_lot 0.12.0",
  "resolv-conf",
@@ -8341,7 +8352,7 @@ dependencies = [
  "bytes 1.1.0",
  "http 0.2.7",
  "httparse",
- "log 0.4.14",
+ "log 0.4.17",
  "rand 0.8.4",
  "rustls 0.20.4",
  "sha-1",
@@ -8520,16 +8531,16 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
  "rand 0.8.4",
  "serde",
 ]
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
  "ctor",
  "version_check",
@@ -8582,7 +8593,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.14",
+ "log 0.4.17",
  "try-lock",
 ]
 
@@ -8606,9 +8617,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -8616,16 +8627,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
- "lazy_static",
- "log 0.4.14",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "log 0.4.17",
+ "once_cell",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
@@ -8643,32 +8654,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
- "quote 1.0.18",
+ "quote 1.0.27",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -8690,8 +8701,8 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c2e18093f11c19ca4e188c177fecc7c372304c311189f12c2f9bea5b7324ac7"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
 ]
 
 [[package]]
@@ -8730,12 +8741,12 @@ dependencies = [
  "ethereum-types",
  "futures 0.3.15",
  "futures-timer",
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
  "hex 0.4.3",
  "idna",
  "js-sys",
  "jsonrpc-core",
- "log 0.4.14",
+ "log 0.4.17",
  "parking_lot 0.12.0",
  "pin-project 1.0.10",
  "rand 0.8.4",
@@ -9017,7 +9028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0608f53c1dc0bad505d03a34bbd49fbf2ad7b51eb036123e896365532745a1"
 dependencies = [
  "futures 0.3.15",
- "log 0.4.14",
+ "log 0.4.17",
  "nohash-hasher",
  "parking_lot 0.12.0",
  "rand 0.8.4",
@@ -9106,7 +9117,7 @@ dependencies = [
  "hex 0.4.3",
  "jubjub",
  "lazy_static",
- "log 0.4.14",
+ "log 0.4.17",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "ripemd160",
@@ -9149,8 +9160,8 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.95",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-timer",
  "web-sys",
  "web3",
  "webpki-roots",
@@ -1191,6 +1190,7 @@ dependencies = [
  "http-body 0.1.0",
  "hyper",
  "hyper-rustls",
+ "instant",
  "itertools",
  "js-sys",
  "lazy_static",
@@ -1216,7 +1216,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-timer",
  "web-sys",
  "winapi",
 ]
@@ -4365,7 +4364,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-timer",
  "web-sys",
  "winapi",
 ]
@@ -4411,7 +4409,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-timer",
 ]
 
 [[package]]

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -150,7 +150,6 @@ winapi = "0.3"
 
 [dev-dependencies]
 mm2_test_helpers = { path = "../mm2_test_helpers" }
-wasm-timer = "0.2.4"
 
 [build-dependencies]
 prost-build = { version = "0.10.4", default-features = false }

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -116,7 +116,7 @@ js-sys = { version = "0.3.27" }
 mm2_db = { path = "../mm2_db" }
 mm2_metamask = { path = "../mm2_metamask" }
 mm2_test_helpers = { path = "../mm2_test_helpers" }
-wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
+wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = { version = "0.4.1" }
 wasm-bindgen-test = { version = "0.3.2" }
 web-sys = { version = "0.3.55", features = ["console", "Headers", "Request", "RequestInit", "RequestMode", "Response", "Window"] }

--- a/mm2src/coins/lp_price.rs
+++ b/mm2src/coins/lp_price.rs
@@ -295,7 +295,7 @@ mod tests {
     #[test]
     fn test_get_cex_rates() {
         use mm2_number::MmNumber;
-        use wasm_timer::SystemTime;
+        use std::time::SystemTime;
 
         use crate::lp_price::{Provider, TickerInfos, TickerInfosRegistry};
 

--- a/mm2src/coins/nft/nft_errors.rs
+++ b/mm2src/coins/nft/nft_errors.rs
@@ -10,8 +10,6 @@ use web3::Error;
 #[derive(Clone, Debug, Deserialize, Display, EnumFromStringify, PartialEq, Serialize, SerializeErrorType)]
 #[serde(tag = "error_type", content = "error_data")]
 pub enum GetNftInfoError {
-    /// `http::Error` can appear on an HTTP request [`http::Builder::build`] building.
-    #[from_stringify("http::Error")]
     #[display(fmt = "Invalid request: {}", _0)]
     InvalidRequest(String),
     #[display(fmt = "Transport: {}", _0)]
@@ -31,17 +29,7 @@ pub enum GetNftInfoError {
         token_address: String,
         token_id: String,
     },
-}
-
-impl From<SlurpError> for GetNftInfoError {
-    fn from(e: SlurpError) -> Self {
-        let error_str = e.to_string();
-        match e {
-            SlurpError::ErrorDeserializing { .. } => GetNftInfoError::InvalidResponse(error_str),
-            SlurpError::Transport { .. } | SlurpError::Timeout { .. } => GetNftInfoError::Transport(error_str),
-            SlurpError::Internal(_) | SlurpError::InvalidRequest(_) => GetNftInfoError::Internal(error_str),
-        }
-    }
+    AddressError(String),
 }
 
 impl From<web3::Error> for GetNftInfoError {
@@ -61,6 +49,17 @@ impl From<GetEthAddressError> for GetNftInfoError {
     fn from(e: GetEthAddressError) -> Self { GetNftInfoError::GetEthAddressError(e) }
 }
 
+impl From<GetInfoFromUriError> for GetNftInfoError {
+    fn from(e: GetInfoFromUriError) -> Self {
+        match e {
+            GetInfoFromUriError::InvalidRequest(e) => GetNftInfoError::InvalidRequest(e),
+            GetInfoFromUriError::Transport(e) => GetNftInfoError::Transport(e),
+            GetInfoFromUriError::InvalidResponse(e) => GetNftInfoError::InvalidResponse(e),
+            GetInfoFromUriError::Internal(e) => GetNftInfoError::Internal(e),
+        }
+    }
+}
+
 impl HttpStatusCode for GetNftInfoError {
     fn status_code(&self) -> StatusCode {
         match self {
@@ -69,7 +68,34 @@ impl HttpStatusCode for GetNftInfoError {
             GetNftInfoError::Transport(_)
             | GetNftInfoError::Internal(_)
             | GetNftInfoError::GetEthAddressError(_)
-            | GetNftInfoError::TokenNotFoundInWallet { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            | GetNftInfoError::TokenNotFoundInWallet { .. }
+            | GetNftInfoError::AddressError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Display, EnumFromStringify, PartialEq, Serialize)]
+pub(crate) enum GetInfoFromUriError {
+    /// `http::Error` can appear on an HTTP request [`http::Builder::build`] building.
+    #[from_stringify("http::Error")]
+    #[display(fmt = "Invalid request: {}", _0)]
+    InvalidRequest(String),
+    #[display(fmt = "Transport: {}", _0)]
+    Transport(String),
+    #[from_stringify("serde_json::Error")]
+    #[display(fmt = "Invalid response: {}", _0)]
+    InvalidResponse(String),
+    #[display(fmt = "Internal: {}", _0)]
+    Internal(String),
+}
+
+impl From<SlurpError> for GetInfoFromUriError {
+    fn from(e: SlurpError) -> Self {
+        let error_str = e.to_string();
+        match e {
+            SlurpError::ErrorDeserializing { .. } => GetInfoFromUriError::InvalidResponse(error_str),
+            SlurpError::Transport { .. } | SlurpError::Timeout { .. } => GetInfoFromUriError::Transport(error_str),
+            SlurpError::Internal(_) | SlurpError::InvalidRequest(_) => GetInfoFromUriError::Internal(error_str),
         }
     }
 }

--- a/mm2src/coins/nft/nft_structs.rs
+++ b/mm2src/coins/nft/nft_structs.rs
@@ -3,6 +3,7 @@ use ethereum_types::Address;
 use mm2_number::BigDecimal;
 use rpc::v1::types::Bytes as BytesJson;
 use serde::Deserialize;
+use serde_json::Value as Json;
 use std::fmt;
 use std::str::FromStr;
 use url::Url;
@@ -34,11 +35,11 @@ pub(crate) enum Chain {
 impl fmt::Display for Chain {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
-            Chain::Avalanche => write!(f, "avalanche"),
-            Chain::Bsc => write!(f, "bsc"),
-            Chain::Eth => write!(f, "eth"),
-            Chain::Fantom => write!(f, "fantom"),
-            Chain::Polygon => write!(f, "polygon"),
+            Chain::Avalanche => write!(f, "AVALANCHE"),
+            Chain::Bsc => write!(f, "BSC"),
+            Chain::Eth => write!(f, "ETH"),
+            Chain::Fantom => write!(f, "FANTOM"),
+            Chain::Polygon => write!(f, "POLYGON"),
         }
     }
 }
@@ -84,6 +85,16 @@ impl FromStr for ContractType {
     }
 }
 
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub(crate) struct UriMeta {
+    pub(crate) image: Option<String>,
+    #[serde(rename(deserialize = "name"))]
+    pub(crate) token_name: Option<String>,
+    description: Option<String>,
+    attributes: Option<Json>,
+    animation_url: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct Nft {
     pub(crate) chain: Chain,
@@ -95,7 +106,7 @@ pub struct Nft {
     pub(crate) block_number_minted: u64,
     pub(crate) block_number: u64,
     pub(crate) contract_type: Option<ContractType>,
-    pub(crate) name: Option<String>,
+    pub(crate) collection_name: Option<String>,
     pub(crate) symbol: Option<String>,
     pub(crate) token_uri: Option<String>,
     pub(crate) metadata: Option<String>,
@@ -103,6 +114,7 @@ pub struct Nft {
     pub(crate) last_metadata_sync: Option<String>,
     pub(crate) minter_address: Option<String>,
     pub(crate) possible_spam: Option<bool>,
+    pub(crate) uri_meta: UriMeta,
 }
 
 /// This structure is for deserializing NFT json to struct.
@@ -223,6 +235,12 @@ pub struct NftTransfersReq {
     pub(crate) url: Url,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) enum TransferStatus {
+    Receive,
+    Send,
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct NftTransferHistory {
     pub(crate) chain: Chain,
@@ -238,8 +256,12 @@ pub(crate) struct NftTransferHistory {
     pub(crate) transaction_type: String,
     pub(crate) token_address: String,
     pub(crate) token_id: BigDecimal,
+    pub(crate) collection_name: Option<String>,
+    pub(crate) image: Option<String>,
+    pub(crate) token_name: Option<String>,
     pub(crate) from_address: String,
     pub(crate) to_address: String,
+    pub(crate) status: TransferStatus,
     pub(crate) amount: BigDecimal,
     pub(crate) verified: u64,
     pub(crate) operator: Option<String>,

--- a/mm2src/coins/nft/nft_tests.rs
+++ b/mm2src/coins/nft/nft_tests.rs
@@ -5,14 +5,14 @@ const TEST_WALLET_ADDR_EVM: &str = "0x394d86994f954ed931b86791b62fe64f4c5dac37";
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod native_tests {
-    use crate::nft::nft_structs::{NftTransferHistoryWrapper, NftWrapper};
+    use crate::nft::nft_structs::{NftTransferHistoryWrapper, NftWrapper, UriMeta};
     use crate::nft::nft_tests::{NFT_HISTORY_URL_TEST, NFT_LIST_URL_TEST, NFT_METADATA_URL_TEST, TEST_WALLET_ADDR_EVM};
-    use crate::nft::send_moralis_request;
+    use crate::nft::send_request_to_uri;
     use common::block_on;
 
     #[test]
     fn test_moralis_nft_list() {
-        let response = block_on(send_moralis_request(NFT_LIST_URL_TEST)).unwrap();
+        let response = block_on(send_request_to_uri(NFT_LIST_URL_TEST)).unwrap();
         let nfts_list = response["result"].as_array().unwrap();
         assert_eq!(2, nfts_list.len());
         for nft_json in nfts_list {
@@ -23,7 +23,7 @@ mod native_tests {
 
     #[test]
     fn test_moralis_nft_transfer_history() {
-        let response = block_on(send_moralis_request(NFT_HISTORY_URL_TEST)).unwrap();
+        let response = block_on(send_request_to_uri(NFT_HISTORY_URL_TEST)).unwrap();
         let mut transfer_list = response["result"].as_array().unwrap().clone();
         assert_eq!(4, transfer_list.len());
         let last_tx = transfer_list.remove(0);
@@ -33,9 +33,12 @@ mod native_tests {
 
     #[test]
     fn test_moralis_nft_metadata() {
-        let response = block_on(send_moralis_request(NFT_METADATA_URL_TEST)).unwrap();
+        let response = block_on(send_request_to_uri(NFT_METADATA_URL_TEST)).unwrap();
         let nft_wrapper: NftWrapper = serde_json::from_str(&response.to_string()).unwrap();
-        assert_eq!(41237364, *nft_wrapper.block_number_minted)
+        assert_eq!(41237364, *nft_wrapper.block_number_minted);
+        let token_uri = nft_wrapper.token_uri.unwrap();
+        let uri_response = block_on(send_request_to_uri(token_uri.as_str())).unwrap();
+        serde_json::from_str::<UriMeta>(&uri_response.to_string()).unwrap();
     }
 }
 
@@ -43,14 +46,14 @@ mod native_tests {
 mod wasm_tests {
     use crate::nft::nft_structs::{NftTransferHistoryWrapper, NftWrapper};
     use crate::nft::nft_tests::{NFT_HISTORY_URL_TEST, NFT_LIST_URL_TEST, NFT_METADATA_URL_TEST, TEST_WALLET_ADDR_EVM};
-    use crate::nft::send_moralis_request;
+    use crate::nft::send_request_to_uri;
     use wasm_bindgen_test::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[wasm_bindgen_test]
     async fn test_moralis_nft_list() {
-        let response = send_moralis_request(NFT_LIST_URL_TEST).await.unwrap();
+        let response = send_request_to_uri(NFT_LIST_URL_TEST).await.unwrap();
         let nfts_list = response["result"].as_array().unwrap();
         assert_eq!(2, nfts_list.len());
         for nft_json in nfts_list {
@@ -61,7 +64,7 @@ mod wasm_tests {
 
     #[wasm_bindgen_test]
     async fn test_moralis_nft_transfer_history() {
-        let response = send_moralis_request(NFT_HISTORY_URL_TEST).await.unwrap();
+        let response = send_request_to_uri(NFT_HISTORY_URL_TEST).await.unwrap();
         let mut transfer_list = response["result"].as_array().unwrap().clone();
         assert_eq!(4, transfer_list.len());
         let last_tx = transfer_list.remove(0);
@@ -71,8 +74,8 @@ mod wasm_tests {
 
     #[wasm_bindgen_test]
     async fn test_moralis_nft_metadata() {
-        let response = send_moralis_request(NFT_METADATA_URL_TEST).await.unwrap();
+        let response = send_request_to_uri(NFT_METADATA_URL_TEST).await.unwrap();
         let nft_wrapper: NftWrapper = serde_json::from_str(&response.to_string()).unwrap();
-        assert_eq!(41237364, *nft_wrapper.block_number_minted)
+        assert_eq!(41237364, *nft_wrapper.block_number_minted);
     }
 }

--- a/mm2src/coins/nft/nft_tests.rs
+++ b/mm2src/coins/nft/nft_tests.rs
@@ -14,7 +14,6 @@ mod native_tests {
     fn test_moralis_nft_list() {
         let response = block_on(send_request_to_uri(NFT_LIST_URL_TEST)).unwrap();
         let nfts_list = response["result"].as_array().unwrap();
-        assert_eq!(2, nfts_list.len());
         for nft_json in nfts_list {
             let nft_wrapper: NftWrapper = serde_json::from_str(&nft_json.to_string()).unwrap();
             assert_eq!(TEST_WALLET_ADDR_EVM, nft_wrapper.owner_of);
@@ -25,10 +24,10 @@ mod native_tests {
     fn test_moralis_nft_transfer_history() {
         let response = block_on(send_request_to_uri(NFT_HISTORY_URL_TEST)).unwrap();
         let mut transfer_list = response["result"].as_array().unwrap().clone();
-        assert_eq!(4, transfer_list.len());
-        let last_tx = transfer_list.remove(0);
-        let transfer_wrapper: NftTransferHistoryWrapper = serde_json::from_str(&last_tx.to_string()).unwrap();
-        assert_eq!(TEST_WALLET_ADDR_EVM, transfer_wrapper.from_address);
+        assert!(!transfer_list.is_empty());
+        let first_tx = transfer_list.remove(transfer_list.len() - 1);
+        let transfer_wrapper: NftTransferHistoryWrapper = serde_json::from_str(&first_tx.to_string()).unwrap();
+        assert_eq!(TEST_WALLET_ADDR_EVM, transfer_wrapper.to_address);
     }
 
     #[test]
@@ -55,7 +54,6 @@ mod wasm_tests {
     async fn test_moralis_nft_list() {
         let response = send_request_to_uri(NFT_LIST_URL_TEST).await.unwrap();
         let nfts_list = response["result"].as_array().unwrap();
-        assert_eq!(2, nfts_list.len());
         for nft_json in nfts_list {
             let nft_wrapper: NftWrapper = serde_json::from_str(&nft_json.to_string()).unwrap();
             assert_eq!(TEST_WALLET_ADDR_EVM, nft_wrapper.owner_of);
@@ -66,10 +64,10 @@ mod wasm_tests {
     async fn test_moralis_nft_transfer_history() {
         let response = send_request_to_uri(NFT_HISTORY_URL_TEST).await.unwrap();
         let mut transfer_list = response["result"].as_array().unwrap().clone();
-        assert_eq!(4, transfer_list.len());
-        let last_tx = transfer_list.remove(0);
-        let transfer_wrapper: NftTransferHistoryWrapper = serde_json::from_str(&last_tx.to_string()).unwrap();
-        assert_eq!(TEST_WALLET_ADDR_EVM, transfer_wrapper.from_address);
+        assert!(!transfer_list.is_empty());
+        let first_tx = transfer_list.remove(transfer_list.len() - 1);
+        let transfer_wrapper: NftTransferHistoryWrapper = serde_json::from_str(&first_tx.to_string()).unwrap();
+        assert_eq!(TEST_WALLET_ADDR_EVM, transfer_wrapper.to_address);
     }
 
     #[wasm_bindgen_test]

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -1587,8 +1587,8 @@ fn kmd_interest(
     const N_S7_HARDFORK_HEIGHT: u64 = 3_484_958;
     // MINUTES_PER_YEAR = 365 * 24 * 60
     const MINUTES_PER_YEAR: u64 = 525_600;
-    // Active user rewards per minute before N_S7_HARDFORK_HEIGHT
-    const AUR_PER_MINUTE: f64 = 0.05 / MINUTES_PER_YEAR as f64;
+    // Minutes required for 100% active user reward before N_S7_HARDFORK_HEIGHT
+    const MINUTES_PER_AUR: u64 = 20 * MINUTES_PER_YEAR;
 
     // value must be at least 10 KMD
     if value < 1_000_000_000 {
@@ -1630,16 +1630,15 @@ fn kmd_interest(
     if height >= 1_000_000 && minutes > 31 * 24 * 60 {
         minutes = 31 * 24 * 60;
     }
-    // Some of these lines are ported as is from Komodo codebase
     minutes -= 59;
-    let mut accrued = (value as f64 * AUR_PER_MINUTE) as u64 * minutes;
     // KIP-0001 proposed a reduction of the AUR from 5% to 0.01%
     // https://github.com/KomodoPlatform/kips/blob/main/kip-0001.mediawiki
     // https://github.com/KomodoPlatform/komodo/pull/584
-    if height >= N_S7_HARDFORK_HEIGHT {
-        accrued /= 500;
+    let accrued = if height >= N_S7_HARDFORK_HEIGHT {
+        (value / MINUTES_PER_AUR) * minutes / 500
+    } else {
+        (value / MINUTES_PER_AUR) * minutes
     };
-    drop_mutability!(accrued);
 
     Ok(accrued)
 }

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -1574,7 +1574,6 @@ impl UtxoHDAccount {
 }
 
 /// Function calculating KMD interest
-/// https://komodoplatform.atlassian.net/wiki/spaces/KPSD/pages/71729215/What+is+the+5+Komodo+Stake+Reward
 /// https://github.com/KomodoPlatform/komodo/blob/master/src/komodo_interest.h
 fn kmd_interest(
     height: Option<u64>,
@@ -1584,6 +1583,12 @@ fn kmd_interest(
 ) -> Result<u64, KmdRewardsNotAccruedReason> {
     const KOMODO_ENDOFERA: u64 = 7_777_777;
     const LOCKTIME_THRESHOLD: u64 = 500_000_000;
+    // dPoW Season 7, Fri Jun 30 2023
+    const N_S7_HARDFORK_HEIGHT: u64 = 3_484_958;
+    // MINUTES_PER_YEAR = 365 * 24 * 60
+    const MINUTES_PER_YEAR: u64 = 525_600;
+    // Active user rewards per minute before N_S7_HARDFORK_HEIGHT
+    const AUR_PER_MINUTE: f64 = 0.05 / MINUTES_PER_YEAR as f64;
 
     // value must be at least 10 KMD
     if value < 1_000_000_000 {
@@ -1618,16 +1623,23 @@ fn kmd_interest(
     }
 
     // interest stop accruing after 1 year before block 1000000
-    if minutes > 365 * 24 * 60 {
-        minutes = 365 * 24 * 60
+    if minutes > MINUTES_PER_YEAR {
+        minutes = MINUTES_PER_YEAR
     };
     // interest stop accruing after 1 month past 1000000 block
     if height >= 1_000_000 && minutes > 31 * 24 * 60 {
         minutes = 31 * 24 * 60;
     }
-    // next 2 lines ported as is from Komodo codebase
+    // Some of these lines are ported as is from Komodo codebase
     minutes -= 59;
-    let accrued = (value / 10_512_000) * minutes;
+    let mut accrued = (value as f64 * AUR_PER_MINUTE) as u64 * minutes;
+    // KIP-0001 proposed a reduction of the AUR from 5% to 0.01%
+    // https://github.com/KomodoPlatform/kips/blob/main/kip-0001.mediawiki
+    // https://github.com/KomodoPlatform/komodo/pull/584
+    if height >= N_S7_HARDFORK_HEIGHT {
+        accrued /= 500;
+    };
+    drop_mutability!(accrued);
 
     Ok(accrued)
 }

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -349,6 +349,21 @@ fn test_kmd_interest_accrue_stop_at() {
 }
 
 #[test]
+// Test case taken from this PR: https://github.com/KomodoPlatform/komodo/pull/584
+fn test_kmd_interest_kip_0001_reduction() {
+    let height = Some(7777776);
+    let value = 64605500822;
+    let lock_time = 1663839248;
+    let current_time = 1663839248 + (31 * 24 * 60 - 1) * 60 + 3600;
+
+    // Starting from dPoW 7th season, according to KIP0001 AUR should be reduced from 5% to 0.01%, i.e. div by 500
+    let expected = value / 10512000 * (31 * 24 * 60 - 59) / 500;
+    println!("expected: {}", expected);
+    let actual = kmd_interest(height, value, lock_time, current_time).unwrap();
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn test_sat_from_big_decimal() {
     let amount = "0.000001".parse().unwrap();
     let sat = sat_from_big_decimal(&amount, 18).unwrap();

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -30,7 +30,7 @@ http = "0.2"
 http-body = "0.1"
 itertools = "0.10"
 lazy_static = "1.4"
-log = "0.4.8"
+log = "0.4.17"
 parking_lot = { version = "0.12.0", features = ["nightly"] }
 parking_lot_core = { version = "0.6", features = ["nightly"] }
 primitive-types = "0.11.1"
@@ -48,13 +48,13 @@ instant = { version = "0.1.12" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 chrono = { version = "0.4", features = ["wasmbind"] }
-getrandom = { version = "0.2", features = ["js"] } # see https://docs.rs/getrandom/0.2.0/getrandom/#webassembly-support
+getrandom = { version = "0.2.9", features = ["js"] } # see https://docs.rs/getrandom/0.2.0/getrandom/#webassembly-support
 gstuff = { version = "0.7", features = ["nightly"] }
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 js-sys = "0.3.27"
 serde_repr = "0.1.6"
 serde-wasm-bindgen = "0.4.3"
-wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
+wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = "0.4.21"
 wasm-bindgen-test = { version = "0.3.2" }
 web-sys = { version = "0.3.55", features = ["console", "CloseEvent", "DomException", "ErrorEvent", "IdbDatabase", "IdbCursor", "IdbCursorWithValue", "IdbFactory", "IdbIndex", "IdbIndexParameters", "IdbObjectStore", "IdbObjectStoreParameters", "IdbOpenDbRequest", "IdbKeyRange", "IdbTransaction", "IdbTransactionMode", "IdbVersionChangeEvent", "MessageEvent", "WebSocket"] }

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -44,12 +44,13 @@ ser_error_derive = { path = "../derives/ser_error_derive" }
 sha2 = "0.9"
 shared_ref_counter = { path = "shared_ref_counter", optional = true }
 uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
-wasm-timer = "0.2.4"
+instant = { version = "0.1.12" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] } # see https://docs.rs/getrandom/0.2.0/getrandom/#webassembly-support
 gstuff = { version = "0.7", features = ["nightly"] }
+instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 js-sys = "0.3.27"
 serde_repr = "0.1.6"
 serde-wasm-bindgen = "0.4.3"

--- a/mm2src/common/shared_ref_counter/Cargo.toml
+++ b/mm2src/common/shared_ref_counter/Cargo.toml
@@ -10,4 +10,4 @@ doctest = false
 enable = []
 
 [dependencies]
-log = { version = "0.4.8", optional = true }
+log = { version = "0.4.17", optional = true }

--- a/mm2src/common/time_cache.rs
+++ b/mm2src/common/time_cache.rs
@@ -21,12 +21,12 @@
 //! This implements a time-based LRU cache for checking gossipsub message duplicates.
 
 use fnv::FnvHashMap;
+use instant::Instant;
 use std::collections::hash_map::{self,
                                  Entry::{Occupied, Vacant},
                                  Iter, Keys};
 use std::collections::VecDeque;
 use std::time::Duration;
-use wasm_timer::Instant;
 
 #[derive(Debug)]
 pub struct ExpiringElement<Element> {

--- a/mm2src/db_common/Cargo.toml
+++ b/mm2src/db_common/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 [dependencies]
 common = { path = "../common" }
 hex = "0.4.2"
-log = "0.4.8"
+log = "0.4.17"
 uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/mm2src/gossipsub/Cargo.toml
+++ b/mm2src/gossipsub/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3.1"
 futures_codec = "0.4.0"
 libp2p-swarm = { git = "https://github.com/libp2p/rust-libp2p.git", tag ="v0.45.1" }
 libp2p-core = { git = "https://github.com/libp2p/rust-libp2p.git", tag ="v0.45.1" }
-log = "0.4.8"
+log = "0.4.17"
 prost = "0.10"
 rand = "0.7"
 sha2 = "0.9"

--- a/mm2src/hw_common/Cargo.toml
+++ b/mm2src/hw_common/Cargo.toml
@@ -22,7 +22,7 @@ rusb = { version = "0.7.0", features = ["vendored"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3.27" }
-wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
+wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = { version = "0.4.1" }
 wasm-bindgen-test = { version = "0.3.1" }
 web-sys = { version = "0.3.55", features = ["console", "Navigator", "Usb", "UsbDevice", "UsbDeviceRequestOptions", "UsbInTransferResult"] }

--- a/mm2src/ledger/Cargo.toml
+++ b/mm2src/ledger/Cargo.toml
@@ -15,7 +15,7 @@ serde_derive = "1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3.27" }
-wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
+wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = { version = "0.4.1" }
 wasm-bindgen-test = { version = "0.3.1" }
 web-sys = { version = "0.3.55" }

--- a/mm2src/mm2_bin_lib/Cargo.toml
+++ b/mm2src/mm2_bin_lib/Cargo.toml
@@ -51,7 +51,7 @@ gstuff = { version = "0.7", features = ["nightly"] }
 js-sys = { version = "0.3.27" }
 mm2_rpc = { path = "../mm2_rpc" }
 serde = "1.0"
-wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
+wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = { version = "0.4.1" }
 
 [target.x86_64-unknown-linux-gnu.dependencies]

--- a/mm2src/mm2_bin_lib/Cargo.toml
+++ b/mm2src/mm2_bin_lib/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "mm2_bin_lib"
-version = "1.0.4-beta"
+version = "1.0.5-beta"
 authors = ["James Lee", "Artem Pikulin", "Artem Grinblat", "Omar S.", "Onur Ozkan", "Alina Sharon", "Caglar Kaya", "Cipi", "Sergey Boiko", "Samuel Onoja", "Roman Sztergbaum", "Kadan Stadelmann <ca333@komodoplatform.com>"]
 edition = "2018"
 default-run = "mm2"

--- a/mm2src/mm2_bitcoin/rpc/Cargo.toml
+++ b/mm2src/mm2_bitcoin/rpc/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Ethcore <admin@ethcore.io>"]
 doctest = false
 
 [dependencies]
-log = "0.4"
+log = "0.4.17"
 serde = "1.0"
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
 serde_derive = "1.0"

--- a/mm2src/mm2_bitcoin/script/Cargo.toml
+++ b/mm2src/mm2_bitcoin/script/Cargo.toml
@@ -13,5 +13,5 @@ keys = { path = "../keys" }
 primitives = { path = "../primitives" }
 serde = "1.0"
 serialization = { path = "../serialization" }
-log = "0.4"
+log = "0.4.17"
 blake2b_simd = "0.5"

--- a/mm2src/mm2_db/Cargo.toml
+++ b/mm2src/mm2_db/Cargo.toml
@@ -24,7 +24,7 @@ primitives = { path = "../mm2_bitcoin/primitives" }
 rand = { version = "0.7", features = ["std", "small_rng", "wasm-bindgen"] }
 serde = "1"
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
-wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
+wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = { version = "0.4.1" }
 wasm-bindgen-test = { version = "0.3.2" }
 web-sys = { version = "0.3.55", features = ["console", "CloseEvent", "DomException", "ErrorEvent", "IdbDatabase", "IdbCursor", "IdbCursorWithValue", "IdbCursorDirection", "IdbFactory", "IdbIndex", "IdbIndexParameters", "IdbObjectStore", "IdbObjectStoreParameters", "IdbOpenDbRequest", "IdbKeyRange", "IdbTransaction", "IdbTransactionMode", "IdbVersionChangeEvent", "MessageEvent", "WebSocket"] }

--- a/mm2src/mm2_libp2p/Cargo.toml
+++ b/mm2src/mm2_libp2p/Cargo.toml
@@ -18,7 +18,7 @@ futures-rustls = { version = "0.21.1" }
 hex = "0.4.2"
 lazy_static = "1.4"
 secp256k1 = { version = "0.20", features = ["rand"] }
-log = "0.4.8"
+log = "0.4.17"
 rand = { package = "rand", version = "0.7", features = ["std", "wasm-bindgen"] }
 regex = "1"
 rmp-serde = "0.14.3"
@@ -33,7 +33,7 @@ tokio = { version = "1.20", features = ["rt-multi-thread", "macros"] }
 libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", tag = "v0.45.1", default-features = false, features = ["dns-tokio", "floodsub", "mplex", "noise", "ping", "request-response", "secp256k1", "tcp-tokio", "websocket"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] } # see https://docs.rs/getrandom/0.2.0/getrandom/#webassembly-support
+getrandom = { version = "0.2.9", features = ["js"] } # see https://docs.rs/getrandom/0.2.0/getrandom/#webassembly-support
 libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", tag = "v0.45.1", default-features = false, features = ["floodsub", "mplex", "noise", "ping", "request-response", "secp256k1", "wasm-ext", "wasm-ext-websocket"] }
 wasm-bindgen-futures = "0.4.21"
 

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -97,7 +97,7 @@ instant = { version = "0.1.12", features = ["wasm-bindgen"] }
 js-sys = { version = "0.3.27" }
 mm2_db = { path = "../mm2_db" }
 mm2_test_helpers = { path = "../mm2_test_helpers" }
-wasm-bindgen = { version = "=0.2.78", features = ["nightly"] }
+wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = { version = "0.4.1" }
 wasm-bindgen-test = { version = "0.3.1" }
 web-sys = { version = "0.3.55", features = ["console"] }

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -90,7 +90,7 @@ sp-trie = { version = "6.0", default-features = false }
 trie-db = { version = "0.23.1", default-features = false }
 trie-root = "0.16.0"
 uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
-wasm-timer = "0.2.4"
+instant = { version = "0.1.12" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }

--- a/mm2src/mm2_main/src/lp_network.rs
+++ b/mm2src/mm2_main/src/lp_network.rs
@@ -23,6 +23,7 @@ use common::executor::SpawnFuture;
 use common::{log, Future01CompatExt};
 use derive_more::Display;
 use futures::{channel::oneshot, StreamExt};
+use instant::Instant;
 use keys::KeyPair;
 use mm2_core::mm_ctx::{MmArc, MmWeak};
 use mm2_err_handle::prelude::*;
@@ -37,7 +38,6 @@ use parking_lot::Mutex as PaMutex;
 use serde::de;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
-use wasm_timer::Instant;
 
 use crate::mm2::lp_ordermatch;
 use crate::mm2::{lp_stats, lp_swap};

--- a/mm2src/mm2_main/src/lp_ordermatch/order_requests_tracker.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/order_requests_tracker.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
+use instant::Instant;
 use std::{collections::hash_map::{HashMap, RawEntryMut},
           num::NonZeroUsize,
           time::Duration};
-use wasm_timer::Instant;
 
 const ONE_SECOND: Duration = Duration::from_secs(1);
 

--- a/mm2src/mm2_metamask/Cargo.toml
+++ b/mm2src/mm2_metamask/Cargo.toml
@@ -18,6 +18,6 @@ parking_lot = { version = "0.12.0", features = ["nightly"] }
 serde = "1.0"
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
 serde_derive = "1.0"
-wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
+wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = { version = "0.4.1" }
 web3 = { git = "https://github.com/KomodoPlatform/rust-web3", tag = "v0.19.0", default-features = false, features = ["eip-1193"] }

--- a/mm2src/mm2_metrics/Cargo.toml
+++ b/mm2src/mm2_metrics/Cargo.toml
@@ -18,7 +18,6 @@ mm2_err_handle = { path = "../mm2_err_handle" }
 serde = "1"
 serde_derive = "1"
 serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
-wasm-timer = "0.2.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper = { version = "0.14.11", features = ["client", "http2", "server", "tcp"] }

--- a/mm2src/mm2_metrics/src/mm_metrics.rs
+++ b/mm2src/mm2_metrics/src/mm_metrics.rs
@@ -386,7 +386,7 @@ mod test {
     use common::{block_on,
                  executor::{abortable_queue::AbortableQueue, Timer},
                  log::{LogArc, LogState}};
-    use wasm_timer::Instant;
+    use std::time::Instant;
 
     #[test]
     fn test_collect_json() {

--- a/mm2src/mm2_net/Cargo.toml
+++ b/mm2src/mm2_net/Cargo.toml
@@ -25,7 +25,7 @@ prost = "0.10"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gstuff = { version = "0.7", features = ["nightly"] }
-wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
+wasm-bindgen = "0.2.86"
 wasm-bindgen-test = { version = "0.3.2" }
 wasm-bindgen-futures = "0.4.21"
 web-sys = { version = "0.3.55", features = ["console", "CloseEvent", "DomException", "ErrorEvent", "IdbDatabase", "IdbCursor", "IdbCursorWithValue", "IdbFactory", "IdbIndex", "IdbIndexParameters", "IdbObjectStore", "IdbObjectStoreParameters", "IdbOpenDbRequest", "IdbKeyRange", "IdbTransaction", "IdbTransactionMode", "IdbVersionChangeEvent", "MessageEvent", "WebSocket"] }

--- a/mm2src/trezor/Cargo.toml
+++ b/mm2src/trezor/Cargo.toml
@@ -25,7 +25,7 @@ bip32 = { version = "0.2.2", default-features = false, features = ["alloc", "sec
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3.27" }
-wasm-bindgen = { version = "0.2.50", features = ["nightly"] }
+wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = { version = "0.4.1" }
 wasm-bindgen-test = { version = "0.3.1" }
 web-sys = { version = "0.3.55" }


### PR DESCRIPTION
**Features:**
- NFT integration [#900](https://github.com/KomodoPlatform/atomicDEX-API/issues/900)
  - UriMeta was added to get info from token uri, status and metadata in nft tx history [#1823](https://github.com/KomodoPlatform/atomicDEX-API/pull/1823)

**Enhancements/Fixes:**
- Deprecated `wasm-timer` dependency was removed from mm2 tree [#1836](https://github.com/KomodoPlatform/atomicDEX-API/pull/1836)
- `log`, `getrandom` and `wasm-bindgen` dependencies were updated to more recent versions that are inline with the latest libp2p upstream [#1837](https://github.com/KomodoPlatform/atomicDEX-API/pull/1837)
- A CI lint pipeline was added that validates pull request titles to ensure that they comply with the conventional commit specifications [#1839](https://github.com/KomodoPlatform/atomicDEX-API/pull/1839)
- KMD AUR were reduced from 5% to 0.01% starting at `nS7HardforkHeight` to comply with [KIP-0001](https://github.com/KomodoPlatform/kips/blob/main/kip-0001.mediawiki) [#1841](https://github.com/KomodoPlatform/atomicDEX-API/pull/1841)