### PR TITLE
fix(incompatible-dep): rollback rmp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,12 +3067,12 @@ checksum = "5a9d968042a4902e08810946fc7cd5851eb75e80301342305af755ca06cb82ce"
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg 1.1.0",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.1",
 ]
 
 [[package]]
@@ -4952,9 +4952,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b305cc4569dd4e8765bab46261f67ef5d4d11a4b6e745100ee5dad8948b46c"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -5816,9 +5816,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.1.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
+checksum = "4ce7d70c926fe472aed493b902010bccc17fa9f7284145cb8772fd22fdb052d8"
 dependencies = [
  "byteorder 1.4.3",
  "rmp",
@@ -6216,9 +6216,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
@@ -6245,13 +6245,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2 1.0.58",
  "quote 1.0.27",
- "syn 1.0.95",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -76,7 +76,7 @@ prost = "0.10"
 protobuf = "2.20"
 rand = { version = "0.7", features = ["std", "small_rng"] }
 rlp = { version = "0.5" }
-rmp-serde = "1.1.1"
+rmp-serde = "0.14.3"
 rpc = { path = "../mm2_bitcoin/rpc" }
 rpc_task = { path = "../rpc_task" }
 script = { path = "../mm2_bitcoin/script" }

--- a/mm2src/mm2_libp2p/Cargo.toml
+++ b/mm2src/mm2_libp2p/Cargo.toml
@@ -21,7 +21,7 @@ secp256k1 = { version = "0.20", features = ["rand"] }
 log = "0.4.17"
 rand = { package = "rand", version = "0.7", features = ["std", "wasm-bindgen"] }
 regex = "1"
-rmp-serde = "1.1.1"
+rmp-serde = "0.14.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.5"
 sha2 = "0.9"

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -72,7 +72,7 @@ rand6 = { version = "0.6", package = "rand" }
 # TODO: Reduce the size of regex by disabling the features we don't use.
 # cf. https://github.com/rust-lang/regex/issues/583
 regex = "1"
-rmp-serde = "1.1.1"
+rmp-serde = "0.14.3"
 rpc = { path = "../mm2_bitcoin/rpc" }
 rpc_task = { path = "../rpc_task" }
 script = { path = "../mm2_bitcoin/script" }


### PR DESCRIPTION
dependency updates:
- `indexmap` `1.7.0` -> `1.9.3`
- `petgraph` `0.6.1` -> `0.6.3`
- `serde` `1.0.136` -> `1.0.164`
- `serde_derive` `1.0.136` -> `1.0.164`