### PR TITLE
feat(cosmos): dynamic gas price and gas limit

### DIFF
--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -1070,6 +1070,10 @@ pub enum WithdrawFee {
         gas_limit: u64,
         gas_price: u64,
     },
+    CosmosGas {
+        gas_limit: u64,
+        gas_price: f64,
+    },
 }
 
 pub struct WithdrawSenderAddress<Address, Pubkey> {

--- a/mm2src/coins/rpc_command/tendermint/ibc_withdraw.rs
+++ b/mm2src/coins/rpc_command/tendermint/ibc_withdraw.rs
@@ -3,7 +3,7 @@ use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::MmError;
 use mm2_number::BigDecimal;
 
-use crate::{lp_coinfind_or_err, MmCoinEnum, WithdrawError, WithdrawResult};
+use crate::{lp_coinfind_or_err, MmCoinEnum, WithdrawError, WithdrawFee, WithdrawResult};
 
 #[derive(Clone, Deserialize)]
 pub struct IBCWithdrawRequest {
@@ -15,6 +15,7 @@ pub struct IBCWithdrawRequest {
     #[serde(default)]
     pub(crate) max: bool,
     pub(crate) memo: Option<String>,
+    pub(crate) fee: Option<WithdrawFee>,
 }
 
 pub async fn ibc_withdraw(ctx: MmArc, req: IBCWithdrawRequest) -> WithdrawResult {

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -19,7 +19,7 @@ use crate::{big_decimal_from_sat_unsigned, utxo::sat_from_big_decimal, BalanceFu
             ValidatePaymentInput, VerificationResult, WaitForHTLCTxSpendArgs, WatcherOps,
             WatcherSearchForSwapTxSpendInput, WatcherValidatePaymentInput, WatcherValidateTakerFeeInput,
             WithdrawError, WithdrawFut, WithdrawRequest};
-use crate::{MmCoinEnum, PaymentInstructionArgs, WatcherReward, WatcherRewardError, WithdrawFee};
+use crate::{MmCoinEnum, PaymentInstructionArgs, WatcherReward, WatcherRewardError};
 use async_trait::async_trait;
 use bitcrypto::sha256;
 use common::executor::abortable_queue::AbortableQueue;
@@ -175,10 +175,7 @@ impl TendermintToken {
 
             let timeout_height = current_block + TIMEOUT_HEIGHT_DELTA;
 
-            let gas_limit = match req.fee {
-                Some(WithdrawFee::CosmosGas { gas_limit, .. }) => gas_limit,
-                _ => IBC_GAS_LIMIT_DEFAULT,
-            };
+            let (_, gas_limit) = platform.gas_info_for_withdraw(&req.fee, IBC_GAS_LIMIT_DEFAULT);
 
             let fee_amount_u64 = platform
                 .calculate_fee_amount_as_u64(msg_transfer.clone(), timeout_height, memo.clone(), req.fee)
@@ -654,10 +651,7 @@ impl MmCoin for TendermintToken {
 
             let timeout_height = current_block + TIMEOUT_HEIGHT_DELTA;
 
-            let gas_limit = match req.fee {
-                Some(WithdrawFee::CosmosGas { gas_limit, .. }) => gas_limit,
-                _ => GAS_LIMIT_DEFAULT,
-            };
+            let (_, gas_limit) = platform.gas_info_for_withdraw(&req.fee, GAS_LIMIT_DEFAULT);
 
             let fee_amount_u64 = platform
                 .calculate_fee_amount_as_u64(msg_send.clone(), timeout_height, memo.clone(), req.fee)


### PR DESCRIPTION
IBC and standard withdrawals for Cosmos now allow users to specify the gas price and gas limit for each transaction. You can do this by including the following information in the RPC payloads:
```json
"fee": {
    "type": "CosmosGas",
    "gas_limit": 125000,
    "gas_price": 0.25
}
```

e.g. payload in the integration test:
https://github.com/KomodoPlatform/atomicDEX-API/blob/af74b50b2714cf77c576e4a85c858e4b2a36191b/mm2src/mm2_main/tests/mm2_tests/tendermint_tests.rs#L162-L171

Determining the gas price to be used:

1- From the RPC payload.
2- From the coins configuration.
3- A default value of `0.25`, which is currently hardcoded in the source code.

Higher prior always overrides the others.

Resolves #1847

cc @yurii-khi @tonymorony