### PR TITLE
feat(watchtower): activate utxo watchers

### DIFF
--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -221,7 +221,7 @@ impl MmCtx {
 
     pub fn is_watcher(&self) -> bool { self.conf["is_watcher"].as_bool().unwrap_or_default() }
 
-    pub fn use_watchers(&self) -> bool { self.conf["use_watchers"].as_bool().unwrap_or_default() }
+    pub fn use_watchers(&self) -> bool { self.conf["use_watchers"].as_bool().unwrap_or(true) }
 
     pub fn netid(&self) -> u16 {
         let netid = self.conf["netid"].as_u64().unwrap_or(0);

--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -218,6 +218,24 @@ pub fn broadcast_swap_message_every<T: 'static + Serialize + Clone + Send>(
     spawn_abortable(fut)
 }
 
+/// Spawns the loop that broadcasts message every `interval` seconds returning the AbortOnDropHandle
+/// to stop it
+pub fn broadcast_swap_message_every_with_initial_delay<T: 'static + Serialize + Clone + Send>(
+    ctx: MmArc,
+    topic: String,
+    msg: T,
+    interval: f64,
+    p2p_privkey: Option<KeyPair>,
+) -> AbortOnDropHandle {
+    let fut = async move {
+        loop {
+            Timer::sleep(interval).await;
+            broadcast_swap_message(&ctx, topic.clone(), msg.clone(), &p2p_privkey);
+        }
+    };
+    spawn_abortable(fut)
+}
+
 /// Broadcast the swap message once
 pub fn broadcast_swap_message<T: Serialize>(ctx: &MmArc, topic: String, msg: T, p2p_privkey: &Option<KeyPair>) {
     let (p2p_private, from) = p2p_private_and_peer_id_to_broadcast(ctx, p2p_privkey.as_ref());

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -12,8 +12,8 @@ use super::{broadcast_my_swap_status, broadcast_swap_message, broadcast_swap_mes
             SwapTxDataMsg, SwapsContext, TransactionIdentifier, WAIT_CONFIRM_INTERVAL};
 use crate::mm2::lp_network::subscribe_to_topic;
 use crate::mm2::lp_ordermatch::{MatchBy, OrderConfirmationsSettings, TakerAction, TakerOrderBuilder};
-use crate::mm2::lp_swap::{broadcast_p2p_tx_msg, tx_helper_topic, wait_for_maker_payment_conf_duration,
-                          TakerSwapWatcherData};
+use crate::mm2::lp_swap::{broadcast_p2p_tx_msg, broadcast_swap_message_every_with_initial_delay, tx_helper_topic,
+                          wait_for_maker_payment_conf_duration, TakerSwapWatcherData};
 use coins::lp_price::fetch_swap_coins_price;
 use coins::{lp_coinfind, CanRefundHtlc, CheckIfMyPaymentSentArgs, ConfirmPaymentInput, FeeApproxStage,
             FoundSwapTxSpend, MmCoinEnum, PaymentInstructionArgs, PaymentInstructions, PaymentInstructionsErr,
@@ -1631,7 +1631,7 @@ impl TakerSwap {
                 );
                 let swpmsg_watcher = SwapWatcherMsg::TakerSwapWatcherMsg(watcher_data);
                 let htlc_keypair = self.taker_coin.derive_htlc_key_pair(&self.unique_swap_data());
-                watcher_broadcast_abort_handle = Some(broadcast_swap_message_every(
+                watcher_broadcast_abort_handle = Some(broadcast_swap_message_every_with_initial_delay(
                     self.ctx.clone(),
                     watcher_topic(&self.r().data.taker_coin),
                     swpmsg_watcher,

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -113,12 +113,16 @@ async fn save_my_taker_swap_event(ctx: &MmArc, swap: &TakerSwap, event: TakerSav
             gui: ctx.gui().map(|g| g.to_owned()),
             mm_version: Some(ctx.mm_version.to_owned()),
             events: vec![],
-            success_events: match ctx.use_watchers() {
-                true => TAKER_USING_WATCHERS_SUCCESS_EVENTS
+            success_events: if ctx.use_watchers()
+                && swap.taker_coin.is_supported_by_watchers()
+                && swap.maker_coin.is_supported_by_watchers()
+            {
+                TAKER_USING_WATCHERS_SUCCESS_EVENTS
                     .iter()
                     .map(|event| event.to_string())
-                    .collect(),
-                false => TAKER_SUCCESS_EVENTS.iter().map(|event| event.to_string()).collect(),
+                    .collect()
+            } else {
+                TAKER_SUCCESS_EVENTS.iter().map(|event| event.to_string()).collect()
             },
             error_events: TAKER_ERROR_EVENTS.iter().map(|event| event.to_string()).collect(),
         }),

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests.rs
@@ -95,7 +95,7 @@ fn start_swaps_and_get_balances(
         String::from("spice describe gravity federal thank unfair blast come canal monkey style afraid")
     };
 
-    let alice_conf = Mm2TestConf::seednode_using_watchers(&alice_passphrase, &coins);
+    let alice_conf = Mm2TestConf::seednode(&alice_passphrase, &coins);
     let mut mm_alice = block_on(MarketMakerIt::start_with_envs(
         alice_conf.conf.clone(),
         alice_conf.rpc_password.clone(),
@@ -112,7 +112,7 @@ fn start_swaps_and_get_balances(
         String::from("also shoot benefit prefer juice shell elder veteran woman mimic image kidney")
     };
 
-    let bob_conf = Mm2TestConf::light_node_using_watchers(&bob_passphrase, &coins, &[&mm_alice.ip.to_string()]);
+    let bob_conf = Mm2TestConf::light_node(&bob_passphrase, &coins, &[&mm_alice.ip.to_string()]);
     let mut mm_bob = block_on(MarketMakerIt::start_with_envs(
         bob_conf.conf.clone(),
         bob_conf.rpc_password,
@@ -574,13 +574,13 @@ fn test_two_watchers_spend_maker_payment_eth_erc20() {
 
     let alice_passphrase =
         String::from("spice describe gravity federal blast come thank unfair canal monkey style afraid");
-    let alice_conf = Mm2TestConf::seednode_using_watchers(&alice_passphrase, &coins);
+    let alice_conf = Mm2TestConf::seednode(&alice_passphrase, &coins);
     let mut mm_alice = MarketMakerIt::start(alice_conf.conf.clone(), alice_conf.rpc_password.clone(), None).unwrap();
     let (_alice_dump_log, _alice_dump_dashboard) = mm_alice.mm_dump();
     log!("Alice log path: {}", mm_alice.log_path.display());
 
     let bob_passphrase = String::from("also shoot benefit prefer juice shell elder veteran woman mimic image kidney");
-    let bob_conf = Mm2TestConf::light_node_using_watchers(&bob_passphrase, &coins, &[&mm_alice.ip.to_string()]);
+    let bob_conf = Mm2TestConf::light_node(&bob_passphrase, &coins, &[&mm_alice.ip.to_string()]);
     let mut mm_bob = MarketMakerIt::start(bob_conf.conf, bob_conf.rpc_password, None).unwrap();
     let (_bob_dump_log, _bob_dump_dashboard) = mm_bob.mm_dump();
     log!("Bob log path: {}", mm_bob.log_path.display());

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -175,21 +175,6 @@ impl Mm2TestConf {
         }
     }
 
-    pub fn seednode_using_watchers(passphrase: &str, coins: &Json) -> Self {
-        Mm2TestConf {
-            conf: json!({
-                "gui": "nogui",
-                "netid": 9998,
-                "passphrase": passphrase,
-                "coins": coins,
-                "rpc_password": DEFAULT_RPC_PASSWORD,
-                "i_am_seed": true,
-                "use_watchers": true,
-            }),
-            rpc_password: DEFAULT_RPC_PASSWORD.into(),
-        }
-    }
-
     pub fn seednode_with_hd_account(passphrase: &str, hd_account_id: u32, coins: &Json) -> Self {
         Mm2TestConf {
             conf: json!({
@@ -214,21 +199,6 @@ impl Mm2TestConf {
                 "coins": coins,
                 "rpc_password": DEFAULT_RPC_PASSWORD,
                 "seednodes": seednodes
-            }),
-            rpc_password: DEFAULT_RPC_PASSWORD.into(),
-        }
-    }
-
-    pub fn light_node_using_watchers(passphrase: &str, coins: &Json, seednodes: &[&str]) -> Self {
-        Mm2TestConf {
-            conf: json!({
-                "gui": "nogui",
-                "netid": 9998,
-                "passphrase": passphrase,
-                "coins": coins,
-                "rpc_password": DEFAULT_RPC_PASSWORD,
-                "seednodes": seednodes,
-                "use_watchers": true
             }),
             rpc_password: DEFAULT_RPC_PASSWORD.into(),
         }


### PR DESCRIPTION
This PR makes `use_watchers` configuration true by default. This means that all nodes will broadcast a watcher message after the taker payment is sent if the swapped coins are supported by watchers (only UTXO for now). It also fixes a problem that caused the nodes to broadcast two watcher messages consecutively after the taker payment is sent.