### PR TITLE
ci(pr-validation): check PR labels

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -5,11 +5,14 @@ on:
     types:
       - opened
       - edited
+      - reopened
       - synchronize
+      - labeled
+      - unlabeled
 
 jobs:
   main:
-    name: Validate PR title
+    name: Validate PR
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5.2.0
@@ -40,3 +43,13 @@ jobs:
             echo "PR title is too long (greater than 72 characters)"
             exit 1
           fi
+
+      - name: Check PR labels
+        if: >
+          (contains(toJson(github.event.pull_request.labels.*.name), 'under review') == false &&
+          contains(toJson(github.event.pull_request.labels.*.name), 'in progress') == false) ||
+          (contains(toJson(github.event.pull_request.labels.*.name), 'under review') == true &&
+          contains(toJson(github.event.pull_request.labels.*.name), 'in progress') == true)
+        run: |
+          echo "PR must have "exactly one" of these labels: [ 'under review', 'in progress' ]."
+          exit 1


### PR DESCRIPTION
Add label validation on PRs. The validation will only succeed if one of the(not together) following labels is used: `under review` or `in progress`.