### PR TITLE
chore(release): bump mm2 version to 1.0.5-beta and add changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-## v1.0.5-beta - ${release-date}
+## v1.0.5-beta - 2023-06-02
 
 **Features:**
+- NFT integration [#900](https://github.com/KomodoPlatform/atomicDEX-API/issues/900)
+  - UriMeta was added to get info from token uri, status and metadata in nft tx history [#1823](https://github.com/KomodoPlatform/atomicDEX-API/pull/1823)
 
 **Enhancements/Fixes:**
-- Remove deprecated dependency `wasm-timer` from mm2 tree [#1836](https://github.com/KomodoPlatform/atomicDEX-API/pull/1836)
-- UriMeta to get info from token uri, status and metadata in nft tx history were added [#1823](https://github.com/KomodoPlatform/atomicDEX-API/pull/1823)
+- Deprecated `wasm-timer` dependency was removed from mm2 tree [#1836](https://github.com/KomodoPlatform/atomicDEX-API/pull/1836)
+- `log`, `getrandom` and `wasm-bindgen` dependencies were updated to more recent versions that are inline with the latest libp2p upstream [#1837](https://github.com/KomodoPlatform/atomicDEX-API/pull/1837)
+- A CI lint pipeline was added that validates pull request titles to ensure that they comply with the conventional commit specifications [#1839](https://github.com/KomodoPlatform/atomicDEX-API/pull/1839)
+- KMD AUR were reduced from 5% to 0.01% starting at `nS7HardforkHeight` to comply with [KIP-0001](https://github.com/KomodoPlatform/kips/blob/main/kip-0001.mediawiki) [#1841](https://github.com/KomodoPlatform/atomicDEX-API/pull/1841)
+
 
 ## v1.0.4-beta - 2023-05-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "mm2_bin_lib"
-version = "1.0.4-beta"
+version = "1.0.5-beta"
 dependencies = [
  "chrono",
  "common",

--- a/mm2src/mm2_bin_lib/Cargo.toml
+++ b/mm2src/mm2_bin_lib/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "mm2_bin_lib"
-version = "1.0.4-beta"
+version = "1.0.5-beta"
 authors = ["James Lee", "Artem Pikulin", "Artem Grinblat", "Omar S.", "Onur Ozkan", "Alina Sharon", "Caglar Kaya", "Cipi", "Sergey Boiko", "Samuel Onoja", "Roman Sztergbaum", "Kadan Stadelmann <ca333@komodoplatform.com>"]
 edition = "2018"
 default-run = "mm2"


### PR DESCRIPTION
This PR bumps the mm2 version to 1.0.5-beta and adds the corresponding changelog entries.