### PR TITLE
feat(rpc): add https support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4108,6 +4108,7 @@ dependencies = [
  "db_common",
  "derive_more",
  "futures 0.3.15",
+ "futures-rustls 0.21.1",
  "gstuff",
  "hex 0.4.3",
  "lazy_static",
@@ -4288,10 +4289,13 @@ dependencies = [
  "primitives",
  "rand 0.6.5",
  "rand 0.7.3",
+ "rcgen",
  "regex",
  "rmp-serde",
  "rpc",
  "rpc_task",
+ "rustls 0.20.4",
+ "rustls-pemfile 1.0.2",
  "script",
  "secp256k1 0.20.3",
  "ser_error",
@@ -4370,6 +4374,7 @@ dependencies = [
  "derive_more",
  "ethkey",
  "futures 0.3.15",
+ "futures-util",
  "gstuff",
  "http 0.2.7",
  "hyper",
@@ -4379,8 +4384,11 @@ dependencies = [
  "mm2_err_handle",
  "prost",
  "rand 0.7.3",
+ "rustls 0.20.4",
  "serde",
  "serde_json",
+ "tokio",
+ "tokio-rustls",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -4943,6 +4951,15 @@ name = "peg-runtime"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c719dcf55f09a3a7e764c6649ab594c18a177e3599c467983cdf644bfc0a4088"
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.0",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -5627,6 +5644,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.11",
+ "yasna",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5996,11 +6025,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -7952,7 +7981,7 @@ dependencies = [
  "pin-project 1.0.10",
  "prost",
  "prost-derive",
- "rustls-pemfile 1.0.0",
+ "rustls-pemfile 1.0.2",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -8863,6 +8892,15 @@ dependencies = [
  "parking_lot 0.12.0",
  "rand 0.8.4",
  "static_assertions",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time 0.3.11",
 ]
 
 [[package]]

--- a/mm2src/mm2_core/Cargo.toml
+++ b/mm2src/mm2_core/Cargo.toml
@@ -29,4 +29,5 @@ gstuff = { version = "0.7", features = ["nightly"] }
 mm2_rpc = { path = "../mm2_rpc" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+futures-rustls = { version = "0.21.1" }
 gstuff = { version = "0.7", features = ["nightly"] }

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -44,12 +44,12 @@ enum-primitive-derive = "0.2"
 futures01 = { version = "0.1", package = "futures" }
 futures = { version = "0.3.1", package = "futures", features = ["compat", "async-await"] }
 gstuff = { version = "0.7", features = ["nightly"] }
-mm2_gui_storage = { path = "../mm2_gui_storage" }
 hash256-std-hasher = "0.15.2"
 hash-db = "0.15.2"
 hex = "0.4.2"
 http = "0.2"
 hw_common = { path = "../hw_common" }
+instant = { version = "0.1.12" }
 itertools = "0.10"
 keys = { path = "../mm2_bitcoin/keys" }
 lazy_static = "1.4"
@@ -57,6 +57,7 @@ lazy_static = "1.4"
 libc = "0.2"
 mm2_core = { path = "../mm2_core" }
 mm2_err_handle = { path = "../mm2_err_handle" }
+mm2_gui_storage = { path = "../mm2_gui_storage" }
 mm2_io = { path = "../mm2_io" }
 mm2-libp2p = { path = "../mm2_libp2p" }
 mm2_metrics = { path = "../mm2_metrics" }
@@ -90,7 +91,6 @@ sp-trie = { version = "6.0", default-features = false }
 trie-db = { version = "0.23.1", default-features = false }
 trie-root = "0.16.0"
 uuid = { version = "1.2.2", features = ["fast-rng", "serde", "v4"] }
-instant = { version = "0.1.12" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }
@@ -106,6 +106,9 @@ web-sys = { version = "0.3.55", features = ["console"] }
 dirs = { version = "1" }
 futures-rustls = { version = "0.21.1" }
 hyper = { version = "0.14.26", features = ["client", "http2", "server", "tcp"] }
+rcgen = "0.10"
+rustls = { version = "0.20", default-features = false }
+rustls-pemfile = "1.0.2"
 tokio = { version = "1.20", features = ["io-util", "rt-multi-thread", "net"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/mm2src/mm2_net/Cargo.toml
+++ b/mm2src/mm2_net/Cargo.toml
@@ -32,5 +32,9 @@ web-sys = { version = "0.3.55", features = ["console", "CloseEvent", "DomExcepti
 js-sys = "0.3.27"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+futures-util = { version = "0.3" }
 hyper = { version = "0.14.26", features = ["client", "http2", "server", "tcp"] }
 gstuff = { version = "0.7", features = ["nightly"] }
+rustls = { version = "0.20", default-features = false }
+tokio = { version = "1.20" }
+tokio-rustls = { version = "0.23", default-features = false }

--- a/mm2src/mm2_net/src/lib.rs
+++ b/mm2src/mm2_net/src/lib.rs
@@ -3,5 +3,6 @@ pub mod transport;
 
 #[cfg(not(target_arch = "wasm32"))] pub mod ip_addr;
 #[cfg(not(target_arch = "wasm32"))] pub mod native_http;
+#[cfg(not(target_arch = "wasm32"))] pub mod native_tls;
 #[cfg(target_arch = "wasm32")] pub mod wasm_http;
 #[cfg(target_arch = "wasm32")] pub mod wasm_ws;

--- a/mm2src/mm2_net/src/native_tls/README.md
+++ b/mm2src/mm2_net/src/native_tls/README.md
@@ -1,0 +1,13 @@
+# HTTPS Support with TLSAcceptor and Builder
+
+This mod provides HTTPS support for [hyper](https://github.com/hyperium/hyper) using [rustls](https://github.com/rustls/rustls). The code in this mod is a port of the [acceptor](https://github.com/rustls/hyper-rustls/tree/286e1fa57ff5cac99994fab355f91c3454d6d83d/src/acceptor) module and the [acceptor.rs](https://github.com/rustls/hyper-rustls/blob/286e1fa57ff5cac99994fab355f91c3454d6d83d/src/acceptor.rs) file from the [hyper-rustls](https://github.com/rustls/hyper-rustls) repository at revision [286e1fa57ff5cac99994fab355f91c3454d6d83d](https://github.com/rustls/hyper-rustls/tree/286e1fa57ff5cac99994fab355f91c3454d6d83d).
+> **Note:** Please be aware that the acceptor module was not available in the latest version of [hyper-rustls](https://docs.rs/hyper-rustls/0.24.0/hyper_rustls/index.html) at the time of writing this, the latest version was 0.24.0 at this time.
+
+## Compatibility
+
+The ported mod is compatible with hyper 0.14 and rustls 0.20.
+
+## Purpose
+
+The purpose of porting these files is to enable retrieving the remote address from the incoming connection and to expose the `TlsStream` type.
+> **Note:** The following commit [7eca34d](https://github.com/KomodoPlatform/atomicDEX-API/pull/1861/commits/7eca34dd4621a7de0033f8a81cc11ad117aeb3c3) show the changes applied to the ported code.

--- a/mm2src/mm2_net/src/native_tls/acceptor.rs
+++ b/mm2src/mm2_net/src/native_tls/acceptor.rs
@@ -1,0 +1,139 @@
+use core::task::{Context, Poll};
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures_util::ready;
+use hyper::server::{
+    accept::Accept,
+    conn::{AddrIncoming, AddrStream},
+};
+use rustls::ServerConfig;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+mod builder;
+pub use builder::AcceptorBuilder;
+use builder::WantsTlsConfig;
+
+enum State {
+    Handshaking(tokio_rustls::Accept<AddrStream>),
+    Streaming(tokio_rustls::server::TlsStream<AddrStream>),
+}
+
+// tokio_rustls::server::TlsStream doesn't expose constructor methods,
+// so we have to TlsAcceptor::accept and handshake to have access to it
+// TlsStream implements AsyncRead/AsyncWrite by handshaking with tokio_rustls::Accept first
+pub struct TlsStream {
+    state: State,
+}
+
+impl TlsStream {
+    fn new(stream: AddrStream, config: Arc<ServerConfig>) -> TlsStream {
+        let accept = tokio_rustls::TlsAcceptor::from(config).accept(stream);
+        TlsStream {
+            state: State::Handshaking(accept),
+        }
+    }
+}
+
+impl AsyncRead for TlsStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut ReadBuf,
+    ) -> Poll<io::Result<()>> {
+        let pin = self.get_mut();
+        match pin.state {
+            State::Handshaking(ref mut accept) => match ready!(Pin::new(accept).poll(cx)) {
+                Ok(mut stream) => {
+                    let result = Pin::new(&mut stream).poll_read(cx, buf);
+                    pin.state = State::Streaming(stream);
+                    result
+                }
+                Err(err) => Poll::Ready(Err(err)),
+            },
+            State::Streaming(ref mut stream) => Pin::new(stream).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for TlsStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let pin = self.get_mut();
+        match pin.state {
+            State::Handshaking(ref mut accept) => match ready!(Pin::new(accept).poll(cx)) {
+                Ok(mut stream) => {
+                    let result = Pin::new(&mut stream).poll_write(cx, buf);
+                    pin.state = State::Streaming(stream);
+                    result
+                }
+                Err(err) => Poll::Ready(Err(err)),
+            },
+            State::Streaming(ref mut stream) => Pin::new(stream).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.state {
+            State::Handshaking(_) => Poll::Ready(Ok(())),
+            State::Streaming(ref mut stream) => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.state {
+            State::Handshaking(_) => Poll::Ready(Ok(())),
+            State::Streaming(ref mut stream) => Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}
+
+/// A TLS acceptor that can be used with hyper servers.
+pub struct TlsAcceptor {
+    config: Arc<ServerConfig>,
+    incoming: AddrIncoming,
+}
+
+/// An Acceptor for the `https` scheme.
+impl TlsAcceptor {
+    /// Provides a builder for a `TlsAcceptor`.
+    pub fn builder() -> AcceptorBuilder<WantsTlsConfig> {
+        AcceptorBuilder::new()
+    }
+    /// Creates a new `TlsAcceptor` from a `ServerConfig` and an `AddrIncoming`.
+    pub fn new(config: Arc<ServerConfig>, incoming: AddrIncoming) -> TlsAcceptor {
+        TlsAcceptor { config, incoming }
+    }
+}
+
+impl<C, I> From<(C, I)> for TlsAcceptor
+    where
+        C: Into<Arc<ServerConfig>>,
+        I: Into<AddrIncoming>,
+{
+    fn from((config, incoming): (C, I)) -> TlsAcceptor {
+        TlsAcceptor::new(config.into(), incoming.into())
+    }
+}
+
+impl Accept for TlsAcceptor {
+    type Conn = TlsStream;
+    type Error = io::Error;
+
+    fn poll_accept(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+        let pin = self.get_mut();
+        match ready!(Pin::new(&mut pin.incoming).poll_accept(cx)) {
+            Some(Ok(sock)) => Poll::Ready(Some(Ok(TlsStream::new(sock, pin.config.clone())))),
+            Some(Err(e)) => Poll::Ready(Some(Err(e))),
+            None => Poll::Ready(None),
+        }
+    }
+}

--- a/mm2src/mm2_net/src/native_tls/acceptor.rs
+++ b/mm2src/mm2_net/src/native_tls/acceptor.rs
@@ -1,20 +1,15 @@
+use crate::native_tls::builder::{AcceptorBuilder, WantsTlsConfig};
 use core::task::{Context, Poll};
+use futures_util::ready;
+use hyper::server::{accept::Accept,
+                    conn::{AddrIncoming, AddrStream}};
+use rustls::ServerConfig;
 use std::future::Future;
 use std::io;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
-
-use futures_util::ready;
-use hyper::server::{
-    accept::Accept,
-    conn::{AddrIncoming, AddrStream},
-};
-use rustls::ServerConfig;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-
-mod builder;
-pub use builder::AcceptorBuilder;
-use builder::WantsTlsConfig;
 
 enum State {
     Handshaking(tokio_rustls::Accept<AddrStream>),
@@ -26,23 +21,25 @@ enum State {
 // TlsStream implements AsyncRead/AsyncWrite by handshaking with tokio_rustls::Accept first
 pub struct TlsStream {
     state: State,
+    remote_addr: SocketAddr,
 }
 
 impl TlsStream {
     fn new(stream: AddrStream, config: Arc<ServerConfig>) -> TlsStream {
+        let remote_addr = stream.remote_addr();
         let accept = tokio_rustls::TlsAcceptor::from(config).accept(stream);
         TlsStream {
             state: State::Handshaking(accept),
+            remote_addr,
         }
     }
+
+    #[inline]
+    pub fn remote_addr(&self) -> SocketAddr { self.remote_addr }
 }
 
 impl AsyncRead for TlsStream {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context,
-        buf: &mut ReadBuf,
-    ) -> Poll<io::Result<()>> {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context, buf: &mut ReadBuf) -> Poll<io::Result<()>> {
         let pin = self.get_mut();
         match pin.state {
             State::Handshaking(ref mut accept) => match ready!(Pin::new(accept).poll(cx)) {
@@ -50,7 +47,7 @@ impl AsyncRead for TlsStream {
                     let result = Pin::new(&mut stream).poll_read(cx, buf);
                     pin.state = State::Streaming(stream);
                     result
-                }
+                },
                 Err(err) => Poll::Ready(Err(err)),
             },
             State::Streaming(ref mut stream) => Pin::new(stream).poll_read(cx, buf),
@@ -59,11 +56,7 @@ impl AsyncRead for TlsStream {
 }
 
 impl AsyncWrite for TlsStream {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
         let pin = self.get_mut();
         match pin.state {
             State::Handshaking(ref mut accept) => match ready!(Pin::new(accept).poll(cx)) {
@@ -71,7 +64,7 @@ impl AsyncWrite for TlsStream {
                     let result = Pin::new(&mut stream).poll_write(cx, buf);
                     pin.state = State::Streaming(stream);
                     result
-                }
+                },
                 Err(err) => Poll::Ready(Err(err)),
             },
             State::Streaming(ref mut stream) => Pin::new(stream).poll_write(cx, buf),
@@ -95,40 +88,31 @@ impl AsyncWrite for TlsStream {
 
 /// A TLS acceptor that can be used with hyper servers.
 pub struct TlsAcceptor {
-    config: Arc<ServerConfig>,
-    incoming: AddrIncoming,
+    pub(crate) config: Arc<ServerConfig>,
+    pub(crate) incoming: AddrIncoming,
 }
 
 /// An Acceptor for the `https` scheme.
 impl TlsAcceptor {
     /// Provides a builder for a `TlsAcceptor`.
-    pub fn builder() -> AcceptorBuilder<WantsTlsConfig> {
-        AcceptorBuilder::new()
-    }
+    pub fn builder() -> AcceptorBuilder<WantsTlsConfig> { AcceptorBuilder::new() }
     /// Creates a new `TlsAcceptor` from a `ServerConfig` and an `AddrIncoming`.
-    pub fn new(config: Arc<ServerConfig>, incoming: AddrIncoming) -> TlsAcceptor {
-        TlsAcceptor { config, incoming }
-    }
+    pub fn new(config: Arc<ServerConfig>, incoming: AddrIncoming) -> TlsAcceptor { TlsAcceptor { config, incoming } }
 }
 
 impl<C, I> From<(C, I)> for TlsAcceptor
-    where
-        C: Into<Arc<ServerConfig>>,
-        I: Into<AddrIncoming>,
+where
+    C: Into<Arc<ServerConfig>>,
+    I: Into<AddrIncoming>,
 {
-    fn from((config, incoming): (C, I)) -> TlsAcceptor {
-        TlsAcceptor::new(config.into(), incoming.into())
-    }
+    fn from((config, incoming): (C, I)) -> TlsAcceptor { TlsAcceptor::new(config.into(), incoming.into()) }
 }
 
 impl Accept for TlsAcceptor {
     type Conn = TlsStream;
     type Error = io::Error;
 
-    fn poll_accept(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+    fn poll_accept(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
         let pin = self.get_mut();
         match ready!(Pin::new(&mut pin.incoming).poll_accept(cx)) {
             Some(Ok(sock)) => Poll::Ready(Some(Ok(TlsStream::new(sock, pin.config.clone())))),

--- a/mm2src/mm2_net/src/native_tls/builder.rs
+++ b/mm2src/mm2_net/src/native_tls/builder.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use hyper::server::conn::AddrIncoming;
+use rustls::ServerConfig;
+
+use super::TlsAcceptor;
+/// Builder for [`TlsAcceptor`]
+pub struct AcceptorBuilder<State>(State);
+
+/// State of a builder that needs a TLS client config next
+pub struct WantsTlsConfig(());
+
+impl AcceptorBuilder<WantsTlsConfig> {
+    /// Creates a new [`AcceptorBuilder`]
+    pub fn new() -> Self {
+        Self(WantsTlsConfig(()))
+    }
+
+    /// Passes a rustls [`ServerConfig`] to configure the TLS connection
+    pub fn with_tls_config(self, config: ServerConfig) -> AcceptorBuilder<WantsAlpn> {
+        AcceptorBuilder(WantsAlpn(config))
+    }
+
+    /// Use rustls [defaults][with_safe_defaults] without [client authentication][with_no_client_auth]
+    ///
+    /// [with_safe_defaults]: rustls::ConfigBuilder::with_safe_defaults
+    /// [with_no_client_auth]: rustls::ConfigBuilder::with_no_client_auth
+    pub fn with_single_cert(
+        self,
+        cert_chain: Vec<rustls::Certificate>,
+        key_der: rustls::PrivateKey,
+    ) -> Result<AcceptorBuilder<WantsAlpn>, rustls::Error> {
+        Ok(AcceptorBuilder(WantsAlpn(
+            ServerConfig::builder()
+                .with_safe_defaults()
+                .with_no_client_auth()
+                .with_single_cert(cert_chain, key_der)?,
+        )))
+    }
+}
+
+impl Default for AcceptorBuilder<WantsTlsConfig> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// State of a builder that needs a incoming address next
+pub struct WantsAlpn(ServerConfig);
+
+impl AcceptorBuilder<WantsAlpn> {
+    /// Configure ALPN accept protocols in order
+    pub fn with_alpn_protocols(
+        mut self,
+        alpn_protocols: Vec<Vec<u8>>,
+    ) -> AcceptorBuilder<WantsIncoming> {
+        self.0 .0.alpn_protocols = alpn_protocols;
+        AcceptorBuilder(WantsIncoming(self.0 .0))
+    }
+
+    /// Configure ALPN to accept HTTP/2
+    pub fn with_http2_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
+        self.0 .0.alpn_protocols = vec![b"h2".to_vec()];
+        AcceptorBuilder(WantsIncoming(self.0 .0))
+    }
+
+    /// Configure ALPN to accept HTTP/1.0
+    pub fn with_http10_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
+        self.0 .0.alpn_protocols = vec![b"http/1.0".to_vec()];
+        AcceptorBuilder(WantsIncoming(self.0 .0))
+    }
+
+    /// Configure ALPN to accept HTTP/1.1
+    pub fn with_http11_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
+        self.0 .0.alpn_protocols = vec![b"http/1.1".to_vec()];
+        AcceptorBuilder(WantsIncoming(self.0 .0))
+    }
+
+    /// Configure ALPN to accept HTTP/2, HTTP/1.1, HTTP/1.0 in that order.
+    pub fn with_all_versions_alpn(mut self) -> AcceptorBuilder<WantsIncoming> {
+        self.0 .0.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec(), b"http/1.0".to_vec()];
+        AcceptorBuilder(WantsIncoming(self.0 .0))
+    }
+}
+
+/// State of a builder that needs a incoming address next
+pub struct WantsIncoming(ServerConfig);
+
+impl AcceptorBuilder<WantsIncoming> {
+    /// Passes a [`AddrIncoming`] to configure the TLS connection and
+    /// creates the [`TlsAcceptor`]
+    pub fn with_incoming(self, incoming: impl Into<AddrIncoming>) -> TlsAcceptor {
+        TlsAcceptor {
+            config: Arc::new(self.0 .0),
+            incoming: incoming.into(),
+        }
+    }
+}

--- a/mm2src/mm2_net/src/native_tls/builder.rs
+++ b/mm2src/mm2_net/src/native_tls/builder.rs
@@ -1,9 +1,8 @@
-use std::sync::Arc;
-
+use crate::native_tls::TlsAcceptor;
 use hyper::server::conn::AddrIncoming;
 use rustls::ServerConfig;
+use std::sync::Arc;
 
-use super::TlsAcceptor;
 /// Builder for [`TlsAcceptor`]
 pub struct AcceptorBuilder<State>(State);
 
@@ -11,11 +10,11 @@ pub struct AcceptorBuilder<State>(State);
 pub struct WantsTlsConfig(());
 
 impl AcceptorBuilder<WantsTlsConfig> {
+    #[inline]
     /// Creates a new [`AcceptorBuilder`]
-    pub fn new() -> Self {
-        Self(WantsTlsConfig(()))
-    }
+    pub fn new() -> Self { Self(WantsTlsConfig(())) }
 
+    #[inline]
     /// Passes a rustls [`ServerConfig`] to configure the TLS connection
     pub fn with_tls_config(self, config: ServerConfig) -> AcceptorBuilder<WantsAlpn> {
         AcceptorBuilder(WantsAlpn(config))
@@ -40,9 +39,7 @@ impl AcceptorBuilder<WantsTlsConfig> {
 }
 
 impl Default for AcceptorBuilder<WantsTlsConfig> {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 
 /// State of a builder that needs a incoming address next
@@ -50,10 +47,7 @@ pub struct WantsAlpn(ServerConfig);
 
 impl AcceptorBuilder<WantsAlpn> {
     /// Configure ALPN accept protocols in order
-    pub fn with_alpn_protocols(
-        mut self,
-        alpn_protocols: Vec<Vec<u8>>,
-    ) -> AcceptorBuilder<WantsIncoming> {
+    pub fn with_alpn_protocols(mut self, alpn_protocols: Vec<Vec<u8>>) -> AcceptorBuilder<WantsIncoming> {
         self.0 .0.alpn_protocols = alpn_protocols;
         AcceptorBuilder(WantsIncoming(self.0 .0))
     }

--- a/mm2src/mm2_net/src/native_tls/mod.rs
+++ b/mm2src/mm2_net/src/native_tls/mod.rs
@@ -1,0 +1,4 @@
+mod acceptor;
+pub use acceptor::{TlsAcceptor, TlsStream};
+
+mod builder;


### PR DESCRIPTION
This PR adds a new mm2 config parameter `https`. When this parameter is set to true, mm2 automatically generates a self-signed certificate internally if no certificate and private key file is found in either the specified paths (`MM_CERT_PATH` and `MM_CERT_KEY_PATH`) as defined in the environment variables or if no `cert.pem` and `key.pem` files are found in the same directory as the compiled mm2 binary (similar to how coins file works).

For the self-signed certificate, the default SANs (Subject Alternative Names) used are `localhost` and `127.0.0.1`, these are set if `alt_names` is not specified in mm2 config. `alt_names` takes an array of strings specifying the desired SANs.

After certificates are loaded, the mm2 service/server is then executed in HTTPS mode, enabling secure communication between the client and server using Transport Layer Security (TLS). This ensures that all requests and responses are encrypted, providing enhanced security for the API.

When `https` is not set, it defaults to false and the mm2 service is executed in HTTP as it was before this PR to maintain backward compatibility for clients relying on it.

Please note that disabling certificate verification/validation is required by the client for requests to work in https mode if self-signed certificates where used.

New dependencies:
`pem v1.1.1`
`rcgen v0.10.0`
`yasna v0.5.2`

dependency update:
`rustls-pemfile 1.0.0 -> 1.0.2`